### PR TITLE
feat(pixi): add prod/dryrun/touch/prodnodes/prodsubmit tasks and test env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,10 +92,12 @@ jobs:
         with:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0
+        with:
+          environments: test
       - name: Run Julia tests with coverage
         run: |
-          pixi run julia workflow/src/legendsimflow/scripts/init-julia-env.jl
-          pixi run julia --code-coverage=user --project=workflow/src/LegendSimflow.jl -e 'using Pkg; Pkg.test(coverage=true)'
+          pixi run -e test julia workflow/src/legendsimflow/scripts/init-julia-env.jl
+          pixi run -e test julia --code-coverage=user --project=workflow/src/LegendSimflow.jl -e 'using Pkg; Pkg.test(coverage=true)'
       - name: Process Julia coverage
         uses: julia-actions/julia-processcoverage@v1
         with:

--- a/docs/source/manual/prod.md
+++ b/docs/source/manual/prod.md
@@ -6,14 +6,32 @@ Run a production by using one of the provided site-specific profiles
 (recommended):
 
 ```console
+> pixi run prod --profile <profile-name>
+```
+
+This is equivalent to calling Snakemake directly:
+
+```console
 > snakemake --workflow-profile workflow/profiles/<profile-name>
 ```
 
-If no system-specific profiles are provided, the `--workflow-profile` option can
-be omitted. Snakemake will use the `default` profile.
+If no system-specific profile is needed, omit `--profile` (defaults to
+`default`):
 
 ```console
-> snakemake
+> pixi run prod
+```
+
+To preview what Snakemake would do without executing anything, use `dryrun`:
+
+```console
+> pixi run dryrun
+```
+
+To mark all output files as up-to-date without rerunning jobs, use `touch`:
+
+```console
+> pixi run touch
 ```
 
 The `--config` command line option is very useful to override configuration
