### PR TITLE
Speed up reading data at the evt tier

### DIFF
--- a/workflow/src/legendsimflow/profile.py
+++ b/workflow/src/legendsimflow/profile.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Callable
 
 import psutil
@@ -36,6 +36,7 @@ def _pct(x: int | float) -> str:
 
 def make_profiler() -> tuple[Callable, Callable]:
     proc = psutil.Process()
+    stats = OrderedDict()
     stats = defaultdict(
         lambda: {
             "wall_s": 0.0,
@@ -79,7 +80,7 @@ def make_profiler() -> tuple[Callable, Callable]:
         msg = "==== profiling report ===="
         log.info(msg)
 
-        blocks = sorted(stats)
+        blocks = list(stats)
         sum_wall_s = sum(stats[b]["wall_s"] for b in blocks)
         sum_max_delta_rss_mb = sum(stats[b]["max_delta_rss_mb"] for b in blocks)
         sum_avg_delta_rss_mb = sum(stats[b]["avg_delta_rss_mb"] for b in blocks)

--- a/workflow/src/legendsimflow/profile.py
+++ b/workflow/src/legendsimflow/profile.py
@@ -72,7 +72,10 @@ def make_profiler() -> tuple[Callable, Callable]:
             log.debug(msg)
 
     def print_stats() -> None:
-        for block, s in dict(stats).items():
+        msg = "==== profiling report ===="
+        log.info(msg)
+        for block in sorted(stats):
+            s = stats[block]
             msg = (
                 f"block {block} ]]] "
                 f"wall_time_s={_f(s['wall_s'])} "
@@ -80,5 +83,7 @@ def make_profiler() -> tuple[Callable, Callable]:
                 f"avg_delta_rss_mb={_f(s['avg_delta_rss_mb'])}"
             )
             log.info(msg)
+        msg = "=========================="
+        log.info(msg)
 
     return profile_block, print_stats

--- a/workflow/src/legendsimflow/profile.py
+++ b/workflow/src/legendsimflow/profile.py
@@ -30,6 +30,10 @@ def _f(x: int | float) -> str:
     return f"{x:.5g}"
 
 
+def _pct(x: int | float) -> str:
+    return f"{x:.1f}"
+
+
 def make_profiler() -> tuple[Callable, Callable]:
     proc = psutil.Process()
     stats = defaultdict(
@@ -101,9 +105,9 @@ def make_profiler() -> tuple[Callable, Callable]:
 
             msg = (
                 f"block {block} ]]] "
-                f"wall_time_s={_f(wall_s)} ({_f(wall_s_frac)}%) "
-                f"max_delta_rss_mb={_f(max_delta_rss_mb)} ({_f(max_delta_rss_mb_frac)}%) "
-                f"avg_delta_rss_mb={_f(avg_delta_rss_mb)} ({_f(avg_delta_rss_mb_frac)}%)"
+                f"wall_time_s={_f(wall_s)} ({_pct(wall_s_frac)}%) "
+                f"max_delta_rss_mb={_f(max_delta_rss_mb)} ({_pct(max_delta_rss_mb_frac)}%) "
+                f"avg_delta_rss_mb={_f(avg_delta_rss_mb)} ({_pct(avg_delta_rss_mb_frac)}%)"
             )
             log.info(msg)
         msg = "=========================="

--- a/workflow/src/legendsimflow/profile.py
+++ b/workflow/src/legendsimflow/profile.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import time
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Callable
 
 import psutil
@@ -36,7 +36,6 @@ def _pct(x: int | float) -> str:
 
 def make_profiler() -> tuple[Callable, Callable]:
     proc = psutil.Process()
-    stats = OrderedDict()
     stats = defaultdict(
         lambda: {
             "wall_s": 0.0,

--- a/workflow/src/legendsimflow/profile.py
+++ b/workflow/src/legendsimflow/profile.py
@@ -74,13 +74,36 @@ def make_profiler() -> tuple[Callable, Callable]:
     def print_stats() -> None:
         msg = "==== profiling report ===="
         log.info(msg)
-        for block in sorted(stats):
+
+        blocks = sorted(stats)
+        sum_wall_s = sum(stats[b]["wall_s"] for b in blocks)
+        sum_max_delta_rss_mb = sum(stats[b]["max_delta_rss_mb"] for b in blocks)
+        sum_avg_delta_rss_mb = sum(stats[b]["avg_delta_rss_mb"] for b in blocks)
+
+        for block in blocks:
             s = stats[block]
+
+            wall_s = s["wall_s"]
+            max_delta_rss_mb = s["max_delta_rss_mb"]
+            avg_delta_rss_mb = s["avg_delta_rss_mb"]
+
+            wall_s_frac = 100.0 * wall_s / sum_wall_s if sum_wall_s else 0.0
+            max_delta_rss_mb_frac = (
+                100.0 * max_delta_rss_mb / sum_max_delta_rss_mb
+                if sum_max_delta_rss_mb
+                else 0.0
+            )
+            avg_delta_rss_mb_frac = (
+                100.0 * avg_delta_rss_mb / sum_avg_delta_rss_mb
+                if sum_avg_delta_rss_mb
+                else 0.0
+            )
+
             msg = (
                 f"block {block} ]]] "
-                f"wall_time_s={_f(s['wall_s'])} "
-                f"max_delta_rss_mb={_f(s['max_delta_rss_mb'])} "
-                f"avg_delta_rss_mb={_f(s['avg_delta_rss_mb'])}"
+                f"wall_time_s={_f(wall_s)} ({_f(wall_s_frac)}%) "
+                f"max_delta_rss_mb={_f(max_delta_rss_mb)} ({_f(max_delta_rss_mb_frac)}%) "
+                f"avg_delta_rss_mb={_f(avg_delta_rss_mb)} ({_f(avg_delta_rss_mb_frac)}%)"
             )
             log.info(msg)
         msg = "=========================="


### PR DESCRIPTION
- **opt: implement cap on number of pes per hit**
- **plots: fix usability coloring**
- **fix: print stats in sorted order for deterministic output**
- **feat: print per-block percentage of total in profiling report**
- **refactor: add _pct and use it for percentage formatting in logs**
- **refactor: preserve insertion order for report blocks**
