### PR TITLE
Refactor output paths

### DIFF
--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -55,8 +55,9 @@ Here's a basic description of its fields:
     various scintillators used in the `opt` tier. These maps are currently not
     produced by the Simflow and therefore supplied as external input.
     - `lar`: the liquid argon optical map file.
-  - `genmeta` (output): generated metadata files (e.g. YAML files storing
-    parameters extracted from the LEGEND-200 data).
+  - `pars` (output): root folder for all generated parameter files (e.g. YAML
+    files storing parameters extracted from the LEGEND-200 data, geometry files,
+    drift time maps).
   - `macros` (output): generated _remage_ macro files
   - `geom` (output): generated simulation geometry files.
   - `dtmaps` (output): generated HPGe drift time maps.

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -62,8 +62,8 @@ Here's a basic description of its fields:
   - `geom` (output): generated simulation geometry files.
   - `dtmaps` (output): generated HPGe drift time maps.
   - `tier` (dict, output): generated outputs for each tier, keyed by tier name
-    (e.g. `tier.stp`, `tier.hit`, ...).
-  - `plots` (output): validation plots/graphics.
+    (e.g. `tier.stp`, `tier.hit`, ...). Validation plots for each tier are
+    stored in a `plots/` subdirectory (e.g. `tier.stp/plots/`).
 - `precompile_pkg`: list of Python module names that contain Numba-accelerated
   routines. To avoid Numba precompilation race conditions, the Simflow
   sequentially imports these modules to ensure that the Numba cache is populated

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -59,8 +59,10 @@ Here's a basic description of its fields:
     files storing parameters extracted from the LEGEND-200 data, geometry files,
     drift time maps).
   - `macros` (output): generated _remage_ macro files
-  - `geom` (output): generated simulation geometry files.
-  - `dtmaps` (output): generated HPGe drift time maps.
+  - `geom` (optional output): generated simulation geometry files. Defaults to
+    `{paths.pars}/geom` if not set.
+  - `dtmaps` (optional output): generated HPGe drift time maps. Defaults to
+    `{paths.pars}/hpge/dtmaps` if not set.
   - `tier` (dict, output): generated outputs for each tier, keyed by tier name
     (e.g. `tier.stp`, `tier.hit`, ...). Validation plots for each tier are
     stored in a `plots/` subdirectory (e.g. `tier.stp/plots/`).

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -61,7 +61,8 @@ Here's a basic description of its fields:
   - `macros` (output): generated _remage_ macro files
   - `geom` (output): generated simulation geometry files.
   - `dtmaps` (output): generated HPGe drift time maps.
-  - `tier_TIER` (output): generated outputs in tier `TIER`.
+  - `tier` (dict, output): generated outputs for each tier, keyed by tier name
+    (e.g. `tier.stp`, `tier.hit`, ...).
   - `plots` (output): validation plots/graphics.
 - `precompile_pkg`: list of Python module names that contain Numba-accelerated
   routines. To avoid Numba precompilation race conditions, the Simflow

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -45,8 +45,8 @@ paths:
 
   pars: $_/generated/pars
   macros: $_/generated/macros
-  geom: $_/generated/pars/geom
-  dtmaps: $_/generated/pars/hpge/dtmaps
+  # geom: $_/generated/pars/geom
+  # dtmaps: $_/generated/pars/hpge/dtmaps
   tier_vtx: $_/generated/tier/vtx
   tier_stp: $_/generated/tier/stp
   tier_opt: $_/generated/tier/opt

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -43,10 +43,10 @@ paths:
     lar: $_/inputs/simprod/l200a-optical-map-lar.lh5
     pen: $_/inputs/simprod/l200a-optical-map-pen.lh5
 
-  genmeta: $_/generated/metadata
+  pars: $_/generated/pars
   macros: $_/generated/macros
-  geom: $_/generated/geom
-  dtmaps: $_/generated/hpge/dtmaps
+  geom: $_/generated/pars/geom
+  dtmaps: $_/generated/pars/hpge/dtmaps
   tier_vtx: $_/generated/tier/vtx
   tier_stp: $_/generated/tier/stp
   tier_opt: $_/generated/tier/opt

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -56,7 +56,6 @@ paths:
     cvt: $_/generated/tier/cvt
     pdf: $_/generated/tier/pdf
   pdf_releases: $_/generated/releases
-  plots: $_/generated/plots
 
 precompile_pkg:
   - dspeed.processors

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -47,13 +47,14 @@ paths:
   macros: $_/generated/macros
   # geom: $_/generated/pars/geom
   # dtmaps: $_/generated/pars/hpge/dtmaps
