### PR TITLE
Generate remage macro in dedicated rule

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -30,7 +30,7 @@ def test_make_macro(config):
     assert (
         fmac
         == Path(config.paths.macros)
-        / f"stp/{config.experiment}-birds_nest_K40-tier_stp.mac"
+        / f"{config.experiment}-birds_nest_K40-tier_stp.mac"
     )
     assert fmac.is_file()
 

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -150,13 +150,10 @@ rule build_tier_stp:
         geom=patterns.geom_gdml_filename(config, tier="stp"),
         macro=rules.gen_remage_macro.output,
     params:
+        # cmd already embeds N_EVENTS=<value> literally (accounting for the
+        # benchmark override), so Snakemake detects reruns from both
+        # primaries_per_job and benchmark.n_primaries changes via cmd alone.
         cmd=smk_remage_run,
-        # the only simconfig field used in the remage CLI is primaries_per_job
-        # (→ N_EVENTS substitution); all other fields affect the macro content
-        # and are already tracked via input.macro → gen_remage_macro.
-        primaries_per_job=lambda wc: mutils.get_simconfig(
-            config, "stp", simid=wc.simid, field="primaries_per_job"
-        ),
     output:
         patterns.output_simjob_filename(config, tier="stp"),
     log:

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -98,6 +98,12 @@ rule gen_remage_macro:
     input:
         geom=patterns.geom_gdml_filename(config, tier="stp"),
     params:
+        # make this rule dependent on the actual simconfig block it is very
+        # important here to ignore the simconfig fields that, if updated,
+        # should not trigger re-creation of existing files. we ignore then
+        # `number_of_jobs` and `primaries_per_job`. Bonus: we ignore
+        # `geom_config_extra` because that dependency is already tracked by
+        # `input.geom`.
         _simconfig_hash=lambda wc: mutils.smk_hash_simconfig(
             config,
             wc,
@@ -160,7 +166,6 @@ rule build_tier_stp:
             ignore=["geom_config_extra", "number_of_jobs"],
         ),
     output:
-        # TODO: protected()
         patterns.output_simjob_filename(config, tier="stp"),
     log:
         patterns.log_filename(config, tier="stp"),

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -120,7 +120,7 @@ def smk_remage_run(wildcards, input, output, threads):
         geom=input.geom,
         output=output,
         procs=threads,
-        macro_free=True,
+        macro_free=False,
     )
 
 
@@ -142,6 +142,7 @@ rule build_tier_stp:
     input:
         verfile=lambda wc: patterns.vtx_filename_for_stp(config, wc.simid),
         geom=patterns.geom_gdml_filename(config, tier="stp"),
+        macro=rules.gen_remage_macro.output,
     params:
         cmd=smk_remage_run,
         # make this rule dependent on the actual simconfig block it is very

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -151,19 +151,11 @@ rule build_tier_stp:
         macro=rules.gen_remage_macro.output,
     params:
         cmd=smk_remage_run,
