### PR TITLE
feat: add PSD usability support to hit tier

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -8,3 +8,14 @@ Python tests are stored in `tests/` and managed with Pytest. Julia tests are in
 - `test_workflow.py`: integration Snakemake testing of the workflow with a dummy
   production (configured in `tests/dummyprod`) that can be tested in CI
 - `l200data/`: test data for the LEGEND-200 data production
+
+## Test data construction
+
+`conftest.py` checks out a pinned commit of `legend-testdata` and copies the
+relevant subdirectories (hardware metadata, datasets, ...) into
+`tests/dummyprod/inputs/` using `_copy_skip_existing`, which skips files that
+already exist at the destination. Those directories are gitignored, so they
+always reflect the checked-out testdata commit and cannot be overridden by
+committed files. When updating the testdata commit, verify that the new content
+is consistent with the test expectations (channelmap validity dates, detector
+lists, dataset entries, ...).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ config_filename = testprod / "simflow-config.yaml"
 @pytest.fixture(scope="session")
 def legend_testdata():
     ldata = LegendTestData()
-    ldata.checkout("9f03127")
+    ldata.checkout("cc43d78")
     return ldata
 
 

--- a/tests/l200data/v2.1.0/generated/par/pht/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-par_pht.json
+++ b/tests/l200data/v2.1.0/generated/par/pht/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-par_pht.json
@@ -1,5 +1,5 @@
 {
-  "ch1234568": {
+  "ch1104000": {
     "pars": { "operations": {} },
     "results": {
       "ecal": {

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 from dbetto import AttrsDict
 
+import legendsimflow.aggregate as agg_mod
 from legendsimflow import aggregate as agg
 from legendsimflow.exceptions import SimflowConfigError
 
@@ -190,5 +192,28 @@ def test_usability_harvesting(config):
         "l200-p02-r006-phy",
         "l200-p02-r007-phy",
     ]
-    # now returns dict[str, int] (hpge -> usability)
-    assert usability["l200-p02-r000-phy"] == {"V99000A": "on", "B99000A": "on"}
+    assert usability["l200-p02-r000-phy"] == {
+        "V99000A": {"usability": "on", "psd_usability": "valid"},
+        "B99000A": {"usability": "off", "psd_usability": "missing"},
+    }
+
+
+def test_psd_usability_unknown_value(config, monkeypatch, caplog):
+    """Unknown psd.status.low_aoe values should warn and default to 'valid'."""
+    original = agg_mod.encode_psd_usability
+
+    # Make encode_psd_usability raise KeyError for any value except "valid"
+    # (simulates an unexpected psd.status.low_aoe in the metadata)
+    def patched_encode(val):
+        if val != "valid":
+            raise KeyError(val)
+        return original(val)
+
+    monkeypatch.setattr(agg_mod, "encode_psd_usability", patched_encode)
+
+    with caplog.at_level(logging.WARNING, logger="legendsimflow.aggregate"):
+        result = agg_mod.gen_list_of_all_usabilities(config)
+
+    assert "unexpected psd.status.low_aoe" in caplog.text
+    # B99000A has psd.status.low_aoe="missing" -> triggers warning -> defaults to "valid"
+    assert result["l200-p02-r000-phy"]["B99000A"]["psd_usability"] == "valid"

--- a/tests/test_hpge_pars.py
+++ b/tests/test_hpge_pars.py
@@ -358,7 +358,7 @@ def test_build_eres_funcs(config, test_l200data):
     )
 
     assert isinstance(meta, dict)
-    assert list(meta.keys()) == ["V99000A"]
+    assert list(meta.keys()) == ["V02160A"]
 
 
 def test_lookup_aoeres(config, test_l200data):
@@ -403,8 +403,8 @@ def test_build_aoeres_funcs(config, test_l200data):
     )
 
     assert isinstance(meta, dict)
-    assert list(meta.keys()) == ["V99000A"]
-    assert meta["V99000A"](2000) == pytest.approx(0.007, abs=0.001)
+    assert list(meta.keys()) == ["V02160A"]
+    assert meta["V02160A"](2000) == pytest.approx(0.007, abs=0.001)
 
 
 def test_lookup_psd_cut_vals(config, test_l200data):

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -90,9 +90,10 @@ rule _init_julia_env:
 rule cache_detector_usabilities:
     """Cache detector usabilities.
 
-    Querying the metadata for detector analysis usability can be slow and
-    constitute the bottleneck in post-processing (`opt` and `hit` tiers).
-    This rule caches the mapping `run -> detector -> usability` on disk.
+    Querying the metadata for detector usability can be slow and constitute
+    the bottleneck in post-processing (``opt`` and ``hit`` tiers). This rule
+    caches the mapping ``run -> detector -> {usability, psd_usability}`` on
+    disk.
     """
     localrule: True
     message:

--- a/workflow/rules/hit.smk
+++ b/workflow/rules/hit.smk
@@ -21,8 +21,8 @@ rule build_tier_hit:
 
     - each chunk is partitioned according to the livetime span of each run
       (see the `make_simstat_partition_file` rule). For each partition:
-    - the detector usability is retrieved from `legend-metadata` and stored in
-      the output;
+    - the detector usability and PSD usability are retrieved from
+      `legend-metadata` and stored in the output;
     - the active volume model is applied based on information from `legend-metadata`;
     - A/E is simulated based on current signal templates extracted from
       LEGEND-200 data;

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -16,18 +16,16 @@
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 import dbetto
 from dbetto import AttrsDict
 from legendmeta.police import validate_dict_schema
-from snakemake.logging import logger as smklog
 
 from . import SimflowConfig, patterns
 from .exceptions import SimflowConfigError
-from .metadata import get_runlist, get_simconfig, runinfo, simpars
+from .metadata import encode_psd_usability, get_runlist, get_simconfig, runinfo, simpars
 
 log = logging.getLogger(__name__)
 
@@ -223,8 +221,6 @@ def gen_list_of_all_hpges_valid_for_modeling(
 
     i.e. a mapping ``runid -> hpge -> voltage``.
     """
-    start = time.time()
-
     all_runids = set()
     for simid in gen_list_of_all_simids(config):
         all_runids.update(get_runlist(config, simid))
@@ -233,11 +229,6 @@ def gen_list_of_all_hpges_valid_for_modeling(
     for runid in sorted(all_runids):
         hpges = gen_list_of_hpges_valid_for_modeling(config, runid)
         out[runid] = {hpge: get_hpge_voltage(config, hpge, runid) for hpge in hpges}
-
-    msg = (
-        f"gen_list_of_all_hpges_valid_for_modeling() took {time.time() - start:.1f} sec"
-    )
-    smklog.debug(msg)
 
     if write_to_file is not None:
         Path(write_to_file).parent.mkdir(parents=True, exist_ok=True)
@@ -251,19 +242,27 @@ def gen_list_of_all_hpges_valid_for_modeling(
 
 def gen_list_of_all_usabilities(
     config: SimflowConfig,
-) -> AttrsDict[str, AttrsDict[str, str]]:
-    """Get usability for all detectors and all runs defined in the Simflow.
+) -> AttrsDict[str, AttrsDict[str, dict]]:
+    """Generate a usability mapping for all detectors and all runs defined in the Simflow.
 
-    Use this function to build a cache, in case repeated calls to
-    :func:`.metadata.usability` are needed. Returns the following dictionary:
+    Use this function to build a cache to avoid repeated metadata lookups.
+    Returns the following dictionary:
 
     .. code-block::
 
         {
-          'l200-p03-r000-phy': {'V00048A': "on", ...},
-          'l200-p03-r001-phy': {'V00050B': "off", ...},
+          'l200-p03-r000-phy': {
+            'V00048A': {'usability': 'on', 'psd_usability': 0},
+            ...
+          },
           ...
         }
+
+    ``psd_usability`` is an integer encoding of the ``psd.status.low_aoe``
+    field in the channel map status for germanium detectors (see
+    ``legendsimflow.metadata.PSD_USABILITY_CODE``). If the field is absent it
+    defaults silently to ``"valid"``; if it has an unexpected value a warning
+    is emitted and it also defaults to ``"valid"``.
 
     Parameters
     ----------
@@ -271,8 +270,6 @@ def gen_list_of_all_usabilities(
         Simflow configuration object.
 
     """
-    start = time.time()
-
     all_runids = set()
     for simid in gen_list_of_all_simids(config):
         all_runids.update(get_runlist(config, simid))
@@ -282,13 +279,27 @@ def gen_list_of_all_usabilities(
         out_dict[runid] = {}
         rinfo = runinfo(config.metadata, runid)
         chmap = config.metadata.hardware.configuration.channelmaps.on(rinfo.start_key)
+        statuses = config.metadata.datasets.statuses.on(rinfo.start_key)
         for chname in chmap:
-            statuses = config.metadata.datasets.statuses.on(rinfo.start_key)
             if chname in statuses:
-                out_dict[runid][chname] = statuses[chname].usability
+                usability = statuses[chname].usability
 
-    msg = f"get_all_usabilities() took {time.time() - start:.1f} sec"
-    smklog.debug(msg)
+                entry = {"usability": usability}
+                if chmap[chname].system == "geds":
+                    psd_usability = "valid"
+                    try:
+                        psd_status = statuses[chname].psd.status.low_aoe
+                        try:
+                            encode_psd_usability(psd_status)  # validate
+                            psd_usability = psd_status
+                        except KeyError:
+                            msg = f"unexpected psd.status.low_aoe value {psd_status!r} for {chname} in {runid}, defaulting to valid"
+                            log.warning(msg)
+                    except AttributeError:
+                        pass
+                    entry["psd_usability"] = psd_usability
+
+                out_dict[runid][chname] = entry
 
     return AttrsDict(out_dict)
 

--- a/workflow/src/legendsimflow/metadata.py
+++ b/workflow/src/legendsimflow/metadata.py
@@ -37,6 +37,12 @@ USABILITY_CODE = {
     "off": 2,
 }
 
+PSD_USABILITY_CODE = {
+    "valid": 0,
+    "present": 1,
+    "missing": 2,
+}
+
 
 def get_simconfig(
     config: SimflowConfig,
@@ -165,6 +171,17 @@ def decode_usability(usability_code: int) -> str:
     """Decode the HPGe usability (see :func:`encode_usability`)."""
     _codes = {v: k for k, v in USABILITY_CODE.items()}
     return _codes[usability_code]
+
+
+def encode_psd_usability(psd_usability: str) -> int:
+    """Encode the PSD usability in an int."""
+    return PSD_USABILITY_CODE[psd_usability]
+
+
+def decode_psd_usability(psd_usability_code: int) -> str:
+    """Decode the PSD usability (see :func:`encode_psd_usability`)."""
+    _codes = {v: k for k, v in PSD_USABILITY_CODE.items()}
+    return _codes[psd_usability_code]
 
 
 def parse_runid(runid: str) -> (str, int, int, str):

--- a/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
@@ -120,12 +120,13 @@ base_mask = (  # noqa: E731
     & (evt.geds.multiplicity == 1)
     & evt.geds.is_good_channel
     & evt.geds.has_aoe
+    & evt.geds.psd.is_good
 )
 _plot_ehist(
     ax,
     base_mask,
     color="silver",
-    label="geds.is_good_channel & geds.has_aoe & geds.multiplicity == 1",
+    label="geds.is_good_channel & geds.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
 )
 _plot_ehist(
     ax,

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -27,7 +27,7 @@ from lgdo import Array, Table, VectorOfVectors, lh5
 from legendsimflow import nersc, patterns, spms_pars, utils
 from legendsimflow import reboost as reboost_utils
 from legendsimflow.awkward import ak_isin
-from legendsimflow.metadata import encode_usability
+from legendsimflow.metadata import encode_psd_usability, encode_usability
 from legendsimflow.profile import make_profiler
 from legendsimflow.tcm import merge_stp_n_opt_tcms_to_lh5
 
@@ -36,6 +36,7 @@ SPMS_ENERGY_THR_PE = 0
 BUFFER_LEN = "50*MB"
 OFF = encode_usability("off")
 ON = encode_usability("on")
+VALID_PSD = encode_psd_usability("valid")
 
 args = nersc.dvs_ro_snakemake(snakemake)  # noqa: F821
 
@@ -185,7 +186,7 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
     on_spms_uids = sorted(
         uid
         for det_name, uid in det2uid["opt"].items()
-        if usabilities[runid].get(det_name, "on") != "off"
+        if (usabilities[runid].get(det_name) or {}).get("usability", "on") != "off"
     )
 
     if add_random_coincidences:
@@ -255,6 +256,7 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
 
         # first read usability and energy
         usability = _read_hits(tcm, "hit", "usability")
+        psd_usability = _read_hits(tcm, "hit", "psd_usability")
         energy = _read_hits(tcm, "hit", "energy")
 
         # we want to only store hits from events in ON and AC detectors and above
@@ -290,6 +292,9 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
 
         is_ss = _read_hits(tcm, "hit", "is_single_site")
         out_table.add_field("geds/is_single_site", VectorOfVectors(is_ss[hitsel]))
+        out_table.add_field(
+            "geds/psd/is_good", VectorOfVectors(psd_usability[hitsel] == VALID_PSD)
+        )
 
         # compute multiplicity
         geds_multiplicity = ak.sum(hitsel, axis=-1)

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -292,6 +292,8 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
 
         is_ss = _read_hits(tcm, "hit", "is_single_site")
         out_table.add_field("geds/is_single_site", VectorOfVectors(is_ss[hitsel]))
+
+        out_table.add_field("geds/psd", Table(size=len(unified_tcm)))
         out_table.add_field(
             "geds/psd/is_good", VectorOfVectors(psd_usability[hitsel] == VALID_PSD)
         )

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -190,9 +190,15 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
             continue
 
         # get the usability
-        usability = usabilities[runid][det_name]
-        if usability is None:
+        det_info = usabilities[runid][det_name]
+        if det_info is None:
+            msg = f"usability not found for {det_name} in {runid}, defaulting to on"
+            log.warning(msg)
             usability = "on"
+            psd_usability = mutils.encode_psd_usability("valid")
+        else:
+            usability = det_info.usability
+            psd_usability = mutils.encode_psd_usability(det_info.psd_usability)
 
         msg = "looking for indices of hit table rows to read..."
         log.debug(msg)
@@ -389,6 +395,10 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                     field,
                     lgdo.Array(np.full(shape=len(chunk), fill_value=field_vals[i])),
                 )
+            out_table.add_field(
+                "psd_usability",
+                lgdo.Array(np.full(shape=len(chunk), fill_value=psd_usability)),
+            )
 
             with perf_block("write_chunk()"):
                 reboost_utils.write_chunk(

--- a/workflow/src/legendsimflow/scripts/tier/opt.py
+++ b/workflow/src/legendsimflow/scripts/tier/opt.py
@@ -222,9 +222,13 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                 sipm_uid = sens_tables[sipm].uid
 
                 # get the usability
-                usability = usabilities[runid][sipm]
-                if usability is None:
+                det_info = usabilities[runid][sipm]
+                if det_info is None:
+                    msg = f"usability not found for {sipm} in {runid}, defaulting to on"
+                    log.warning(msg)
                     usability = "on"
+                else:
+                    usability = det_info.usability
 
                 msg = f"applying optical map for SiPM {sipm}"
                 log.debug(msg)


### PR DESCRIPTION
## Summary

- Adds `PSD_USABILITY_CODE` encoding (`valid=0`, `present=1`, `missing=2`) and `encode_psd_usability`/`decode_psd_usability` to `metadata.py`, mirroring the existing `USABILITY_CODE` pattern
- Extends `gen_list_of_all_usabilities()` in `aggregate.py` to return `{usability, psd_usability}` per detector, reading `psd.status.low_aoe` from the channel map status metadata
- Writes `psd_usability` as an integer column in the `hit` tier output
- Adds warnings in `hit.py` and `opt.py` when usability metadata is absent for a detector
- Updates tests to cover the new encoding and the warning/fallback path for unknown `psd.status.low_aoe` values

## Test plan

- [x] `pixi run test-python` passes
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)