-  tier_vtx: $_/generated/tier/vtx
-  tier_stp: $_/generated/tier/stp
-  tier_opt: $_/generated/tier/opt
-  tier_hit: $_/generated/tier/hit
-  tier_evt: $_/generated/tier/evt
-  tier_cvt: $_/generated/tier/cvt
-  tier_pdf: $_/generated/tier/pdf
+  tier:
+    vtx: $_/generated/tier/vtx
+    stp: $_/generated/tier/stp
+    opt: $_/generated/tier/opt
+    hit: $_/generated/tier/hit
+    evt: $_/generated/tier/evt
+    cvt: $_/generated/tier/cvt
+    pdf: $_/generated/tier/pdf
   pdf_releases: $_/generated/releases
   plots: $_/generated/plots
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from legendmeta import LegendMetadata
 from legendtestdata import LegendTestData
 from pygeoml200 import core
 
+from legendsimflow.utils import apply_path_defaults
+
 testprod = Path(__file__).parent / "dummyprod"
 config_filename = testprod / "simflow-config.yaml"
 
@@ -53,6 +55,7 @@ def make_config(legend_testdata):
         return d
 
     config["paths"] = _make_path(config["paths"])
+    apply_path_defaults(config["paths"])
 
     def _copy_skip_existing(src, dst):
         if not Path(dst).exists():

--- a/tests/dummyprod/simflow-config.yaml
+++ b/tests/dummyprod/simflow-config.yaml
@@ -22,8 +22,6 @@ paths:
 
   pars: $_/generated/pars
   macros: $_/generated/macros
-  geom: $_/generated/pars/geom
-  dtmaps: $_/generated/pars/hpge/dtmaps
   tier_vtx: ./generated/tier/vtx
   tier_stp: ./generated/tier/stp
   tier_opt: ./generated/tier/opt

--- a/tests/dummyprod/simflow-config.yaml
+++ b/tests/dummyprod/simflow-config.yaml
@@ -20,10 +20,10 @@ paths:
     lar: $_/inputs/simprod/l200a-optical-map-lar.lh5
     pen: $_/inputs/simprod/l200a-optical-map-pen.lh5
 
-  genmeta: $_/generated/metadata
+  pars: $_/generated/pars
   macros: $_/generated/macros
-  geom: $_/generated/geom
-  dtmaps: $_/generated/dtmaps
+  geom: $_/generated/pars/geom
+  dtmaps: $_/generated/pars/hpge/dtmaps
   tier_vtx: ./generated/tier/vtx
   tier_stp: ./generated/tier/stp
   tier_opt: ./generated/tier/opt

--- a/tests/dummyprod/simflow-config.yaml
+++ b/tests/dummyprod/simflow-config.yaml
@@ -22,13 +22,14 @@ paths:
 
   pars: $_/generated/pars
   macros: $_/generated/macros
-  tier_vtx: ./generated/tier/vtx
-  tier_stp: ./generated/tier/stp
-  tier_opt: ./generated/tier/opt
-  tier_hit: ./generated/tier/hit
-  tier_evt: $_/generated/tier/evt
-  tier_cvt: $_/generated/tier/cvt
-  tier_pdf: $_/generated/tier/pdf
+  tier:
+    vtx: ./generated/tier/vtx
+    stp: ./generated/tier/stp
+    opt: ./generated/tier/opt
+    hit: ./generated/tier/hit
+    evt: $_/generated/tier/evt
+    cvt: $_/generated/tier/cvt
+    pdf: $_/generated/tier/pdf
   pdf_releases: $_/generated/releases
   plots: $_/generated/plots
 

--- a/tests/dummyprod/simflow-config.yaml
+++ b/tests/dummyprod/simflow-config.yaml
@@ -31,7 +31,6 @@ paths:
     cvt: $_/generated/tier/cvt
     pdf: $_/generated/tier/pdf
   pdf_releases: $_/generated/releases
-  plots: $_/generated/plots
 
 nersc:
   dvs_ro: false

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -207,19 +207,17 @@ def test_dtmap_filenames(config):
     assert "singles" in str(result)
     assert result.parent.name == "plots"
 
-    # benchmark_dtmap_filename uses bare expand() and returns str
     result = p.benchmark_dtmap_filename(config, hpge_detector=DET, hpge_voltage=VOLTAGE)
-    assert isinstance(result, str)
-    assert DET in result
-    assert result.endswith(".tsv")
+    assert isinstance(result, Path)
+    assert DET in str(result)
+    assert result.suffix == ".tsv"
 
 
 def test_currmod_filenames(config):
-    # input_currmod_evt_idx_file uses bare expand() and returns str
     result = p.input_currmod_evt_idx_file(config, runid=RUNID, hpge_detector=DET)