-        # make this rule dependent on the actual simconfig block it is very
-        # important here to ignore the simconfig fields that, if updated,
-        # should not trigger re-creation of existing files. we ignore then
-        # `number_of_jobs` and in the future we could also ignore
-        # `primaries_per_job`, such that Snakemake will keep the existing stp
-        # files with a different number of primaries on disk. Bonus: we ignore
-        # `geom_config_extra` because that dependency is already tracked by
-        # `input.geom`.
-        _simconfig_hash=lambda wc: mutils.smk_hash_simconfig(
-            config,
-            wc,
-            tier="stp",
-            ignore=["geom_config_extra", "number_of_jobs"],
+        # the only simconfig field used in the remage CLI is primaries_per_job
+        # (→ N_EVENTS substitution); all other fields affect the macro content
+        # and are already tracked via input.macro → gen_remage_macro.
+        primaries_per_job=lambda wc: mutils.get_simconfig(
+            config, "stp", simid=wc.simid, field="primaries_per_job"
         ),
     output:
         patterns.output_simjob_filename(config, tier="stp"),

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -84,6 +84,32 @@ rule build_geom_gdml:
         "legend-pygeom-l200 --verbose --config {input} -- {output} &> {log}"
 
 
+rule gen_remage_macro:
+    """Write the remage macro file for a `stp` tier simulation to disk.
+
+    Renders the macro template for the given `simid` using
+    {func}`legendsimflow.commands.make_remage_macro` and writes it to the
+    canonical macro path under ``generated/macros/``.
+
+    Uses wildcard `simid`.
+    """
+    message:
+        "Generating remage macro for stp.{wildcards.simid}"
+    input:
+        geom=patterns.geom_gdml_filename(config, tier="stp"),
+    params:
+        _simconfig_hash=lambda wc: mutils.smk_hash_simconfig(
+            config,
+            wc,
+            tier="stp",
+            ignore=["geom_config_extra", "number_of_jobs", "primaries_per_job"],
+        ),
+    output:
+        patterns.input_simjob_filename(config, tier="stp"),
+    run:
+        commands.make_remage_macro(config, wildcards.simid, tier="stp", geom=input.geom)
+
+
 def smk_remage_run(wildcards, input, output, threads):
     """Generate the remage command line for use in Snakemake rules."""
     return commands.remage_run(

--- a/workflow/src/legendsimflow/commands.py
+++ b/workflow/src/legendsimflow/commands.py
@@ -41,10 +41,14 @@ def remage_run(
 ) -> str:
     """Build a remage CLI invocation string for a given simulation.
 
-    This constructs a shell-escaped command line for remage by first rendering
-    the macro via :func:`make_remage_macro` using the simulation configuration
-    (from ``simconfig.yaml``), and then assembling the remage CLI with the
-    appropriate arguments and macro handling.
+    This constructs a shell-escaped command line for remage. When
+    ``macro_free`` is True, the macro is rendered inline via
+    :func:`make_remage_macro` and its content is passed directly on the CLI.
+    When ``macro_free`` is False (default), the pre-existing macro file path
+    is referenced on the CLI and substitutions are passed via
+    ``--macro-substitutions``; in that case the caller is responsible for
+    generating the macro file beforehand (e.g. via the ``gen_remage_macro``
+    Snakemake rule).
 
     Notes
     -----
@@ -64,7 +68,7 @@ def remage_run(
     - If ``config.runcmd.remage`` is set, it is used to determine the remage
       executable (split with :func:`shlex.split`), otherwise ``remage`` is used.
     - If ``config.nersc.dvs_ro`` is set, remage is set to read all inputs from
-      the read-only filesystem mount ``/dvs/ro`` at NERSC.
+      the read-only filesystem mount ``/dvs_ro`` at NERSC.
     - If ``config.nersc.scratch`` is set, the command will write the output
       file on the scratch disk and move it to the final expected destination at
       the end.

--- a/workflow/src/legendsimflow/commands.py
+++ b/workflow/src/legendsimflow/commands.py
@@ -109,7 +109,8 @@ def remage_run(
     sim_cfg = get_simconfig(config, tier, simid=simid)
 
     # get macro
-    macro_text, _ = make_remage_macro(config, simid, tier=tier, geom=geom)
+    if macro_free:
+        macro_text, _ = make_remage_macro(config, simid, tier=tier, geom=geom)
 
     # need some modifications if this is a benchmark run
     try:

--- a/workflow/src/legendsimflow/metadata.py
+++ b/workflow/src/legendsimflow/metadata.py
@@ -106,7 +106,7 @@ def smk_hash_simconfig(
     tier = kwargs["tier"] if "tier" in kwargs else wildcards.tier  # noqa: SIM401
     simid = kwargs["simid"] if "simid" in kwargs else wildcards.simid  # noqa: SIM401
 
-    scfg = get_simconfig(config, tier, simid)
+    scfg = get_simconfig(config, tier, simid).copy()
 
     if field is not None:
         scfg = scfg.get(field)

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -125,7 +125,7 @@ def input_simjob_filename(config: SimflowConfig, **kwargs) -> Path:
 
     ext = ".mac" if tier == "stp" else ".lh5"
     fname = config.experiment + "-{simid}" + f"-tier_{tier}" + ext
-    return _expand(config.paths.macros / f"{tier}" / fname, **kwargs)
+    return _expand(config.paths.macros / fname, **kwargs)
 
 
 def output_simjob_filename(config: SimflowConfig, **kwargs) -> Path:


### PR DESCRIPTION
Supersedes #140 

## Summary

- Add a dedicated `gen_remage_macro` rule that writes the remage `.mac` file as a declared Snakemake output, replacing the previous approach of generating it as a side effect during DAG evaluation
- Switch `build_tier_stp` to `macro_free=False` and add the macro file as a tracked `input:`, completing the explicit dependency chain `build_geom_gdml → gen_remage_macro → build_tier_stp`
- Simplify `build_tier_stp` params: replace the broad simconfig hash with a single `primaries_per_job` field — the only simconfig value actually used in the remage CLI; all other fields are now tracked via `input.macro`
- Fix a latent mutation bug in `smk_hash_simconfig`: copy the simconfig dict before popping ignored fields to avoid modifying the shared metadata object
- Drop the `stp/` subdirectory from the macro path (`generated/macros/{exp}-{simid}-tier_stp.mac`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)