### PR TITLE
Forced trigger library and correction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: "v2.4.1"
     hooks:
       - id: codespell
-        args: ["-L", "nd,unparseable,compiletime,livetime,livetimes"]
+        args: ["-L", "nd,unparseable,compiletime,livetime,livetimes,puls"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.11.0.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ config_filename = testprod / "simflow-config.yaml"
 @pytest.fixture(scope="session")
 def legend_testdata():
     ldata = LegendTestData()
-    ldata.checkout("0bb2dfc")
+    ldata.checkout("9f03127")
     return ldata
 
 

--- a/tests/test_spms_pars.py
+++ b/tests/test_spms_pars.py
@@ -1,0 +1,125 @@
+"""Tests for spms_pars module."""
+
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+import pytest
+
+from legendsimflow import spms_pars
+
+
+@pytest.fixture
+def mock_forced_trig_library():
+    """Create a mock forced trigger library for testing."""
+    # Create structured array with npe, t0, and rawid fields
+    # 10 events, 3 SiPM channels each
+    npe_data = ak.Array(
+        [
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [[2, 3, 4], [5, 6, 7], [8, 9, 10]],
+            [[3, 4, 5], [6, 7, 8], [9, 10, 11]],
+            [[4, 5, 6], [7, 8, 9], [10, 11, 12]],
+            [[5, 6, 7], [8, 9, 10], [11, 12, 13]],
+            [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+            [[2, 2, 2], [3, 3, 3], [4, 4, 4]],
+            [[3, 3, 3], [4, 4, 4], [5, 5, 5]],
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [[10, 20, 30], [40, 50, 60], [70, 80, 90]],
+        ]
+    )
+
+    t0_data = ak.Array(
+        [
+            [[100.0, 200.0, 300.0], [150.0, 250.0, 350.0], [120.0, 220.0, 320.0]],
+            [[105.0, 205.0, 305.0], [155.0, 255.0, 355.0], [125.0, 225.0, 325.0]],
+            [[110.0, 210.0, 310.0], [160.0, 260.0, 360.0], [130.0, 230.0, 330.0]],
+            [[115.0, 215.0, 315.0], [165.0, 265.0, 365.0], [135.0, 235.0, 335.0]],
+            [[120.0, 220.0, 320.0], [170.0, 270.0, 370.0], [140.0, 240.0, 340.0]],
+            [[50.0, 150.0, 250.0], [100.0, 200.0, 300.0], [75.0, 175.0, 275.0]],
+            [[55.0, 155.0, 255.0], [105.0, 205.0, 305.0], [80.0, 180.0, 280.0]],
+            [[60.0, 160.0, 260.0], [110.0, 210.0, 310.0], [85.0, 185.0, 285.0]],
+            [[65.0, 165.0, 265.0], [115.0, 215.0, 315.0], [90.0, 190.0, 290.0]],
+            [[70.0, 170.0, 270.0], [120.0, 220.0, 320.0], [95.0, 195.0, 295.0]],
+        ]
+    )
+
+    # SiPM channel UIDs: 101, 102, 103
+    rawid_array = np.array([101, 102, 103], dtype=np.int32)
+
+    # Create the library structure like get_forced_trigger_library returns
+    return ak.Array(
+        {
+            "npe": npe_data,
+            "t0": t0_data,
+            "rawid": ak.Array([rawid_array for _ in range(len(npe_data))]),
+        }
+    )
+
+
+def test_extract_single_channel(mock_forced_trig_library):
+    """Test extracting data for a single SiPM channel."""
+    npe, t0 = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 101)
+
+    # Should have data for all 10 events
+    assert len(npe) == 10
+    assert len(t0) == 10
+
+
+def test_extract_all_channels(mock_forced_trig_library):
+    """Test extracting data for all channels combined."""
+    npe, t0 = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "all", 0)
+
+    # Should have flattened data but 10 events
+    assert len(npe) == 10
+    assert len(t0) == 10
+
+
+def test_extract_different_channels(mock_forced_trig_library):
+    """Test extracting data from different channels."""
+    npe1, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 101)
+    npe2, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 102)
+    npe3, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 103)
+
+    # All should have same length but different values
+    assert len(npe1) == len(npe2) == len(npe3) == 10
+    # Values should be different
+    assert ak.to_list(npe1) != ak.to_list(npe2)
+    assert ak.to_list(npe2) != ak.to_list(npe3)
+
+
+def test_extract_missing_sipm_raises_error(mock_forced_trig_library):
+    """Test that missing SiPM UID raises ValueError."""
+    with pytest.raises(ValueError, match="SiPM UID 999 not found"):
+        spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 999)
+
+
+def test_extract_preserves_array_structure(mock_forced_trig_library):
+    """Test that extracted data preserves awkward array structure."""
+    npe, t0 = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 101)
+
+    # Should be awkward arrays
+    assert isinstance(npe, ak.Array)
+    assert isinstance(t0, ak.Array)
+
+    # Should contain valid data
+    npe_list = ak.to_list(npe)
+    t0_list = ak.to_list(t0)
+
+    for npe_val, t0_val in zip(npe_list, t0_list, strict=True):
+        assert isinstance(npe_val, list)
+        assert isinstance(t0_val, list)
+        assert len(npe_val) > 0
+        assert len(t0_val) > 0
+
+
+def test_extract_all_combines_channels(mock_forced_trig_library):
+    """Test that 'all' mode properly flattens all channels."""
+    npe_all, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "all", 0)
+
+    npe_101, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 101)
+    npe_102, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 102)
+    npe_103, _ = spms_pars.get_sipm_rc_data(mock_forced_trig_library, "sipm", 103)
+
+    # All data should be combination of three channels
+    assert len(npe_all) == len(npe_101) == len(npe_102) == len(npe_103)