-    assert isinstance(result, str)
-    assert RUNID in result
-    assert DET in result
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
 
     result = p.output_currmod_filename(config, runid=RUNID, hpge_detector=DET)
     assert isinstance(result, Path)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -8,7 +8,7 @@ from legendsimflow import patterns as p
 def test_all(config):
     assert isinstance(p.simjob_base_segment(config), str)
     assert isinstance(p.log_filename(config), Path)
-    assert isinstance(p.plots_dirname(config), Path)
+    assert isinstance(p.plots_dirname(config, "stp"), Path)
     assert isinstance(p.benchmark_filename(config), Path)
     assert isinstance(p.geom_gdml_filename(config), Path)
     assert isinstance(p.input_simjob_filename(config, tier="stp"), Path)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,40 +2,318 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from legendsimflow import patterns as p
 
+SIMID = "birds_nest_K40"
+JOBID = "0000"
+RUNID = "l200-p02-r000-phy"
+DET = "V99000A"
+VOLTAGE = 4200
 
-def test_all(config):
-    assert isinstance(p.simjob_base_segment(config), str)
-    assert isinstance(p.log_filename(config), Path)
-    assert isinstance(p.plots_dirname(config, "stp"), Path)
-    assert isinstance(p.benchmark_filename(config), Path)
-    assert isinstance(p.geom_gdml_filename(config), Path)
-    assert isinstance(p.input_simjob_filename(config, tier="stp"), Path)
-    assert isinstance(p.output_simjob_filename(config, tier="stp"), Path)
-    assert isinstance(p.output_simjob_regex(config, tier="stp"), str)
-    assert isinstance(p.input_simid_filenames(config, 2, tier="stp"), list)
-    assert all(
-        isinstance(p, Path) for p in p.input_simid_filenames(config, 2, tier="stp")
-    )
-    assert isinstance(p.output_simid_filenames(config, 2, tier="stp"), list)
 
-    # test dtmap filename with hpge_voltage
-    dtmap = p.output_dtmap_filename(config, hpge_detector="V99000A", hpge_voltage=4200)
-    assert isinstance(dtmap, Path)
-    assert "V99000A-4200V" in str(dtmap)
+def test_simjob_base_segment(config):
+    result = p.simjob_base_segment(config)
+    assert isinstance(result, str)
+    assert config.experiment in result
 
-    assert isinstance(p.output_currmod_filename(config, hpge_detector="boh"), Path)
+    result = p.simjob_base_segment(config, simid=SIMID, jobid=JOBID)
+    assert SIMID in result
+    assert JOBID in result
 
-    assert isinstance(p.vtx_filename_for_stp(config, "lar_hpge_shell_K42"), Path)
-    assert p.vtx_filename_for_stp(config, "hpge_bulk_high_thr_Rn222_to_Po214") == []
-    assert p.vtx_filename_for_stp(config, "phbr_surface_Ra228_to_Ac228") == []
 
-    assert isinstance(p.tier_cvt_base_segment(config), str)
-    assert isinstance(p.output_tier_cvt_filename(config), Path)
-    assert isinstance(p.log_tier_cvt_filename(config), Path)
+def test_log_dirname(config):
+    result = p.log_dirname(config)
+    assert isinstance(result, Path)
+    assert config._proctime in str(result)
+
+
+def test_log_filename(config):
+    result = p.log_filename(config)
+    assert isinstance(result, Path)
+
+    result = p.log_filename(config, tier="stp", simid=SIMID, jobid=JOBID)
+    assert isinstance(result, Path)
+    assert "stp" in str(result)
+    assert SIMID in str(result)
+    assert JOBID in str(result)
+    assert result.suffix == ".log"
+
+
+def test_benchmark_filename(config):
+    result = p.benchmark_filename(config)
+    assert isinstance(result, Path)
+
+    result = p.benchmark_filename(config, tier="hit", simid=SIMID, jobid=JOBID)
+    assert isinstance(result, Path)
+    assert "hit" in str(result)
+    assert result.suffix == ".tsv"
+
+
+def test_plots_dirname(config):
+    for tier in ("stp", "hit", "opt", "cvt"):
+        result = p.plots_dirname(config, tier)
+        assert isinstance(result, Path)
+        assert result.name == "plots"
+        assert str(config.paths.tier[tier]) in str(result)
+
+
+def test_geom_filenames(config):
+    result = p.geom_config_filename(config)
+    assert isinstance(result, Path)
+    assert config.experiment in str(result)
+    assert result.suffix == ".yaml"
+
+    result = p.geom_gdml_filename(config)
+    assert isinstance(result, Path)
+    assert config.experiment in str(result)
+    assert result.suffix == ".gdml"
+
+    result = p.geom_log_filename(config)
+    assert isinstance(result, Path)
+    assert config.experiment in str(result)
+    assert result.suffix == ".log"
+
+    result = p.geom_gdml_filename(config, simid=SIMID, tier="stp")
+    assert SIMID in str(result)
+    assert "stp" in str(result)
+
+
+def test_input_simjob_filename(config):
+    with pytest.raises(RuntimeError, match="tier"):
+        p.input_simjob_filename(config)
+
+    # stp inputs are macro files; vtx/hit/opt inputs are lh5
+    result = p.input_simjob_filename(config, tier="stp")
+    assert isinstance(result, Path)
+    assert result.suffix == ".mac"
+
+    result = p.input_simjob_filename(config, tier="vtx")
+    assert result.suffix == ".lh5"
+
+    # jobid is not part of the input filename (one macro per simid)
+    result = p.input_simjob_filename(config, tier="stp", simid=SIMID)
+    assert isinstance(result, Path)
+    assert SIMID in str(result)
+
+
+def test_output_simjob_filename(config):
+    with pytest.raises(RuntimeError, match="tier"):
+        p.output_simjob_filename(config)
+
+    for tier in ("vtx", "stp", "hit", "opt"):
+        result = p.output_simjob_filename(config, tier=tier)
+        assert isinstance(result, Path)
+        assert result.suffix == ".lh5"
+        assert tier in str(result)
+
+    result = p.output_simjob_filename(config, tier="stp", simid=SIMID, jobid=JOBID)
+    assert SIMID in str(result)
+    assert JOBID in str(result)
 
     files = p.output_simjob_filename(config, tier="stp", jobid=["0000", "0001"])
     assert isinstance(files, list)
