### PR TITLE
fix: SSD opv threshold and plots tarball path corrections

### DIFF
--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -296,6 +296,17 @@ def test_cvt_filenames(config):
     assert result.suffix == ".tsv"
 
 
+def test_plots_tarball_filename(config):
+    result = p.plots_tarball_filename(config)
+    assert isinstance(result, Path)
+    assert result.suffix == ".xz"
+    assert result.stem.endswith(".tar")
+    assert "plots" in result.name
+    # tarball must live inside generated/, not in the repo root
+    assert str(config.paths.generated) in str(result)
+    assert result.parent.name == "tarballs"
+
+
 def test_pdf_filenames(config):
     result = p.pdffile_rel_basename(simid=SIMID)
     assert isinstance(result, str)

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -318,7 +318,7 @@ checks depletion voltage, and calculates weighting potential.
 - `opv_val`: Operational voltage in V (Float32)
 - `T`: Floating-point precision type (typically Float32)
 - `refinement_limits`: Vector of refinement thresholds for SSD
--  `threshold`: Maximum allowed difference between simulated and measured depletion voltage (default: 100 V)
+-  `threshold`: Maximum allowed difference between simulated and measured depletion voltage (default: 200 V)
 # Returns
 - `sim`: Fully configured SolidStateDetectors Simulation object
 """

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -324,7 +324,7 @@ checks depletion voltage, and calculates weighting potential.
 """
 function setup_hpge_simulation(meta_path::String,
     meta::PropDict, xtal::PropDict,
-    opv_val::Real, T::Any, refinement_limits::AbstractVector; threshold::Real = 100)::Simulation
+    opv_val::Real, T::Any, refinement_limits::AbstractVector; threshold::Real = 200)::Simulation
 
     sim = Simulation{T}(LegendData, meta, xtal)
 

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -98,7 +98,7 @@ def plots_tarball_filename(config: SimflowConfig) -> Path:
     name of the directory where the Simflow lives is used as a proxy.
     """
     cycle_dir = config.paths.generated.parent
-    return cycle_dir / "tarballs" / (cycle_dir.name + "-plots.tar.xz")
+    return config.paths.generated / "tarballs" / (cycle_dir.name + "-plots.tar.xz")
 
 
 # geometry


### PR DESCRIPTION
## Summary

- Increase depletion voltage check threshold in `setup_hpge_simulation` from 100 V to 200 V
- Fix plots tarball path: was stored in the repo root directory (`<cycle_dir>/tarballs/`), now correctly stored under `generated/tarballs/`

## Test plan

- [x] All existing Python tests pass (`test_archive.py`, `test_patterns.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)