--- a/workflow/rules/opt.smk
+++ b/workflow/rules/opt.smk
@@ -54,6 +54,7 @@ rule build_tier_opt:
         detector_usabilities=rules.cache_detector_usabilities.output,
     params:
         optmap_per_sipm=True,
+        add_random_coincidences=False,
         scintillator_volume_name="liquid_argon",
     output:
         patterns.output_simjob_filename(config, tier="opt"),

--- a/workflow/src/legendsimflow/scripts/plots/tier_hit_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_hit_observables.py
@@ -54,7 +54,7 @@ def fig(table):
     h_ene = hist.new.Reg(int(5000 / bw), 0, 5000, name="energy (keV)").Double()
     h_ene.fill(data.energy)
     plot.plot_hist(h_ene, ax)
-    ax.set_ylabel(f"Counts / {bw} keV")
+    ax.set_ylabel(f"counts / {bw} keV")
     ax.set_yscale("log")
 
     # energy inset

--- a/workflow/src/legendsimflow/spms_pars.py
+++ b/workflow/src/legendsimflow/spms_pars.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import logging
+import random
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+import awkward as ak
+import numpy as np
+from lgdo import lh5
+
+from .profile import make_profiler
+from .utils import lookup_dataflow_config
+
+log = logging.getLogger(__name__)
+
+
+def lookup_evt_files(l200data: str, runid: str, evt_tier_name: str) -> list[str | Path]:
+    """Lookup the paths to the `evt` files."""
+
+    _, period, run, data_type = re.split(r"\W+", runid)
+
+    if isinstance(l200data, str):
+        l200data = Path(l200data)
+
+    dataflow_config = lookup_dataflow_config(l200data)
+
+    # get the paths to evt tier files
+    df_cfg = (
+        dataflow_config["setups"]["l200"]["paths"]
+        if ("setups" in dataflow_config)
+        else dataflow_config["paths"]
+    )
+
+    evt_path = Path(df_cfg[f"tier_{evt_tier_name}"]).resolve()
+    return list((evt_path / data_type / period / run).glob("*"))
+
+
+def _process_spms_windows(
+    spms: ak.Array,
+    win_ranges: list[tuple[float, float]],
+    time_domain_ns: tuple[float, float],
+    min_sep_ns: float,
+) -> tuple[ak.Array, ak.Array]:
+    """Helper function to process SiPM data within specified window ranges.
+
+    Parameters
+    ----------
+    spms
+        SiPM data array with fields `energy` and `t0`.
+    win_ranges
+        List of `(start, end)` tuples defining window ranges in nanoseconds.
+    time_domain_ns
+        Target time range `(start, end)` for output times in nanoseconds.
+        E.g., `(-1000, 5000)` means output times will be in `[-1000, 5000]`.
+    min_sep_ns
+        Minimal separation between windows in nanoseconds.
+    Returns
+    -------
+    npe
+        Photoelectron counts extracted from the requested windows.
+    t0
+        Times relative to time_domain_ns extracted from the requested windows.
+    """
+    # Validate inputs to avoid infinite loops and invalid window definitions
+    if time_domain_ns[1] <= time_domain_ns[0]:
+        msg = (
+            f"time_domain_ns must have time_domain_ns[1] > time_domain_ns[0], "
+            f"got {time_domain_ns}"
+        )
+        raise ValueError(msg)
+    if min_sep_ns < 0:
+        msg = f"min_sep_ns must be non-negative, got {min_sep_ns}"
+        raise ValueError(msg)
+    win_len_ns = time_domain_ns[1] - time_domain_ns[0]
+
+    npe_list = []
+    t0_list = []
+
+    for win_range in win_ranges:
+        # Ensure each window range is a valid (start, end) pair
+        if len(win_range) != 2:
+            msg = f"Each win_range must be a (start, end) tuple, got {win_range!r}"
+            raise ValueError(msg)
+        start, end = win_range
+        if end <= start:
+            msg = (
+                f"Each win_range must satisfy start < end, got start={start}, end={end}"
+            )
+            raise ValueError(msg)
+        starts = []
+        current_start = start
+        while current_start + win_len_ns <= end:
+            starts.append(current_start)
+            current_start += win_len_ns + min_sep_ns
+        ends = [s + win_len_ns for s in starts]
+
+        for wstart, wend in zip(starts, ends, strict=True):
+            tmsk = (spms.t0 >= wstart) & (spms.t0 < wend)
+            npe_tmp = spms.energy[tmsk]
+            t0_tmp = spms.t0[tmsk] - (wstart - time_domain_ns[0])
+
+            npe_list.append(npe_tmp)
+            t0_list.append(t0_tmp)
+
+    if not npe_list:
+        return ak.Array([]), ak.Array([])
+
+    return ak.concatenate(npe_list), ak.concatenate(t0_list)
+
+
+def get_rc_library(
+    evt_files: Iterable[str],
+    min_num_evts: int,
+    time_domain_ns: tuple[float, float] = (-1_000, 5_000),
+    min_sep_ns: float = 6_000,
+    ext_trig_range_ns: list[tuple[float, float]] | None = None,
+    ge_trig_range_ns: list[tuple[float, float]] | None = None,
+) -> ak.Array:
+    """Extract a library of forced trigger events.
+
+    To be used in correcting the SiPM photoelectrons with random coincidences.
+
+    This reformats the data to make use of several windows within a waveform to
+    build forced trigger events and then stores the number of pe and times for
+    each SiPM channel from that window (to be used for corrections).
+
+    This function processes two types of triggers with different window ranges:
+
+    - Forced/pulser triggers: uses full waveform ``[(1_000, 44_000), (55_000,
+      100_000)]`` ns
+    - HPGe/LAr triggers: uses first half only ``(1_000, 44_000)`` ns
+
+    Both are always filtered to exclude muon coincidences.
+
+    Parameters
+    ----------
+    evt_files
+        List of event tier data files.
+    min_num_evts
+        Minimum number of events requested for forced trigger correction. The
+        function attempts to collect at least ``min_num_evts`` events but may
+        return fewer if insufficient data are available in the input files.
+    time_domain_ns
+        Target time range (start, end) for output times in nanoseconds.  E.g.,
+        ``(-1000, 5000)`` means output times will be in ``[-1000, 5000]``.
+        Default: ``(-1_000, 5_000)``.
+    min_sep_ns
+        Minimal separation time between two windows in a trace, in nanoseconds.
+        Default 6000.
+    ext_trig_range_ns
+        Window ranges for forced/pulser trigger events, as list of (start, end)
+        tuples in nanoseconds. Default: ``[(1_000, 44_000), (55_000,
+        100_000)]``.
+    ge_trig_range_ns
+        Window ranges for HPGe/LAr trigger events, as list of (start, end)
+        tuples in nanoseconds.  Default: ``[(1_000, 44_000)]``.
+
+    Returns
+    -------
+    Array with fields "npe", the number of pe per SiPM and per hit, "t0", the
+    time relative to the start of a window in the trace, per SiPM and per hit
+    (makes sure that t0 are between bounds specified in `time_domain_ns`), and
+    "rawid" the SiPM channel numbers.
+    """
+    perf_block, print_perf = make_profiler()
+
+    npe_chunks: list[ak.Array] = []
+    t0_chunks: list[ak.Array] = []
+    n_collected_events = 0
+    rawids = None
+
+    # Set defaults if not provided
+    if ext_trig_range_ns is None:
+        ext_trig_range_ns = [(1_000, 44_000), (55_000, 100_000)]
+    if ge_trig_range_ns is None:
+        ge_trig_range_ns = [(1_000, 44_000)]
+
+    # shuffle evt_files in case rc change during the run
+    evt_files = list(evt_files)
+    random.shuffle(evt_files)
+
+    files_processed = 0
+
+    for file in evt_files:
+        if n_collected_events >= min_num_evts:
+            break
+
+        files_processed += 1
+
+        # Load all necessary data once
+        with perf_block("ftlib_read_data"):
+            evt = lh5.read(
+                "evt",
+                file,
+                field_mask=[
+                    "trigger/is_forced",
+                    "coincident/geds",
+                    "coincident/muon_offline",
+                    "coincident/puls",
+                    "spms/energy",
+                    "spms/t0",
+                    "spms/rawid",
+                ],
+            ).view_as("ak")
+
+        is_forced = evt.trigger.is_forced
+        is_geds_trig = evt.coincident.geds
+        is_muon = evt.coincident.muon_offline
+        is_pulser = evt.coincident.puls  # codespell:ignore puls
+
+        rawids_tmp = evt.spms.rawid[0]
+
+        if rawids is not None and not ak.all(rawids == rawids_tmp):
+            msg = "rawid should be the same in all cases"
+            raise ValueError(msg)
+
+        # Process forced/pulser events with full waveform windows
+        mask_forced_pulser = (is_forced | is_pulser) & ~is_muon
+        n_forced_pulser = int(ak.sum(mask_forced_pulser))
+        spms_fp = evt.spms[mask_forced_pulser]
+        if len(spms_fp) > 0:
+            with perf_block("ftlib_process_windows()"):
+                npe_chunk, t0_chunk = _process_spms_windows(
+                    spms_fp, ext_trig_range_ns, time_domain_ns, min_sep_ns
+                )
+                if len(npe_chunk) > 0:
+                    npe_chunks.append(npe_chunk)
+                    t0_chunks.append(t0_chunk)
+                    n_collected_events += len(npe_chunk)
+
+        # Process geds trigger events with limited window
+        mask_geds = is_geds_trig & ~is_muon
+        n_geds = int(ak.sum(mask_geds))
+        spms_ge_trig = evt.spms[mask_geds]
+        if len(spms_ge_trig) > 0:
+            with perf_block("ftlib_process_windows()"):
+                npe_chunk, t0_chunk = _process_spms_windows(
+                    spms_ge_trig, ge_trig_range_ns, time_domain_ns, min_sep_ns
+                )
+                if len(npe_chunk) > 0:
+                    npe_chunks.append(npe_chunk)
+                    t0_chunks.append(t0_chunk)
+                    n_collected_events += len(npe_chunk)
+
+        log.debug(
+            "forced-trigger library file %s: forced_or_pulser_events=%d "
+            "geds_events=%d cumulative_events=%d",
+            Path(file).name,
+            n_forced_pulser,
+            n_geds,
+            n_collected_events,
+        )
+
+        rawids = rawids_tmp
+
+    log.debug(
+        "forced-trigger library summary: files_processed=%d "
+        "returned_events=%d requested_min_events=%d",
+        files_processed,
+        n_collected_events,
+        min_num_evts,
+    )
+
+    with perf_block("ftlib_concatenate()"):
+        if npe_chunks:
+            npe = ak.concatenate(npe_chunks)
+            t0 = ak.concatenate(t0_chunks)
+        else:
+            npe = ak.Array([])
+            t0 = ak.Array([])
+
+        # Handle case where no events passed the filters
+        if len(npe) == 0 or rawids is None:
+            log.warning(
+                "No events passed the filters in get_random_coincidences_library, "
+                "returning empty arrays"
+            )
+            rawid = np.empty(
+                (0, len(rawids) if rawids is not None else 0), dtype=np.int32
+            )
+        else:
+            rawid = np.vstack([rawids] * len(npe))
+
+    print_perf()
+
+    return ak.Array(
+        {
+            "npe": npe,
+            "t0": t0,
+            "rawid": rawid,
+        }
+    )
+
+
+def get_rc_library_chunk(
+    rc_library: ak.Array,
+    chunk_len: int,
+    rc_offset: dict,
+) -> ak.Array:
+    """Select a chunk-length slice from a pre-sampled random coincidence library.
+
+    Always returns exactly ``chunk_len`` entries using wrap-around indexing when
+    necessary, and advances ``rc_offset["idx"]`` accordingly.
+    """
+    lib_len = len(rc_library)
+
+    if chunk_len > lib_len:
+        msg = (
+            "forced trigger library smaller than chunk; "
+            "reusing events with wrap-around."
+        )
+        log.warning(msg)
+
+    start_idx = rc_offset.get("idx", 0)
+    idx_array = (np.arange(chunk_len) + start_idx) % lib_len
+    rc_offset["idx"] = int((start_idx + chunk_len) % lib_len)
+
+    return rc_library[idx_array]
+
+
+def get_sipm_rc_data(
+    rc_library: ak.Array,
+    sipm: str,
+    sipm_uid: int,
+) -> tuple[ak.Array, ak.Array]:
+    """Extract data for a specific SiPM channel from the library.
+
+    Filters the forced trigger library to return only the photoelectron counts
+    and times for a single SiPM channel across all events.
+
+    Parameters
+    ----------
+    ft_library
+        Library of forced trigger events containing npe, t0, and rawid fields.
+    sipm
+        SiPM channel name to extract data for. If "all", flatten channel
+        dimension.
+    sipm_uid
+        SiPM channel ID to extract data for.
+
+    Returns
+    -------
+    npe
+        Photoelectron counts for the SiPM channel across all events.
+    t0
+        Photoelectron times for the SiPM channel across all events.
+
+    Raises
+    ------
+    ValueError
+        If the SiPM UID is not found in the library.
+    """
+    if sipm == "all":
+        npe = ak.flatten(rc_library.npe, axis=-1)
+        t0 = ak.flatten(rc_library.t0, axis=-1)
+
+    else:
+        # Find the channel index for this SiPM UID
+        # rawid[0] gives the channel IDs (should be the same for all events)
+        channel_indices = ak.where(rc_library.rawid[0] == sipm_uid)[0]
+
+        if len(channel_indices) == 0:
+            msg = f"SiPM UID {sipm_uid} not found in forced trigger library"
+            raise ValueError(msg)
+
+        ch_idx = int(channel_indices[0])
+
+        # Select data for this channel from all events
+        npe = rc_library.npe[:, ch_idx]
+        t0 = rc_library.t0[:, ch_idx]
+
+    return npe, t0

