### PR TITLE
Tooling to build realistic pulse shape libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "numpy",
     "psutil",
     "pyg4ometry",
+    "dspeed",
     "pygama >=2.3.6",
     "pylegendmeta >=1.3.5",
     "reboost >=0.10.3,<0.11",
@@ -193,6 +194,7 @@ dbetto = ">=1.3.2,<1.4"
 legend-pydataobj = ">=1.17.1"
 legend-pygeom-l200 = ">=0.8,<0.9"
 legend-pygeom-tools = ">=0.2,<0.3"
+dspeed = ">=2.1,<2.2"
 matplotlib = "*"
 numpy = "*"
 pylegendmeta = ">=1.3.5,<1.4"

--- a/tests/test_psl.py
+++ b/tests/test_psl.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+import pytest
+from lgdo import Array, Scalar
+
+from legendsimflow import psl
+
+
+def test_build_electronics_response_kernel():
+    # test first with all options
+    dt = 10.0
+    mu_bandwidth = 0.0
+    sigma_bandwidth = 50.0
+    tau_rc = 100.0
+
+    kernel = psl.build_electronics_response_kernel(
+        dt, mu_bandwidth, sigma_bandwidth, tau_rc
+    )
+    assert isinstance(kernel, np.ndarray)
+    assert kernel.size > 0
+    assert np.all(kernel >= 0)
+    assert np.isclose(np.sum(kernel), 1.0, atol=1e-2)
+
+    # 'full' mode results in a length of (len(rf_preamp) + len(rf_digi) - 1)
+    assert len(kernel) == 600 * 2 - 1  # default kernel length
+
+    # check the errors raised
+    with pytest.raises(ValueError):
+        psl.build_electronics_response_kernel(-1, mu_bandwidth, sigma_bandwidth, tau_rc)
+
+    with pytest.raises(ValueError):
+        psl.build_electronics_response_kernel(dt, mu_bandwidth, -10, tau_rc)
+
+    with pytest.raises(ValueError):
+        psl.build_electronics_response_kernel(dt, mu_bandwidth, sigma_bandwidth, -10)
+
+    # now check with gaussian only
+
+    dt = 10.0
+    mu_bandwidth = 0.0
+    sigma_bandwidth = 50.0
+    tau_rc = 100.0
+
+    kernel = psl.build_electronics_response_kernel(
+        dt, mu_bandwidth, sigma_bandwidth, tau_rc, gaussian_only=True
+    )
+    assert isinstance(kernel, np.ndarray)
+    assert kernel.size > 0
+    assert np.all(kernel >= 0)
+    assert np.isclose(np.sum(kernel), 1.0, atol=1e-2)
+
+    assert len(kernel) == 600  # default kernel length for gaussian only
+
+
+def test_convolve_waveform_with_kernel():
+    # create a simple test waveform (delta function)
+    wf = np.zeros((10, 1000))
+    wf[:, 500] = 1.0
+
+    dt = 10.0
+    mu_bandwidth = 0.0
+    sigma_bandwidth = 50.0
+    tau_rc = 100.0
+
+    kernel = psl.build_electronics_response_kernel(
+        dt, mu_bandwidth, sigma_bandwidth, tau_rc
+    )
+
+    # convolve
+    convolved = psl.apply_electronics_response(wf, kernel)
+
+    assert isinstance(convolved, ak.Array)
+
+    # shape should not be altered due to the slicing
+    assert convolved.to_numpy().shape == wf.shape
+
+    # test with a large batch size
+    convolved_1000 = psl.apply_electronics_response(wf, kernel, batch_size=1000)
+
+    # test with a small
+    convolved_2 = psl.apply_electronics_response(wf, kernel, batch_size=2)
+
+    assert convolved_1000.to_numpy().shape == wf.shape
+    assert convolved_2.to_numpy().shape == wf.shape
+
+
+def test_shift_array():
+    # create a simple test waveform (delta function)
+    wf = np.zeros((10, 1000))
+    wf[:, 500] = 1.0
+
+    shifted, peak_indices = psl.align_waveforms_to_peak(
+        wf, alignment_idx=510, nsamples_output_current_wfs=1000
+    )
+
+    assert isinstance(shifted, np.ndarray)
+    assert isinstance(peak_indices, np.ndarray)
+
+    assert shifted.shape == wf.shape
+
+    assert len(peak_indices) == wf.shape[0]
+
+
+def test_align_waveforms_to_peak_correctness():
+    # delta functions at different positions across waveforms
+    n_wfs, n_samples = 5, 200
+    peak_positions = [20, 50, 100, 150, 180]
+    wf = np.zeros((n_wfs, n_samples))
+    for i, p in enumerate(peak_positions):
+        wf[i, p] = 1.0
+
+    alignment_idx = 100
+
+    shifted, returned_peaks = psl.align_waveforms_to_peak(
+        wf, alignment_idx=alignment_idx, nsamples_output_current_wfs=n_samples
+    )
+
+    # returned peak indices must match the input positions
+    np.testing.assert_array_equal(returned_peaks, peak_positions)
+
+    # for waveforms whose shift doesn't push the peak outside the output window,
+    # the peak must land exactly at alignment_idx after shifting
+    for i, p in enumerate(peak_positions):
+        shift = alignment_idx - p
+        dst = p + shift  # == alignment_idx
+        if 0 <= dst < n_samples:
+            assert np.argmax(shifted[i]) == alignment_idx, (
+                f"waveform {i}: peak expected at {alignment_idx}, "
+                f"got {np.argmax(shifted[i])}"
+            )
+
+
+def test_align_waveforms_to_peak_clipping():
+    # peak near the start: left-clipping
+    wf_left = np.zeros((1, 100))
+    wf_left[0, 5] = 1.0
+    shifted_left, _ = psl.align_waveforms_to_peak(
+        wf_left, alignment_idx=50, nsamples_output_current_wfs=100
+    )
+    # peak lands at 50; samples originally before index 0 are zero-padded
+    assert shifted_left[0, 50] == 1.0
+    assert np.sum(shifted_left[0, :50]) == 0.0
+
+    # peak near the end: right-clipping
+    wf_right = np.zeros((1, 100))
+    wf_right[0, 95] = 1.0
+    shifted_right, _ = psl.align_waveforms_to_peak(
+        wf_right, alignment_idx=10, nsamples_output_current_wfs=100
+    )
+    # peak lands at 10; samples originally after index 99 are lost (zero-padded)
+    assert shifted_right[0, 10] == 1.0
+    assert np.sum(shifted_right[0, 11:]) == 0.0
+
+
+def test_align_waveforms_to_peak_different_output_length():
+    # output shorter than input: exercises length-asymmetric index arithmetic
+    n_wfs, n_samples_in, n_samples_out = 3, 200, 150
+    # peaks at: 10 (large positive shift → left-clip into shorter output),
+    #           80 (fits comfortably),
+    #           190 (large negative shift → right-clip into shorter output)
+    peak_positions = [10, 80, 190]
+    alignment_idx = 75
+
+    wf = np.zeros((n_wfs, n_samples_in))
+    for i, p in enumerate(peak_positions):
+        wf[i, p] = 1.0
+
+    shifted, returned_peaks = psl.align_waveforms_to_peak(
+        wf, alignment_idx=alignment_idx, nsamples_output_current_wfs=n_samples_out
+    )
+
+    assert shifted.shape == (n_wfs, n_samples_out)
+    np.testing.assert_array_equal(returned_peaks, peak_positions)
+
+    # waveform 1 (peak at 80): shift = 75 - 80 = -5, fits entirely in output
+    assert np.argmax(shifted[1]) == alignment_idx
+    assert shifted[1, alignment_idx] == 1.0
+
+    # waveform 0 (peak at 10): shift = +65, peak lands at 75
+    assert shifted[0, alignment_idx] == 1.0
+    assert np.sum(shifted[0, :alignment_idx]) == 0.0  # left side zero-padded
+
+    # waveform 2 (peak at 190): shift = 75 - 190 = -115, dst = 75
+    # but src start = 115, src end = min(200, 150+115) = 200 → only 85 samples copied
+    assert shifted[2, alignment_idx] == 1.0
+    assert np.sum(shifted[2, alignment_idx + 1 :]) == 0.0  # right side zero-padded
+
+
+def test_align_waveforms_to_peak_awkward_input():
+    wf_np = np.zeros((4, 100))
+    wf_np[:, 40] = 1.0
+    wf_ak = ak.Array(wf_np.tolist())
+
+    shifted_np, peaks_np = psl.align_waveforms_to_peak(
+        wf_np, alignment_idx=50, nsamples_output_current_wfs=100
+    )
+    shifted_ak, peaks_ak = psl.align_waveforms_to_peak(
+        wf_ak, alignment_idx=50, nsamples_output_current_wfs=100
+    )
+
+    np.testing.assert_array_equal(peaks_np, peaks_ak)
+    np.testing.assert_array_almost_equal(shifted_np, shifted_ak)
+
+
+def test_make_realistic_pulse_shape_lib():
+    rng = np.random.default_rng()
+    ideal_psl = {
+        "r": Array([0.1, 0.2, 0.3], attrs={"units": "m"}),
+        "z": Array([-0.1, 0, 0.1], attrs={"units": "m"}),
+        "waveform_0": Array(rng.random((3, 1000))),
+        "dt": Scalar(10, attrs={"units": "ns"}),
+    }
+
+    kernel = psl.build_electronics_response_kernel(1, 0, 100, 100)
+
+    output = psl.make_realistic_pulse_shape_lib(
+        ideal_psl,
+        kernel,
+        500,
+        1000,
+        mw_pars={
+            "length": 48,
+            "num_mw": 3,
+            "mw_type": 0,
+        },
+    )
+    assert isinstance(output, dict)
+
+    for item in output.values():
+        assert isinstance(item, (Array, Scalar))
+
+    assert "r" in output
+    assert "z" in output
+
+    assert "waveform_0" in output
+
+    assert output["r"].view_as("np").shape == (3,)
+    assert output["z"].view_as("np").shape == (3,)
+
+    assert output["waveform_0"].view_as("np").shape == (3, 1000)
+    assert "drift_time_0" in output
+    assert output["drift_time_0"].view_as("np").shape == (3,)
+
+
+_MW_PARS = {"length": 48, "num_mw": 3, "mw_type": 0}
+
+
+def test_make_realistic_pulse_shape_lib_nan_propagation():
+    # Build a 2D waveform map (n_r=3, n_z=4) where one pixel is NaN
+    rng = np.random.default_rng(0)
+    wfs = rng.random((3, 4, 1000))
+    nan_pixel = (1, 2)
+    wfs[nan_pixel] = np.nan
+
+    ideal_psl = {
+        "r": Array([0.1, 0.2, 0.3], attrs={"units": "m"}),
+        "z": Array([-0.15, -0.05, 0.05, 0.15], attrs={"units": "m"}),
+        "waveform_0": Array(wfs),
+        "dt": Scalar(10, attrs={"units": "ns"}),
+    }
+
+    kernel = psl.build_electronics_response_kernel(1, 0, 100, 100)
+    output = psl.make_realistic_pulse_shape_lib(
+        ideal_psl, kernel, 500, 1000, mw_pars=_MW_PARS
+    )
+
+    out_wfs = output["waveform_0"].view_as("np")
+    out_dt = output["drift_time_0"].view_as("np")
+
+    # NaN pixel must remain NaN in both outputs
+    assert np.all(np.isnan(out_wfs[nan_pixel])), "NaN pixel not propagated to waveform"
+    assert np.isnan(out_dt[nan_pixel]), "NaN pixel not propagated to drift time"
+
+    # all other pixels must be finite
+    mask = np.zeros((3, 4), dtype=bool)
+    mask[nan_pixel] = True
+    assert np.all(np.isfinite(out_wfs[~mask])), (
+        "unexpected NaN in valid waveform pixels"
+    )
+    assert np.all(np.isfinite(out_dt[~mask])), (
+        "unexpected NaN in valid drift-time pixels"
+    )
+
+
+def test_make_realistic_pulse_shape_lib_3d():
+    # Simulate the real input shape coming from Julia via HDF5:
+    # Julia writes (n_samples, n_z, n_r); Python reads back (n_r, n_z, n_samples)
+    n_r, n_z, n_samples = 4, 5, 1000
+    rng = np.random.default_rng(1)
+    wfs = rng.random((n_r, n_z, n_samples))
+
+    ideal_psl = {
+        "r": Array(np.linspace(0.0, 0.03, n_r), attrs={"units": "m"}),
+        "z": Array(np.linspace(0.0, 0.04, n_z), attrs={"units": "m"}),
+        "waveform_0": Array(wfs),
+        "dt": Scalar(10, attrs={"units": "ns"}),
+    }
+
+    kernel = psl.build_electronics_response_kernel(1, 0, 100, 100)
+    output = psl.make_realistic_pulse_shape_lib(
+        ideal_psl, kernel, 500, 1000, mw_pars=_MW_PARS
+    )
+
+    assert output["waveform_0"].view_as("np").shape == (n_r, n_z, n_samples)
+    assert output["drift_time_0"].view_as("np").shape == (n_r, n_z)

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -489,11 +489,11 @@ Compute a drift time map for an HPGe detector at a specific crystal axis angle.
 # Arguments
 - `sim`: SolidStateDetectors Simulation object
 - `meta`: Detector metadata (PropDict)
