### PR TITLE
add outer cyclinder option to `get_lar_minishroud_confine_commands()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "pylegendmeta >=1.3.5",
     "reboost >=0.10.3,<0.11",
     "revertex >=0.1.2",
-    "snakemake >=9.17",
+    "snakemake >=9.18",
     "snakemake-storage-plugin-fs",
     "snakemake-executor-plugin-slurm",
     "snakemake-logger-plugin-rich",
@@ -207,7 +207,7 @@ pylegendmeta = ">=1.3.5,<1.4"
 psutil = "*"
 
 # execution
-snakemake = ">=9.17,<10"
+snakemake = ">=9.18,<10"
 snakemake-storage-plugin-fs = "*"
 snakemake-executor-plugin-slurm = "*"
 # snakemake-logger-plugin-rich = "..."  # not on conda-forge

--- a/tests/dummyprod/inputs/simprod/config/tier/stp/l200p02/simconfig.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/stp/l200p02/simconfig.yaml
@@ -74,15 +74,29 @@ exotic_physics_hpge:
   number_of_jobs: 4
 
 lar_inside:
-  template: $_/templates/default.mac
+  template: $_/template.mac
   generator: ~defines:K42
-  confinement: "~function:legendsimflow.confine.get_lar_minishroud_confine_commands(<...>,'minishroud_tube*',True,lar_name= 'liquid_argon')"
+  confinement: >-
+    ~function:legendsimflow.confine.get_lar_minishroud_confine_commands(
+      <...>,
+      'minishroud_tube*',
+      True,
+      lar_name='liquid_argon'
+    )
   primaries_per_job: 10_000
   number_of_jobs: 4
 
 lar_outside:
-  template: $_/templates/default.mac
+  template: $_/template.mac
   generator: ~defines:K42
-  confinement: "~function:legendsimflow.confine.get_lar_minishroud_confine_commands(<...>,'minishroud_tube*',False,lar_name= 'liquid_argon')"
+  confinement: >-
+    ~function:legendsimflow.confine.get_lar_minishroud_confine_commands(
+      <...>,
+      'minishroud_tube*',
+      False,
+      lar_name='liquid_argon',
+      outer_radius_in_mm=1000,
+      outer_height_in_mm=2000
+    )
   primaries_per_job: 10_000
   number_of_jobs: 4

--- a/tests/test_confine.py
+++ b/tests/test_confine.py
@@ -60,3 +60,38 @@ def test_get_lar_minishroud_confine_commands(test_generate_gdml):
         test_generate_gdml,
     )
     assert lines_eval_args == lines
+
+    # outer cylinder: valid outside confinement
+    lines_outer = confine.get_lar_minishroud_confine_commands(
+        test_generate_gdml,
+        inside=False,
+        outer_radius_in_mm=1000,
+        outer_height_in_mm=2000,
+    )
+    assert "/RMG/Generator/Confinement/Geometrical/AddSolid Cylinder" in lines_outer
+    assert (
+        "/RMG/Generator/Confinement/Geometrical/Cylinder/OuterRadius 1000 mm"
+        in lines_outer
+    )
+    assert (
+        "/RMG/Generator/Confinement/Geometrical/Cylinder/Height 2000 mm" in lines_outer
+    )
+
+    # outer cylinder: raises when inside=True
+    with pytest.raises(ValueError):
+        confine.get_lar_minishroud_confine_commands(
+            test_generate_gdml,
+            inside=True,
+            outer_radius_in_mm=1000,
+            outer_height_in_mm=2000,
+        )
+
+    # outer cylinder: raises when only one parameter is given
+    with pytest.raises(ValueError):
+        confine.get_lar_minishroud_confine_commands(
+            test_generate_gdml, inside=False, outer_radius_in_mm=1000
+        )
+    with pytest.raises(ValueError):
+        confine.get_lar_minishroud_confine_commands(
+            test_generate_gdml, inside=False, outer_height_in_mm=2000
+        )

--- a/workflow/src/legendsimflow/confine.py
+++ b/workflow/src/legendsimflow/confine.py
@@ -15,11 +15,14 @@
 from __future__ import annotations
 
 import fnmatch
+from collections.abc import Iterable, Sequence
 
 import pyg4ometry
 
 
-def _get_matching_volumes(volume_list: list, patterns: str | list) -> list[str]:
+def _get_matching_volumes(
+    volume_list: Iterable[str], patterns: str | Sequence[str]
+) -> list[str]:
     """Return volumes from `volume_list` whose names match `patterns`.
 
     Wildcard patterns are supported via :func:`fnmatch.fnmatch`.
@@ -49,11 +52,13 @@ def _get_matching_volumes(volume_list: list, patterns: str | list) -> list[str]:
 
 def get_lar_minishroud_confine_commands(
     reg: pyg4ometry.geant4.Registry,
-    pattern: str = "minishroud_tube*",
+    pattern: str | Sequence[str] = "minishroud_tube*",
     inside: bool = True,
     lar_name: str = "liquid_argon",
+    outer_radius_in_mm: float | None = None,
+    outer_height_in_mm: float | None = None,
 ) -> list[str]:
-    """Extract the commands for the LAr confinement inside/ outside the NMS from the GDML.
+    """Extract the commands for the LAr confinement inside/outside the NMS from the GDML.
 
     Parameters
     ----------
@@ -66,6 +71,12 @@ def get_lar_minishroud_confine_commands(
         exclude the minishroud volumes from the generation region.
     lar_name
         The name of the physical volume of the LAr.
+    outer_radius_in_mm
+        If provided, gives an outer radius for the confinement. Only supported
+        for outside confinement (inside=False).
+    outer_height_in_mm
+        If provided, gives an outer height for the confinement. Only supported
+        for outside confinement (inside=False).
 
     Returns
     -------
@@ -88,6 +99,23 @@ def get_lar_minishroud_confine_commands(
         f"/RMG/Generator/Confinement/SamplingMode {mode}",
     ]
     lines += [f"/RMG/Generator/Confinement/Physical/AddVolume {lar_name}"]
+
+    if (outer_radius_in_mm is None) != (outer_height_in_mm is None):
+        msg = "outer_radius_in_mm and outer_height_in_mm must be provided together"
+        raise ValueError(msg)
+
+    if outer_radius_in_mm is not None and outer_height_in_mm is not None:
+        if inside:
+            msg = (
+                "outer_radius and outer_height parameters are only supported for "
+                f"outside confinement (inside=False), but inside={inside} was given."
+            )
+            raise ValueError(msg)
+        lines += [
+            "/RMG/Generator/Confinement/Geometrical/AddSolid Cylinder",
+            f"/RMG/Generator/Confinement/Geometrical/Cylinder/OuterRadius {outer_radius_in_mm} mm",
+            f"/RMG/Generator/Confinement/Geometrical/Cylinder/Height {outer_height_in_mm} mm",
+        ]
 
     for s in string_list:
         vol = reg.physicalVolumeDict[s]
@@ -113,10 +141,10 @@ def get_lar_minishroud_confine_commands(
         dz = outer_ms.pDz
 
         # type conversions from pyg4ometry types
-        if not isinstance(r_max, (float, int)):
+        if not isinstance(r_max, float | int):
             r_max = r_max.eval()
 
-        if not isinstance(dz, (float, int)):
+        if not isinstance(dz, float | int):
             dz = dz.eval()
 
         command = "AddSolid" if inside else "AddExcludedSolid"

--- a/workflow/src/legendsimflow/metadata.py
+++ b/workflow/src/legendsimflow/metadata.py
@@ -24,7 +24,7 @@ from dbetto import AttrsDict
 from legendmeta import LegendMetadata
 from legendmeta.police import validate_dict_schema
 from lgdo import lh5
-from snakemake.io.container import Wildcards
+from snakemake.iocontainers import Wildcards
 
 from . import SimflowConfig, utils
 from .exceptions import SimflowConfigError

--- a/workflow/src/legendsimflow/nersc.py
+++ b/workflow/src/legendsimflow/nersc.py
@@ -19,7 +19,7 @@ import shutil
 from collections.abc import Callable, Iterable
 from pathlib import Path
 
-from snakemake.io.container import InputFiles
+from snakemake.iocontainers import InputFiles
 from snakemake.script import Snakemake
 
 from . import SimflowConfig


### PR DESCRIPTION
I was not confident in this at all, so I added an additional workflow run test where the stp tier benchmark run is performed. It takes time ~10 mins but I think its worth it.

Already found some bugs