--- a/workflow/src/legendsimflow/utils.py
+++ b/workflow/src/legendsimflow/utils.py
@@ -269,6 +269,32 @@ def get_hit_tier_name(l200data: str) -> str:
     raise RuntimeError(msg)
 
 
+def get_evt_tier_name(l200data: str) -> str:
+    """Extract the name of the evt tier for this production cycle.
+
+    If the `pet` tier is present this is used else the `evt` tier is used.
+
+    Parameters
+    ----------
+    l200data
+        Path to the production cycle of l200 data.
+    """
+
+    df_cfg = lookup_dataflow_config(l200data).paths
+
+    # first check if pet exists
+    has_pet = ("tier_pet" in df_cfg) and Path(df_cfg.tier_pet).exists()
+    has_evt = ("tier_evt" in df_cfg) and Path(df_cfg.tier_evt).exists()
+
+    if has_pet:
+        return "pet"
+    if has_evt:
+        return "evt"
+
+    msg = f"The l200data {l200data} does not contain a valid pet or evt tier"
+    raise RuntimeError(msg)
+
+
 def hash_dict(d: dict | AttrsDict) -> str:
     """Compute the hash of a Python dict."""
     if isinstance(d, AttrsDict):


### PR DESCRIPTION
We generate forced-trigger–like events from the full dataset, since the actual forced triggers are recorded at a low rate. This allows us to maximize the number of random-coincidence events available for the correction.

The implementation is parameterized by:
- a chosen window length,
- a minimum separation between consecutive windows,
- and the allowed window range within the waveform.

For LEGEND-200 data, the window range is set to [1μs,44μs]. This choice is motivated by the distribution of the average number of photoelectrons (summed over channels) in 16 ns bins across the full waveform (see plot).

Each window is assigned a reference time defined as the window start time. This reference time is subtracted from the event t0 values so that they lie within the interval [0, window length].
Alternatively, one could define the reference time as “window start + 1 µs”, which would shift the t0 values to the interval [−1μs, window length−1μs].

A remaining point to decide is how to handle cases where insufficient random-coincidence data are available for the correction. The current implementation raises an error in this situation. As an alternative, we could allow the same random-coincidence event to be reused multiple times.

<img width="1285" height="458" alt="image" src="https://github.com/user-attachments/assets/f9399e69-4444-4a7c-ba10-51a4e4efc2bd" />