-- `T`: Numeric type (e.g., Float32)
 - `angle_deg`: Crystal axis angle in degrees
 - `grid_step`: Grid spacing in meters
-- `padding`: pixels used to pad the map and avoid grid edge effects (see
-  `extend_drift_time_map()`).
+- `padding`: Number of pixel layers used to pad the map and avoid grid edge
+  effects (see `extend_drift_time_map()`)
+- `T`: Numeric type (e.g., Float32)
 
 # Returns
 - `NamedTuple`: Contains `:r`, `:z` axes and `:drift_time_XXX_deg` matrix

--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -203,27 +203,21 @@ def align_waveforms_to_peak(
     # Convert to NumPy for matrix operations
     wfs = ak.to_numpy(wf_input) if isinstance(wf_input, ak.Array) else wf_input
 
-    # Output Array - Indices not covered by the shifted signal are automatically padded with 0.0
     n_wfs, n_samples = wfs.shape
-    shifted_wfs = np.zeros((n_wfs, nsamples_output_current_wfs), dtype=float)
-
-    # Find Amax
     peak_indices = np.argmax(wfs, axis=1)
+    shifts = alignment_idx - peak_indices  # (n_wfs,)
 
-    # Shift each waveform
-    for i in range(n_wfs):
-        peak = peak_indices[i]
-        shift = alignment_idx - peak
+    # For each destination index d, the corresponding source index is d - shift[i].
+    # Build a (n_wfs, n_samples_out) source-index matrix, mask out-of-bounds positions
+    # with 0 (safe to index), then zero out those positions in the result.
+    d = np.arange(nsamples_output_current_wfs)  # (n_samples_out,)
+    src_idx = d[np.newaxis, :] - shifts[:, np.newaxis]  # (n_wfs, n_samples_out)
+    valid = (src_idx >= 0) & (src_idx < n_samples)
+    src_idx_safe = np.clip(src_idx, 0, n_samples - 1)
 
-        # Bounds to prevent IndexErrors
-        start_src = max(0, -shift)
-        end_src = min(n_samples, nsamples_output_current_wfs - shift)
-
-        if start_src < end_src:
-            start_dst = start_src + shift
-            end_dst = end_src + shift
-
-            shifted_wfs[i, start_dst:end_dst] = wfs[i, start_src:end_src]
+    shifted_wfs = np.where(
+        valid, wfs[np.arange(n_wfs)[:, np.newaxis], src_idx_safe], 0.0
+    )
 
     return shifted_wfs, peak_indices
 

--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -1,0 +1,407 @@
+# Copyright (C) 2026 Luigi Pertoldi <gipert@pm.me>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+import awkward as ak
+import numpy as np
+from lgdo import Array, Scalar
+from reboost import units
+from scipy.signal import convolve, fftconvolve
+
+logger = logging.getLogger(__name__)
+
+
+def build_electronics_response_kernel(
+    dt: float,
+    mu_bandwidth: float,
+    sigma_bandwidth: float,
+    tau_rc: float,
+    gaussian_only: bool = False,
+    *,
+    kernel_length: int = 600,
+    kernel_start: int = -100,
+) -> np.ndarray:
+    """Create the system response kernel (gaussian + exponential decay).
+
+    This is obtained by convolving a Gaussian (representing the digitizer
+    bandwidth) with a causal exponential decay (representing the preamplifier
+    response). The kernel is normalized to have a sum of 1.
+
+    Note
+    ----
+    The 'full' mode of convolution results in a length of 2*kernel_length - 1.
+    If `gaussian_only` is True, the kernel will have a length of
+    `kernel_length` and will only contain the Gaussian component, since no
+    convolution is performed.
+
+    Parameters
+    ----------
+    dt
+        The time step between samples in the waveform (in ns)
+    mu_bandwidth
+        The mean of the Gaussian representing the digitizer bandwidth (in ns)
+    sigma_bandwidth
+        The standard deviation of the Gaussian representing the digitizer
+        bandwidth (in ns)
+    tau_rc
+        The time constant of the exponential decay representing the
+        preamplifier response (in ns)
+    gaussian_only
+        If True, only use the Gaussian component (default is False)
+    kernel_length
+        The total length of the response kernel in samples (default is 600)
+    kernel_start
+        The starting index of the kernel relative to the waveform (default is
+        -100, meaning the kernel will cover from -100 to 500 samples)
+
+    Returns
+    -------
+    rf
+        The normalized response kernel
+    """
+
+    # Validate inputs
+    if dt <= 0:
+        msg = f"dt must be positive, got {dt}"
+        raise ValueError(msg)
+    if sigma_bandwidth <= 0:
+        msg = f"sigma_bandwidth must be positive, got {sigma_bandwidth}"
+        raise ValueError(msg)
+    if not gaussian_only and tau_rc <= 0:
+        msg = f"tau_rc must be positive, got {tau_rc}"
+        raise ValueError(msg)
+
+    # Convert to samples
+    mu_samples = mu_bandwidth / dt
+    sigma_samples = sigma_bandwidth / dt
+    tau_samples = tau_rc / dt
+
+    # Define the sample range
+    x = np.arange(kernel_start, kernel_start + kernel_length)
+
+    # Compute Gaussian response (digitizer bandwidth)
+    rf_digi = np.exp(-0.5 * ((x - mu_samples) / sigma_samples) ** 2)
+
+    # Validate before normalization
+    digi_sum = np.sum(rf_digi)
+    if digi_sum == 0:
+        msg = (
+            "Digitizer response normalization failed: sum is zero. "
+            "This may indicate numerical underflow with the given sigma_bandwidth."
+        )
+        raise ValueError(msg)
+
+    rf_digi /= digi_sum
+
+    if gaussian_only:
+        return rf_digi
+
+    # Compute causal exponential decay (preamplifier response) - response is zero for x < 0
+    rf_preamp = np.zeros_like(x, dtype=float)
+    rf_preamp[x >= 0] = np.exp(-x[x >= 0] / tau_samples)
+
+    # Validate before normalization
+    preamp_sum = np.sum(rf_preamp)
+    if preamp_sum == 0:
+        msg = (
+            "Preamp response normalization failed: sum is zero. "
+            "This may indicate numerical underflow with the given tau_rc."
+        )
+        raise ValueError(msg)
+    rf_preamp /= preamp_sum
+
+    # Convolve preamp and digitizer responses - 'full' mode results in a length of (len(rf_preamp) + len(rf_digi) - 1)
+    return convolve(rf_preamp, rf_digi, mode="full")
+
+
+def apply_electronics_response(
+    wf_array: ak.Array | np.ndarray, rf_kernel: np.ndarray, batch_size: int = 50000
+) -> ak.Array:
+    """Vectorized convolution using FFT with batching to save memory.
+
+    Parameters
+    ----------
+    wf_array
+        Array of waveforms (all of same length)
+    rf_kernel
+        The response kernel (gaussian + exponential)
+    batch_size
+        Number of waveforms to process at once (default is 50,000)
+
+    Returns
+    -------
+    convolved_wfs
+        The convolved waveforms as an Awkward Array
+    """
+    n_events = len(wf_array)
+    # Reshape kernel for broadcasting (1, Kernel_Length)
+    kernel_2d = rf_kernel[np.newaxis, :]
+
+    convolved_results = []
+
+    # Process in batches to prevent memory overflow
+    for i in range(0, n_events, batch_size):
+        batch = wf_array[i : i + batch_size]
+        wf_matrix = np.asarray(batch)
+        wf_conv = fftconvolve(wf_matrix, kernel_2d, mode="full")
+
+        # Slice to original length to maintain timing relative to start. This preserves the initial points to emulate baseline
+        wf_conv_sliced = wf_conv[:, : wf_matrix.shape[1]]
+        convolved_results.append(wf_conv_sliced)
+
+    # Concatenate batches and return as Awkward Array
+    return ak.concatenate(convolved_results)
+
+
+def align_waveforms_to_peak(
+    wf_input: ak.Array | np.ndarray,
+    alignment_idx: int,
+    nsamples_output_current_wfs: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Align an array of waveforms by shifting their maximum to a fixed index.
+
+    No normalization is performed; raw amplitudes are preserved.
+
+    Note
+    ----
+    The output peak_indices is not the original drift time as the current
+    waveform inherits baseline from convolution.
+
+    Parameters
+    ----------
+    wf_input
+        Input array of current waveforms
+    alignment_idx
+        The index in the output array where the peak will be placed
+    nsamples_output_current_wfs
+        The total length of the resulting aligned current waveforms
+
+    Returns
+    -------
+    shifted_wfs
+        2D array of shifted waveforms
+    peak_indices
+        1D array containing the original peak index for each current waveform
+    """
+
+    # Convert to NumPy for matrix operations
+    wfs = ak.to_numpy(wf_input) if isinstance(wf_input, ak.Array) else wf_input
+
+    # Output Array - Indices not covered by the shifted signal are automatically padded with 0.0
+    n_wfs, n_samples = wfs.shape
+    shifted_wfs = np.zeros((n_wfs, nsamples_output_current_wfs), dtype=float)
+
+    # Find Amax
+    peak_indices = np.argmax(wfs, axis=1)
+
+    # Shift each waveform
+    for i in range(n_wfs):
+        peak = peak_indices[i]
+        shift = alignment_idx - peak
+
+        # Bounds to prevent IndexErrors
+        start_src = max(0, -shift)
+        end_src = min(n_samples, nsamples_output_current_wfs - shift)
+
+        if start_src < end_src:
+            start_dst = start_src + shift
+            end_dst = end_src + shift
+
+            shifted_wfs[i, start_dst:end_dst] = wfs[i, start_src:end_src]
+
+    return shifted_wfs, peak_indices
+
+
+def _check_pulse_shape_lib_keys(
+    pulse_shape_lib: Mapping[str, Array | Scalar],
+) -> None:
+    """Validate that the waveform map contains the required keys with correct types."""
+    required_keys = {"r", "z", "dt"}
+    missing_keys = required_keys - set(pulse_shape_lib.keys())
+
+    if missing_keys:
+        msg = f"Ideal waveform map is missing required keys: {missing_keys}"
+        raise ValueError(msg)
+
+    for key in required_keys:
+        if not isinstance(pulse_shape_lib[key], (Array, Scalar)):
+            msg = f"Key '{key}' must be of type Array or Scalar, got {type(pulse_shape_lib[key])}"
+            raise TypeError(msg)
+
+    for key, item in pulse_shape_lib.items():
+        if not isinstance(item, (Array, Scalar)):
+            msg = f"Key '{key}' must be of type Array or Scalar, got {type(item)}"
+            raise TypeError(msg)
+
+
+def make_realistic_pulse_shape_lib(
+    ideal_pulse_shape_lib_obj: Mapping[str, Array | Scalar],
+    rf_kernel: np.ndarray,
+    alignment_idx: int,
+    nsamples_output_current_wfs: int,
+    mw_pars: dict[str, float | int],
+    dt_data: float = 1.0,
+) -> dict[str, Array | Scalar]:
+    """Apply the waveform post-processing chain to generate a realistic waveform map.
+
+    Starts from an ideal waveform map and performs the following steps:
+
+    1. Converts coordinates (m to mm)
+    2. Convolves with system response
+    3. Aligns by Peak Time
+    4. Calculates compensated Drift Time
+
+    Parameters
+    ----------
+    ideal_pulse_shape_lib_obj
+        Mapping containing the ideal waveform map with coordinates and waveforms.
+
+        This should have the following format:
+
+        - r: 1D array of radial coordinates
+        - z: 1D array of axial coordinates
+        - dt: Time step between samples in the waveforms
+        - waveform_X: 3D array of ideal charge waveforms for angle X
+          (shape: [n_z, n_r, n_samples])
+    rf_kernel
+        The system response kernel (from :func:`build_electronics_response_kernel`)
+    alignment_idx
+        The index in the output array where waveform peaks will be aligned
+    nsamples_output_current_wfs
+        The total length of the resulting aligned current waveforms
+    mw_pars
+        Dictionary of parameters for the moving window average step, with keys:
+
+        - length: The length of the moving window (in samples)
+        - num_mw: The number of moving windows to use in the moving window
+          average
+        - mw_type: The type of moving window to apply (see
+          :func:`dspeed.processors.moving_window_multi` for details)
+    dt_data
+        The time step of the original data waveforms (in ns), used to scale
+        the derivative.
+
+    Returns
+    -------
+    realistic_pulse_shape_lib
+        Struct containing the processed realistic waveform map with the
+        following keys:
+
+        - r: 1D array of radial coordinates
+        - z: 1D array of axial coordinates
+        - t0: Global time offset applied to align waveforms
+        - waveform_X: 3D array of processed current waveforms for angle X
+          (shape: [n_r, n_z, nsamples_output_current_wfs], spatial axes
+          reversed relative to Julia due to HDF5 column-/row-major conversion)
+        - drift_time_X: 2D array of calculated drift times for angle X
+          (shape: [n_r, n_z])
+    """
+
+    _check_pulse_shape_lib_keys(ideal_pulse_shape_lib_obj)
+
+    realistic_pulse_shape_lib = {}
+    dt = ideal_pulse_shape_lib_obj["dt"].value * units.units_convfact(
+        ideal_pulse_shape_lib_obj["dt"], "ns"
+    )
+
+    realistic_pulse_shape_lib["dt"] = Scalar(dt, attrs={"units": "ns"})
+    realistic_pulse_shape_lib["t0"] = Scalar(
+        -1.0 * alignment_idx * dt, attrs={"units": "ns"}
+    )  # Set the global t0 relative to alignment index
+
+    # Delay of the response kernel
+    kernel_delay_idx = np.argmax(rf_kernel)
+
+    for coord in ["r", "z"]:
+        if coord in ideal_pulse_shape_lib_obj:
+            realistic_pulse_shape_lib[coord] = Array(
+                units.units_conv_ak(ideal_pulse_shape_lib_obj[coord], "mm").to_numpy(),
+                attrs={"units": "mm"},
+            )
+
+    # Search for waveform keys (general - I can have any angle in the ideal map)
+    keys_to_convolve = [k for k in ideal_pulse_shape_lib_obj if "waveform" in k]
+
+    for key in keys_to_convolve:
+        logger.info("Processing %s...", key)
+
+        # Extract and prepare data
+        ideal_wfs = ideal_pulse_shape_lib_obj[key]
+        ideal_wfs_arr = ideal_wfs.view_as("np")
+
+        # Julia writes arrays in column-major (Fortran) order; HDF5/Python reads them
+        # back in row-major (C) order, reversing the axis order. Julia stores waveforms
+        # as (n_samples, n_z, n_r), which Python reads as (n_r, n_z, n_samples). The
+        # code assumes samples are on the last axis, which is satisfied after this
+        # reversal regardless of the spatial axis ordering.
+
+        # Record NaN mask before zeroing (shape: [n_r, n_z], True where pixel is invalid)
+        nan_mask = np.isnan(ideal_wfs_arr).any(axis=-1)
+        ideal_wfs_arr = np.nan_to_num(ideal_wfs_arr, nan=0.0)
+
+        original_shape = ideal_wfs_arr.shape
+        wfs_flat = ideal_wfs_arr.reshape(-1, original_shape[-1])
+
+        # Convolution electronics
+        convolved_ak = apply_electronics_response(wfs_flat, rf_kernel)
+        wfs_convolved = ak.to_numpy(convolved_ak)
+
+        # Derivative (Charge -> Current)
+        wfs_current = np.diff(wfs_convolved, axis=-1, prepend=0) * (dt_data / dt)
+
+        # Calculate drift time from Amax
+        current_peak_indices = np.argmax(wfs_current, axis=1)
+        drift_indices = current_peak_indices - kernel_delay_idx
+        drift_times_flat = drift_indices * dt
+        drift_times_2d = drift_times_flat.reshape(original_shape[:-1]).astype(
+            np.float64
+        )
+
+        # Restore NaN for invalid pixels in drift time
+        drift_times_2d[nan_mask] = np.nan
+        dt_key = key.replace("waveform", "drift_time")
+        realistic_pulse_shape_lib[dt_key] = Array(drift_times_2d, attrs={"units": "ns"})
+
+        # Moving Window Average
+        # NOTE: import is intentionally deferred here to work around a bug in dspeed
+        # where importing it at module level causes a pint unit registry conflict.
+        from dspeed.processors import moving_window_multi  # noqa: PLC0415
+
+        wf_in = wfs_current.astype(float, copy=False)
+        wfs_mwa = np.zeros_like(wf_in)
+        moving_window_multi(
+            wf_in, mw_pars["length"], mw_pars["num_mw"], mw_pars["mw_type"], wfs_mwa
+        )
+
+        # Align current waveforms to Amax
+        wfs_aligned, _ = align_waveforms_to_peak(
+            wfs_mwa, alignment_idx, nsamples_output_current_wfs
+        )
+
+        # Reshape
+        new_length = wfs_aligned.shape[-1]
+        new_shape = (*original_shape[:-1], new_length)
+        wfs_out = wfs_aligned.reshape(new_shape).astype(np.float64)
+
+        # Restore NaN for invalid pixels in waveforms
+        wfs_out[nan_mask] = np.nan
+        realistic_pulse_shape_lib[key] = Array(wfs_out)
+
+    _check_pulse_shape_lib_keys(realistic_pulse_shape_lib)
+    return realistic_pulse_shape_lib

--- a/workflow/src/legendsimflow/scripts/make_hpge_realistic_pulse_shape_lib.py
+++ b/workflow/src/legendsimflow/scripts/make_hpge_realistic_pulse_shape_lib.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2026 Giovanna Saleh <giovanna.saleh@phd.unipd.it>,
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from lgdo import Struct, lh5
+from reboost import units
+
+from legendsimflow import psl
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+ALIGNMENT_IDX = 3000  # Index to align current waveforms to Amax
+NSAMPLES_OUTPUT_CURRENT_WFS = (
+    5001  # Final length of the realistic current waveforms in the map
+)
+DT_DATA = 16.0  # Time step of the original data waveforms in ns (used to scale the derivative)
+MW_PARS = {
+    "length": 48,
+    "num_mw": 3,
+    "mw_type": 0,
+}  # Parameters for the moving window average step
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--detector", required=True, help="Detector name (LH5 group)")
+    parser.add_argument(
+        "--sigma-conv",
+        type=float,
+        required=True,
+        help="Sigma of the gaussian component of the convolution kernel in ns",
+    )
+    parser.add_argument(
+        "--tau-conv",
+        type=float,
+        required=True,
+        help="Tau of the exponential component of the convolution kernel in ns",
+    )
+    parser.add_argument("--input-file", required=True)
+    parser.add_argument("--output-file", required=True)
+    args = parser.parse_args()
+
+    # 1. Load data
+    ideal_map_obj = lh5.read(args.detector, args.input_file)
+    dt = ideal_map_obj["dt"].value * units.units_convfact(ideal_map_obj["dt"], "ns")
+
+    # 2. Setup Physics Kernel (mu=0, sigma=sigma-conv ns, tau=tau-conv ns)
+    rf_kernel = psl.build_electronics_response_kernel(
+        dt,
+        mu_bandwidth=0,
+        sigma_bandwidth=args.sigma_conv,
+        tau_rc=args.tau_conv,
+    )
+
+    # 3. Process
+    realistic_dict = psl.make_realistic_pulse_shape_lib(
+        ideal_map_obj,
+        rf_kernel,
+        ALIGNMENT_IDX,
+        NSAMPLES_OUTPUT_CURRENT_WFS,
+        mw_pars=MW_PARS,
+        dt_data=DT_DATA,
+    )
+
+    # 4. Write output with units
+    out_struct = Struct(realistic_dict)
+    lh5.write(
+        obj=out_struct, name=args.detector, lh5_file=args.output_file, wo_mode="of"
+    )
+
+    logger.info("Realistic library created successfully: %s", args.output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Introduces the Python module `legendsimflow.psl` and a driver script to build a **realistic pulse-shape library (PSL)** from an ideal (simulated) one by applying the full electronics response and waveform post-processing chain.

### New Python library (`workflow/src/legendsimflow/psl.py`)

- `build_electronics_response_kernel` — builds a Gaussian × causal-exponential kernel modelling the combined digitizer bandwidth and preamplifier response
- `apply_electronics_response` — batched FFT convolution of waveform arrays with the response kernel (memory-efficient, processes in configurable batches)
- `align_waveforms_to_peak` — shifts each current waveform so its maximum lands at a fixed sample index
- `make_realistic_pulse_shape_lib` — full post-processing chain: unit conversion → convolution → charge-to-current differentiation → moving-window average → drift-time extraction → peak alignment → reshape and NaN-mask restoration

### New driver script (`workflow/src/legendsimflow/scripts/make_hpge_realistic_pulse_shape_lib.py`)

CLI entry point that reads an ideal PSL from an LH5 file, runs the post-processing chain with configurable kernel parameters, and writes the realistic PSL back to HDF5.

### Julia fixes (`workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl`)

- `compute_ideal_pulse_shape_lib`: rename internal axis variable `x_axis` → `r_axis` for consistency
- `compute_drift_time_map`: move `T` type parameter to 3rd position to match call sites and `compute_ideal_pulse_shape_lib` convention (previous order caused a silent type mismatch); add missing `nothing` guard after `find_valid_spawn_position`; use `T(NaN)` for the fill value to respect the type parameter

### Other

- Pin `dspeed` to `>=2.1,<2.2` in pixi dependencies
- Add unit tests for all new Python functions