+    assert len(files) == 2
     assert "0000" in files[0].name
     assert "0001" in files[1].name
+
+
+def test_output_simjob_regex(config):
+    with pytest.raises(RuntimeError, match="tier"):
+        p.output_simjob_regex(config)
+
+    result = p.output_simjob_regex(config, tier="stp")
+    assert isinstance(result, str)
+    assert config.experiment in result
+    assert "stp" in result
+    assert "*" in result
+
+
+def test_input_simid_filenames(config):
+    # input filename has no {jobid}, so n_macros does not affect the count
+    result = p.input_simid_filenames(config, 3, tier="stp", simid=SIMID)
+    assert isinstance(result, list)
+    assert all(isinstance(f, Path) for f in result)
+    assert all(SIMID in str(f) for f in result)
+
+
+def test_output_simid_filenames(config):
+    result = p.output_simid_filenames(config, 3, tier="stp", simid=SIMID)
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(f, Path) for f in result)
+    assert all(SIMID in str(f) for f in result)
+
+
+def test_vtx_filename_for_stp(config):
+    result = p.vtx_filename_for_stp(config, "lar_hpge_shell_K42")
+    assert isinstance(result, Path)
+    assert "vtx" in str(result)
+
+    assert p.vtx_filename_for_stp(config, "hpge_bulk_high_thr_Rn222_to_Po214") == []
+    assert p.vtx_filename_for_stp(config, "phbr_surface_Ra228_to_Ac228") == []
+
+
+def test_plot_tier_filenames(config):
+    result = p.plot_tier_stp_vertices_filename(config)
+    assert isinstance(result, Path)
+    assert result.suffix == ".pdf"
+    assert "stp" in str(result)
+    assert result.parent.name == "plots"
+
+    result = p.plot_tier_stp_vertices_filename(config, simid=SIMID)
+    assert SIMID in result.name
+
+    result = p.plot_tier_hit_observables_filename(config)
+    assert isinstance(result, Path)
+    assert "hit" in str(result)
+    assert result.parent.name == "plots"
+
+    result = p.plot_tier_opt_observables_filename(config)
+    assert isinstance(result, Path)
+    assert "opt" in str(result)
+    assert result.parent.name == "plots"
+
+    result = p.plot_tier_cvt_observables_filename(config)
+    assert isinstance(result, Path)
+    assert "cvt" in str(result)
+    assert result.parent.name == "plots"
+
+
+def test_dtmap_filenames(config):
+    result = p.output_dtmap_filename(config, hpge_detector=DET, hpge_voltage=VOLTAGE)
+    assert isinstance(result, Path)
+    assert DET in str(result)
+    assert f"{VOLTAGE}V" in str(result)
+    assert result.suffix == ".lh5"
+    assert "singles" in str(result)
+
+    result = p.output_dtmap_merged_filename(config, runid=RUNID)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert result.suffix == ".lh5"
+
+    result = p.log_dtmap_filename(config, hpge_detector=DET, hpge_voltage=VOLTAGE)
+    assert isinstance(result, Path)
+    assert DET in str(result)
+    assert result.suffix == ".log"
+
+    result = p.plot_dtmap_filename(config, hpge_detector=DET, hpge_voltage=VOLTAGE)
+    assert isinstance(result, Path)
+    assert DET in str(result)
+    assert f"{VOLTAGE}V" in str(result)
+    assert result.suffix == ".pdf"
+    assert "singles" in str(result)
+    assert result.parent.name == "plots"
+
+    # benchmark_dtmap_filename uses bare expand() and returns str
+    result = p.benchmark_dtmap_filename(config, hpge_detector=DET, hpge_voltage=VOLTAGE)
+    assert isinstance(result, str)
+    assert DET in result
+    assert result.endswith(".tsv")
+
+
+def test_currmod_filenames(config):
+    # input_currmod_evt_idx_file uses bare expand() and returns str
+    result = p.input_currmod_evt_idx_file(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, str)
+    assert RUNID in result
+    assert DET in result
+
+    result = p.output_currmod_filename(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
+    assert result.suffix == ".yaml"
+
+    result = p.output_currmod_merged_filename(config, runid=RUNID)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert result.suffix == ".yaml"
+
+    result = p.log_currmod_filename(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
+    assert result.suffix == ".log"
+
+    result = p.plot_currmod_filename(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
+    assert result.suffix == ".pdf"
+    assert result.parent.name == "plots"
+
+
+def test_hpge_obs_model_filenames(config):
+    result = p.output_eresmod_filename(config, runid=RUNID)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert result.suffix == ".yaml"
+    assert "eresmod" in str(result)
+
+    result = p.output_aoeresmod_filename(config, runid=RUNID)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert result.suffix == ".yaml"
+    assert "aoeresmod" in str(result)
+
+    result = p.output_psdcuts_filename(config, runid=RUNID)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert result.suffix == ".yaml"
+    assert "psdcuts" in str(result)
+
+
+def test_simstat_log_filename(config):
+    result = p.log_simstat_part_filename(config, simid=SIMID)
+    assert isinstance(result, Path)
+    assert SIMID in str(result)
+    assert result.suffix == ".log"
+    assert "simstat" in str(result)
+
+
+def test_cvt_filenames(config):
+    result = p.tier_cvt_base_segment(config)
+    assert isinstance(result, str)
+    assert config.experiment in result
+
+    result = p.tier_cvt_base_segment(config, simid=SIMID)
+    assert SIMID in result
+
+    result = p.output_tier_cvt_filename(config)
+    assert isinstance(result, Path)
+    assert result.suffix == ".lh5"
+
+    result = p.output_tier_cvt_filename(config, simid=SIMID)
+    assert SIMID in str(result)
+
+    result = p.log_tier_cvt_filename(config)
+    assert isinstance(result, Path)
+    assert result.suffix == ".log"
+
+    result = p.benchmark_tier_cvt_filename(config)
+    assert isinstance(result, Path)
+    assert result.suffix == ".tsv"
+
+
+def test_pdf_filenames(config):
+    result = p.pdffile_rel_basename(simid=SIMID)
+    assert isinstance(result, str)
+    assert SIMID in result
+
+    result = p.output_pdf_filename(config, simid=SIMID)
+    assert isinstance(result, str)
+    assert SIMID in result
+    assert result.endswith(".lh5")
+
+    result = p.log_pdffile_path(config, simid=SIMID)
+    assert isinstance(result, str)
+    assert SIMID in result
+    assert result.endswith(".log")
+
+    result = p.benchmark_pdffile_path(config, simid=SIMID)
+    assert isinstance(result, str)
+    assert SIMID in result
+    assert result.endswith(".tsv")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,31 @@ def test_merge_defaults():
     assert result["key"] == {"nested": "value"}
 
 
+def test_apply_path_defaults():
+    """Test apply_path_defaults fills in geom and dtmaps from pars when absent."""
+    pars = Path("/prod/generated/pars")
+
+    # both absent: should be derived from pars
+    paths = {"pars": pars}
+    utils.apply_path_defaults(paths)
+    assert paths["geom"] == pars / "geom"
+    assert paths["dtmaps"] == pars / "hpge/dtmaps"
+
+    # both present: should be left unchanged
+    custom_geom = Path("/custom/geom")
+    custom_dtmaps = Path("/custom/dtmaps")
+    paths = {"pars": pars, "geom": custom_geom, "dtmaps": custom_dtmaps}
+    utils.apply_path_defaults(paths)
+    assert paths["geom"] == custom_geom
+    assert paths["dtmaps"] == custom_dtmaps
+
+    # only one absent
+    paths = {"pars": pars, "geom": custom_geom}
+    utils.apply_path_defaults(paths)
+    assert paths["geom"] == custom_geom
+    assert paths["dtmaps"] == pars / "hpge/dtmaps"
+
+
 def test_setup_logdir_link():
     """Test setup_logdir_link creates symlink to log directory."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -8,10 +8,7 @@ dummyprod = Path(__file__).parent / "dummyprod"
 
 
 def test_run():
-    output = smkapi.OutputSettings(
-        verbose=False,
-        dryrun=True,
-    )
+    output = smkapi.OutputSettings(verbose=False)
 
     # build workflow and DAG
     with smkapi.SnakemakeApi(output) as api:
@@ -25,6 +22,4 @@ def test_run():
             resource_settings=smkapi.ResourceSettings(cores=1),
         )
         dag = wf_api.dag()
-        dag.execute_workflow(
-            executor="dryrun",
-        )
+        dag.execute_workflow(executor="touch")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -34,7 +34,7 @@ config = SIMFLOW_CONTEXT.config
 # it at the start and cache it for later
 SIMFLOW_CONTEXT |= {
     "modelable_hpges": gen_list_of_all_hpges_valid_for_modeling(
-        config, write_to_file=config.paths.generated / "modelable_hpge_detectors.yaml"
+        config, write_to_file=config.paths.pars / "modelable_hpge_detectors.yaml"
     ),
 }
 

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -95,7 +95,7 @@ rule cache_detector_usabilities:
     params:
         runlist=config.runlist,
     output:
-        config.paths.generated / "detector_usabilities.yaml",
+        config.paths.pars / "detector_usabilities.yaml",
     run:
         import dbetto
 

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -75,7 +75,7 @@ rule _init_julia_env:
     message:
         "Initializing Julia environment"
     output:
-        config.paths.dtmaps / ".julia-env-initialized",
+        config.paths.generated / ".julia-env-initialized",
     shell:
         "julia --project=workflow/src/LegendSimflow.jl "
         "workflow/src/legendsimflow/scripts/init-julia-env.jl && "

--- a/workflow/rules/hit.smk
+++ b/workflow/rules/hit.smk
@@ -55,7 +55,7 @@ rule make_simstat_partition_file:
         runinfo=config.metadata.datasets.runinfo,
         runlist=lambda wc: aggregate.get_runlist(config, wc.simid),
     output:
-        config.paths.genmeta / "simstat" / "partitions_{simid}.yaml",
+        config.paths.pars / "simstat" / "partitions_{simid}.yaml",
     log:
         patterns.log_simstat_part_filename(config),
     script:

--- a/workflow/rules/opt.smk
+++ b/workflow/rules/opt.smk
@@ -50,7 +50,7 @@ rule build_tier_opt:
         optmap_lar=on_scratch_smk(config.paths.optical_maps.lar),
         # NOTE: technically this rule only depends on one block in the
         # partitioning file, but in practice the full file will always change
-        simstat_part_file=config.paths.genmeta / "simstat" / "partitions_{simid}.yaml",
+        simstat_part_file=config.paths.pars / "simstat" / "partitions_{simid}.yaml",
         detector_usabilities=rules.cache_detector_usabilities.output,
     params:
         optmap_per_sipm=True,

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -82,9 +82,9 @@ def benchmark_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(pat, **kwargs)
 
 
-def plots_dirname(config: SimflowConfig, **kwargs) -> Path:
-    """Formats the plots directory path for a `simid` and `tier`."""
-    return _expand(config.paths.plots / "{tier}" / "{simid}", **kwargs)
+def plots_dirname(config: SimflowConfig, tier: str) -> Path:
+    """Returns the plots directory path for a `tier`."""
+    return config.paths.tier[tier] / "plots"
 
 
 # geometry
@@ -190,25 +190,25 @@ def vtx_filename_for_stp(config: SimflowConfig, simid: str, **kwargs) -> Path | 
 
 def plot_tier_stp_vertices_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        plots_dirname(config, tier="stp") / "tier-stp-vertices.pdf", **kwargs
+        plots_dirname(config, "stp") / "{simid}-tier-stp-vertices.pdf", **kwargs
     )
 
 
 def plot_tier_hit_observables_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        plots_dirname(config, tier="hit") / "tier-hit-observables.pdf", **kwargs
+        plots_dirname(config, "hit") / "{simid}-tier-hit-observables.pdf", **kwargs
     )
 
 
 def plot_tier_opt_observables_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        plots_dirname(config, tier="opt") / "tier-opt-observables.pdf", **kwargs
+        plots_dirname(config, "opt") / "{simid}-tier-opt-observables.pdf", **kwargs
     )
 
 
 def plot_tier_cvt_observables_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        plots_dirname(config, tier="cvt") / "tier-cvt-observables.pdf", **kwargs
+        plots_dirname(config, "cvt") / "{simid}-tier-cvt-observables.pdf", **kwargs
     )
 
 
@@ -237,8 +237,8 @@ def log_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 def plot_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
     pat = (
-        config.paths.plots
-        / "hpge/dtmaps/{hpge_detector}-{hpge_voltage}V-drift-time-map.pdf"
+        config.paths.dtmaps
+        / "singles/plots/{hpge_detector}-{hpge_voltage}V-drift-time-map.pdf"
     )
     return _expand(pat, **kwargs)
 
@@ -279,7 +279,9 @@ def log_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def plot_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    pat = config.paths.plots / "hpge/currmod/{runid}-{hpge_detector}-fit-result.pdf"
+    pat = (
+        config.paths.pars / "hpge/currmod/plots/{runid}-{hpge_detector}-fit-result.pdf"
+    )
     return _expand(pat, **kwargs)
 
 

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -248,7 +248,7 @@ def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
         config.paths.benchmarks
         / "hpge/dtmaps/{hpge_detector}-{hpge_voltage}V-drift-time-map.tsv"
     )
-    return expand(pat, **kwargs, allow_missing=True)[0]
+    return _expand(pat, **kwargs)
 
 
 # hpge current model
@@ -256,7 +256,7 @@ def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 def input_currmod_evt_idx_file(config: SimflowConfig, **kwargs) -> Path:
     pat = config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-best-evt-idx.txt"
-    return expand(pat, **kwargs, allow_missing=True)[0]
+    return _expand(pat, **kwargs)
 
 
 def output_currmod_filename(config: SimflowConfig, **kwargs) -> Path:

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -137,7 +137,7 @@ def output_simjob_filename(config: SimflowConfig, **kwargs) -> Path:
         raise RuntimeError(msg)
 
     fname = simjob_base_segment(config) + f"-tier_{tier}.lh5"
-    return _expand(config.paths[f"tier_{tier}"] / fname, **kwargs)
+    return _expand(config.paths.tier[tier] / fname, **kwargs)
 
 
 def output_simjob_regex(config: SimflowConfig, **kwargs) -> str:
@@ -148,7 +148,7 @@ def output_simjob_regex(config: SimflowConfig, **kwargs) -> str:
         raise RuntimeError(msg)
 
     fname = config.experiment + "-*-tier_{tier}.lh5"
-    expr = str(Path(config["paths"][f"tier_{tier}"]) / "{simid}" / fname)
+    expr = str(config.paths.tier[tier] / "{simid}" / fname)
     return _expand(expr, **kwargs)
 
 
@@ -324,7 +324,7 @@ def tier_cvt_base_segment(config: SimflowConfig, **kwargs) -> str:
 
 def output_tier_cvt_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.tier_cvt / (tier_cvt_base_segment(config) + ".lh5"), **kwargs
+        config.paths.tier.cvt / (tier_cvt_base_segment(config) + ".lh5"), **kwargs
     )
 
 
@@ -346,22 +346,17 @@ def pdffile_rel_basename(**kwargs):
 
 
 def output_pdf_filename(config: SimflowConfig, **kwargs):
-    expr = str(Path(config["paths"]["tier_pdf"]) / (pdffile_rel_basename() + ".lh5"))
+    expr = str(config.paths.tier.pdf / (pdffile_rel_basename() + ".lh5"))
     return expand(expr, **kwargs, allow_missing=True)[0]
 
 
 def log_pdffile_path(config: SimflowConfig, **kwargs):
     pat = str(
-        Path(config["paths"]["log"])
-        / config._proctime
-        / "pdf"
-        / (pdffile_rel_basename() + ".log")
+        config.paths.log / config._proctime / "pdf" / (pdffile_rel_basename() + ".log")
     )
     return expand(pat, **kwargs, allow_missing=True)[0]
 
 
 def benchmark_pdffile_path(config: SimflowConfig, **kwargs):
-    pat = str(
-        Path(config["paths"]["benchmarks"]) / "pdf" / (pdffile_rel_basename() + ".tsv")
-    )
+    pat = str(config.paths.benchmarks / "pdf" / (pdffile_rel_basename() + ".tsv"))
     return expand(pat, **kwargs, allow_missing=True)[0]

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -255,20 +255,20 @@ def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def input_currmod_evt_idx_file(config: SimflowConfig, **kwargs) -> Path:
-    pat = config.paths.genmeta / "hpge/currmod/{runid}-{hpge_detector}-best-evt-idx.txt"
+    pat = config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-best-evt-idx.txt"
     return expand(pat, **kwargs, allow_missing=True)[0]
 
 
 def output_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.genmeta / "hpge/currmod/{runid}-{hpge_detector}-model.yaml",
+        config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-model.yaml",
         **kwargs,
     )
 
 
 def output_currmod_merged_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.genmeta / "hpge/currmod/{runid}-model.yaml",
+        config.paths.pars / "hpge/currmod/{runid}-model.yaml",
         **kwargs,
     )
 
@@ -288,21 +288,21 @@ def plot_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
 
 def output_eresmod_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.genmeta / "hpge/eresmod/{runid}-model.yaml",
+        config.paths.pars / "hpge/eresmod/{runid}-model.yaml",
         **kwargs,
     )
 
 
 def output_aoeresmod_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.genmeta / "hpge/aoeresmod/{runid}-model.yaml",
+        config.paths.pars / "hpge/aoeresmod/{runid}-model.yaml",
         **kwargs,
     )
 
 
 def output_psdcuts_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(
-        config.paths.genmeta / "hpge/psdcuts/{runid}-psd-cuts.yaml",
+        config.paths.pars / "hpge/psdcuts/{runid}-psd-cuts.yaml",
         **kwargs,
     )
 

--- a/workflow/src/legendsimflow/utils.py
+++ b/workflow/src/legendsimflow/utils.py
@@ -78,6 +78,27 @@ def _make_path(d):
     return d
 
 
+def apply_path_defaults(paths: dict) -> None:
+    """Set default values for optional path keys derived from ``paths.pars``.
+
+    The following keys are optional in the Simflow configuration and, if
+    absent, are derived from ``paths.pars``:
+
+    - ``geom``: defaults to ``{paths.pars}/geom``
+    - ``dtmaps``: defaults to ``{paths.pars}/hpge/dtmaps``
+
+    Parameters
+    ----------
+    paths
+        The ``paths`` section of the Simflow configuration, with all values
+        already converted to :class:`pathlib.Path` objects.
+    """
+    if "geom" not in paths:
+        paths["geom"] = paths["pars"] / "geom"
+    if "dtmaps" not in paths:
+        paths["dtmaps"] = paths["pars"] / "hpge/dtmaps"
+
+
 def init_simflow_context(raw_config: dict, workflow=None) -> AttrsDict:
     """Pre-process and sanitize the Simflow configuration.
 
@@ -125,6 +146,9 @@ def init_simflow_context(raw_config: dict, workflow=None) -> AttrsDict:
 
     # convert all strings in the "paths" block to pathlib.Path
     config["paths"] = _make_path(config.paths)
+
+    # fill in optional paths derived from paths.pars
+    apply_path_defaults(config["paths"])
 
     if "l200data" in config.paths:
         config["paths"]["l200data"] = nersc.dvs_ro(config, config.paths.l200data)


### PR DESCRIPTION
## Summary

Refactor the Simflow output directory structure for a cleaner logical separation between *data tiers* and *parameters*, and improve config ergonomics.

### `generated/pars/` — consolidate all parameter files

All generated parameter files are now collected under a single `generated/pars/` tree instead of being scattered across `generated/metadata/`, `generated/geom/`, and `generated/hpge/dtmaps/`:

```
generated/pars/
├── hpge/
│   ├── dtmaps/singles/   drift time maps (per detector)
│   ├── dtmaps/           merged drift time maps (per run)
│   ├── eresmod/          energy resolution models
│   ├── aoeresmod/        A/E resolution models
│   ├── psdcuts/          PSD cut values
│   └── currmod/          current pulse models + plots/
├── geom/                 simulation geometry files
├── simstat/              event statistics partitions
├── detector_usabilities.yaml
└── modelable_hpge_detectors.yaml
```

The `paths.genmeta` config key is replaced by `paths.pars`. The `paths.geom` and `paths.dtmaps` keys are now **optional**: if omitted they default to `{pars}/geom` and `{pars}/hpge/dtmaps` respectively.

### `paths.tier` — nested dict for tier output paths

The flat `paths.tier_stp`, `paths.tier_hit`, … keys are replaced by a single nested mapping:

```yaml
paths:
  tier:
    stp: generated/tier/stp
    hit: generated/tier/hit
    ...
```

### Drop `paths.plots` — co-locate plots with data

The global `paths.plots` config key is removed. Validation plots are now written into a `plots/` subdirectory next to the data they visualise:

| Plot | Path |
|------|------|
| Tier observables / vertices | `tier.{t}/plots/{simid}-tier-{t}-*.pdf` |
| Drift time maps | `{dtmaps}/singles/plots/{det}-{V}V-*.pdf` |
| Current pulse model fits | `{pars}/hpge/currmod/plots/{runid}-{det}-*.pdf` |

### Other fixes

- Julia env marker file (`.julia-env-initialized`) moved from `paths.dtmaps` to `paths.generated`
- Remaining dict-style `config["paths"][...]` accesses in `patterns.py` replaced with AttrsDict attribute-style access
- Workflow test switched from `--dry-run` to `--touch` execution

## Tests

- `apply_path_defaults()` unit test covering absent / present / partial optional path keys
- Comprehensive `test_patterns.py` rewrite: 19 focused test functions covering every public function in `patterns.py`