@@ -157,7 +175,7 @@ value of 10 000 is a reasonable starting point.
 Run the production as usual. Snakemake will spawn exactly one job per `simid`:
 
 ```console
-> snakemake --workflow-profile workflow/profiles/<profile-name>
+> pixi run prod --profile <profile-name>
 ```
 
 ### Inspecting results

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -112,8 +112,13 @@ The first step is obtaining the software, which is fully specified by the
 [pixi](https://pixi.sh), which can be easily installed following instructions on
 the official documentation.
 
-To load the software, just execute `pixi shell`. Alternatively, you may run
-Snakemake via `pixi run snakemake ...`.
+To load the software, just execute `pixi shell`. Alternatively, use the provided
+pixi tasks to run the workflow without entering a shell:
+
+- `pixi run prod [--profile <name>]` — run a full production (recommended)
+- `pixi run dryrun` — preview what Snakemake would do without executing
+- `pixi run touch` — mark all outputs as up-to-date without re-running jobs
+- `pixi run snakemake [ARGS]` — pass arbitrary arguments directly to Snakemake
 
 If you prefer, you can use a Python-only package manager of your choice, for
 example [uv](https://docs.astral.sh/uv/):

--- a/docs/source/manual/sites.md
+++ b/docs/source/manual/sites.md
@@ -57,7 +57,7 @@ Now you can proceed with setting up and running the production workflow, with
 e.g. on a compute node:
 
 ```console
-> pixi run snakemake --workflow-profile workflow/profiles/nersc-compute
+> pixi run prod --profile nersc-compute
 ```
 
 Using the provided `nersc-*` profiles is recommended (have a look at them!).
@@ -100,6 +100,13 @@ that some rules are unaffected by them.
 
 ### Multi-node execution
 
+:::{warning}
+
+Multi-node execution via `snakemake-nersc` / `pixi run prodnodes` is **highly
+experimental**. Use at your own risk and always verify results afterwards.
+
+:::
+
 As of Snakemake v8.30, support for parallel execution across multiple compute
 nodes or interaction with job schedulers (such as Slurm) is not well supported.
 
@@ -121,11 +128,27 @@ starting many `srun` instances for performance reasons. As a result, the only
 reliable way to run Snakemake is with one instance on a single compute node.
 
 The `snakemake-nersc` executable, exposed by `legend-simflow` offers a way to
-parallelize the workflow in some situations over several nodes. The usage is:
+parallelize the workflow in some situations over several nodes. The recommended
+invocation is:
 
 ```console
-> [pixi run] snakemake-nersc -N NUMBER_OF_NODES [SNAKEMAKE ARGS]
+> pixi run prodnodes NUMBER_OF_NODES
 ```
+
+which is equivalent to:
+
+```console
+> snakemake-nersc --nodes NUMBER_OF_NODES
+```
+
+To submit the workflow as a batch Slurm job instead, use:
+
+```console
+> pixi run prodsubmit --time HH:MM:SS [--nodes N]
+```
+
+where `--time` is the requested wall time (required) and `--nodes` defaults to
+`1`.
 
 The program determines the list of simulations (see the `simlist` in
 {ref}`production`) that the user wants to process, partitions it in
@@ -139,6 +162,22 @@ srun -N1 -n1 snakemake --workflow-profile workflow/profiles/nersc-compute --conf
 
 wait
 ```
+
+:::{warning}
+
+The Snakemake instances spawned per chunk are fully independent and share no
+locking mechanism. It is the user's responsibility to ensure that each instance
+operates on a **disjoint subset of the DAG** — otherwise multiple instances may
+try to build the same output concurrently, leading to race conditions and
+corrupted files.
+
+In practice this means that any shared steps (e.g. `par`, which produces
+drift-time maps and other parameters consumed by all `hit`/`opt` jobs) **must be
+completed before** launching the multi-node run. The safest approach is to first
+run `pixi run prod` with only the shared steps in `make_steps`, wait for it to
+finish, and only then launch the multi-node run with those steps excluded.
+
+:::
 
 This approach makes it unfortunately harder to manually interrupt the Simflow,
 e.g. hitting `Ctrl+C` will just make Slurm print some jobset status information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,10 +157,10 @@ dryrun = { cmd = "snakemake --dry-run" }
 touch = { cmd = "snakemake --touch" }
 
 [tool.pixi.tasks.prod]
-cmd = "snakemake --logger {{ --logger }} --workflow-profile workflow/profiles/{{ profile }}"
+cmd = "snakemake --logger {{ logger }} --workflow-profile workflow/profiles/{{ profile }}"
 args = [
   {arg = "profile", default = "default"},
-  {arg = "--logger", default = "snkmt,rich"},
+  {arg = "logger", default = "snkmt,rich"},
 ]
 depends-on = ["precompile"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "legend_simflow",
     "pylegendtestdata",
     "pytest>=6",
     "pytest-cov>=3",
@@ -99,6 +98,94 @@ all = [
 [project.scripts]
 snakemake-nersc = "legendsimflow.cli:snakemake_nersc_cli"
 snakemake-nersc-batch = "legendsimflow.cli:snakemake_nersc_batch_cli"
+
+[tool.pixi.workspace]
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64"]
+
+# NOTE: non-conda dependencies will be installed from pypi (e.g. legend-dataflow-scripts)
+[tool.pixi.pypi-dependencies]
+legend-simflow = { path = ".", editable = true }
+
+# FIXME: remove when https://github.com/prefix-dev/pixi/issues/532 is closed
+[tool.pixi.dependencies]
+# legend-simflow core dependencies
+awkward = "*"
+dbetto = ">=1.3.2,<1.4"
+# legend-dataflow-scripts = "..."  # not on conda-forge
+legend-pydataobj = ">=1.17.1"
+legend-pygeom-l200 = ">=0.8,<0.9"
+legend-pygeom-tools = ">=0.2,<0.3"
+dspeed = ">=2.1,<2.2"
+matplotlib = "*"
+numpy = "*"
+pylegendmeta = ">=1.3.5,<1.4"
+psutil = "*"
+"ruamel.yaml" = "*"
+
+# execution
+snakemake = ">=9.17,<9.18"
+snakemake-storage-plugin-fs = "*"
+snakemake-executor-plugin-slurm = "*"
+# snakemake-logger-plugin-rich = "..."  # not on conda-forge
+snakemake-logger-plugin-snkmt = "*"
+
+# tier hit
+hist = "*"
+mplhep = ">=1.0"
+legend-pygeom-hpges = ">=0.9,<0.10"
+pyg4ometry = "*"
+pygama = ">=2.3.6,<2.4"
+reboost = ">=0.10.3,<0.11"
+
+# tier stp
+remage = ">=0.19.5,<0.20"
+
+# drift-time maps and other SSD.jl jobs
+julia = ">=1.12,<1.13"
+h5py = "*"
+hdf5 = "*"
+revertex = ">=0.1.2,<0.2"
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }
+
+[tool.pixi.tasks]
+snakemake = { cmd = "snakemake", depends-on = ["precompile"] }
+dryrun = { cmd = "snakemake --dry-run" }
+touch = { cmd = "snakemake --touch" }
+
+[tool.pixi.tasks.prod]
+cmd = "snakemake --logger {{ --logger }} --workflow-profile workflow/profiles/{{ profile }}"
+args = [
+  {arg = "profile", default = "default"},
+  {arg = "--logger", default = "snkmt,rich"},
+]
+depends-on = ["precompile"]
+
+[tool.pixi.tasks.prodnodes]
+# NOTE: snkmt does not work here because of race condition
+cmd = "snakemake-nersc --nodes {{ n_nodes }}"
+args = ["n_nodes"]
+depends-on = ["precompile"]
+
+[tool.pixi.tasks.prodsubmit]
+cmd = "snakemake-nersc-batch --time {{ time }} --nodes {{ nodes }}"
+args = [
+  {arg = "time"},
+  {arg = "nodes", default = "1"},
+]
+depends-on = ["precompile"]
+
+[tool.pixi.tasks.precompile]
+cmd = "python -c 'from dspeed.processors import *; from lgdo.compression import *; import matplotlib; import pygama; import pygeomhpges; import pygeomoptics; import pygeomtools; import reboost; import remage; import revertex' && touch .pixi/precompile.stamp"
+outputs = [".pixi/precompile.stamp"]
+
+[tool.pixi.feature.test.tasks]
+test-python = { cmd = "pytest -vvv" }
+test-julia = { cmd = "julia ../legendsimflow/scripts/init-julia-env.jl && julia --project=. -e 'using Pkg; Pkg.test()'", cwd = "workflow/src/LegendSimflow.jl" }
+test = { depends-on = ["test-python", "test-julia"] }
 
 [tool.uv.workspace]
 exclude = ["generated", "inputs", "software", "workflow"]
@@ -163,7 +250,6 @@ pydocstyle.convention = "numpy"
 "tests/**" = ["T20"]
 "noxfile.py" = ["T20"]
 
-
 [tool.pylint]
 py-version = "3.9"
 ignore-paths = [".*/_version.py"]
@@ -178,61 +264,3 @@ messages_control.disable = [
   "wrong-import-position",
   "too-many-nested-blocks"
 ]
-
-[tool.pixi.tasks.precompile]
-cmd = "python -c 'from dspeed.processors import *; from lgdo.compression import *; import matplotlib; import pygama; import pygeomhpges; import pygeomoptics; import pygeomtools; import reboost; import remage; import revertex' && touch .pixi/precompile.stamp"
-outputs = [".pixi/precompile.stamp"]
-
-[tool.pixi.tasks]
-snakemake = { cmd = "snakemake", depends-on = ["precompile"] }
-test-python = { cmd = "pytest -vvv" }
-test-julia = { cmd = "julia workflow/src/legendsimflow/scripts/init-julia-env.jl && julia --project=workflow/src/LegendSimflow.jl -e 'using Pkg; Pkg.test()'" }
-test = { depends-on = ["test-python", "test-julia"] }
-
-[tool.pixi.workspace]
-channels = ["conda-forge", "bioconda"]
-platforms = ["linux-64"]
-
-# NOTE: non-conda dependencies will be installed from pypi (e.g. legend-dataflow-scripts)
-[tool.pixi.pypi-dependencies]
-legend-simflow = { path = ".", editable = true }
-
-# FIXME: remove when https://github.com/prefix-dev/pixi/issues/532 is closed
-[tool.pixi.dependencies]
-# legend-simflow core dependencies
-awkward = "*"
-dbetto = ">=1.3.2,<1.4"
-# legend-dataflow-scripts = "..."  # not on conda-forge
-legend-pydataobj = ">=1.17.1"
-legend-pygeom-l200 = ">=0.8,<0.9"
-legend-pygeom-tools = ">=0.2,<0.3"
-dspeed = ">=2.1,<2.2"
-matplotlib = "*"
-numpy = "*"
-pylegendmeta = ">=1.3.5,<1.4"
-psutil = "*"
-"ruamel.yaml" = "*"
-
-# execution
-snakemake = ">=9.17,<9.18"
-snakemake-storage-plugin-fs = "*"
-snakemake-executor-plugin-slurm = "*"
-# snakemake-logger-plugin-rich = "..."  # not on conda-forge
-snakemake-logger-plugin-snkmt = "*"
-
-# tier hit
-hist = "*"
-mplhep = ">=1.0"
-legend-pygeom-hpges = ">=0.9,<0.10"
-pyg4ometry = "*"
-pygama = ">=2.3.6,<2.4"
-reboost = ">=0.10.3,<0.11"
-
-# tier stp
-remage = ">=0.19.5,<0.20"
-
-# drift-time maps and other SSD.jl jobs
-julia = ">=1.12,<1.13"
-h5py = "*"
-hdf5 = "*"
-revertex = ">=0.1.2,<0.2"

--- a/workflow/src/legendsimflow/cli.py
+++ b/workflow/src/legendsimflow/cli.py
@@ -221,7 +221,9 @@ def snakemake_nersc_batch_cli():
     if args.job_name is not None:
         cmd.extend(["--job-name", args.job_name])
     if args.mail_user is not None:
-        cmd.extend(["--mail-type", "TIME_LIMIT,FAIL", "--mail-user", args.mail_user])
+        cmd.extend(
+            ["--mail-type", "TIME_LIMIT,FAIL,END", "--mail-user", args.mail_user]
+        )
 
     if int(args.nodes) > 1:
         snakemake = "pixi run snakemake-nersc --nodes $SLURM_NNODES"


### PR DESCRIPTION
## Summary

- Reorganizes the pixi configuration: test tasks (`test`, `test-python`, `test-julia`) are moved into a dedicated `test` feature environment; new workflow tasks added: `dryrun`, `touch`, `prod` (with `--profile` and `--logger` args), `prodnodes`, `prodsubmit` (wrapping `snakemake-nersc-batch` with `--time`/`--nodes` args)
- Removes redundant `legend_simflow` self-dependency from `[test]` extras (package is already installed editable via pixi)
- Updates the CI `test_julia` job to install and activate the `test` pixi environment (`environments: test`, `pixi run -e test`)
- Updates docs (`prod.md`, `setup.md`, `sites.md`) to recommend the new pixi tasks; adds an **experimental** warning and a DAG-independence caveat to the multi-node NERSC section

## Test plan

- [ ] Verify `pixi run prod` / `pixi run dryrun` / `pixi run touch` work in a local checkout
- [ ] Verify `pixi run -e test test` runs Python and Julia tests
- [ ] Verify CI `test_julia` job passes with the updated `setup-pixi` config
- [ ] Verify `pixi run prodnodes N` invokes `snakemake-nersc --nodes N` correctly on NERSC
- [ ] Verify `pixi run prodsubmit --time HH:MM:SS` invokes `snakemake-nersc-batch` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)