### PR TITLE
minor: clarify why we leave geom rules in stp.smk in a comment

### DIFF
--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -28,6 +28,10 @@ rule gen_all_tier_stp:
         aggregate.gen_list_of_all_simid_outputs(config, tier="stp"),
 
 
+# NOTE: the geometry rules below intentionally live in stp.smk rather than a
+# shared module. The geometry must always be produced as part of an stp tier
+# production — upper tiers (vtx, hit, opt, ...) are required to take the
+# geometry from an existing stp production and must never build their own.
 rule gen_geom_config:
     """Write a geometry configuration file for legend-pygeom-l200.
 


### PR DESCRIPTION
## Summary

- Adds a comment above `gen_geom_config` in `workflow/rules/stp.smk` explaining that the geometry rules intentionally live there

## Motivation

The geometry rules (`gen_geom_config`, `build_geom_gdml`) need to be produced as part of an `stp` tier production. Upper tiers (`vtx`, `hit`, `opt`, ...) must always take the geometry from an existing `stp` production and must never build their own. The comment makes this design intent explicit for future contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)