### PR TITLE
Fix partition_simstat to handle unsorted runlists

### DIFF
--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -24,3 +24,18 @@ def test_partition_simstat_expected_dict():
     }
 
     assert partition_simstat(n_events, n_events_part, runlist) == expected
+
+
+def test_partition_simstat_unsorted_runlist():
+    n_events = {"job_000": 10, "job_001": 10}
+    n_events_part = {
+        "l200-p03-r001-phy": 5,
+        "l200-p03-r002-phy": 10,
+        "l200-p03-r003-phy": 5,
+    }
+    sorted_runlist = sorted(n_events_part.keys())
+    reversed_runlist = list(reversed(sorted_runlist))
+
+    assert partition_simstat(
+        n_events, n_events_part, sorted_runlist
+    ) == partition_simstat(n_events, n_events_part, reversed_runlist)

--- a/workflow/src/legendsimflow/partitioning.py
+++ b/workflow/src/legendsimflow/partitioning.py
@@ -66,6 +66,9 @@ def partition_simstat(
         list of runs in the form ``<experiment>-<period>-<run>-<datatype>``.
 
     """
+    # sort runids to guarantee sequential partitioning
+    runlist = sorted(runlist)
+
     # remaining events per run to allocate across jobs
     remaining_run_events = dict(n_events_part)
 


### PR DESCRIPTION
## Summary
Fixed the `partition_simstat` function to produce consistent results regardless of the input runlist order by sorting the runlist internally before processing.

## Changes
- **partitioning.py**: Added internal sorting of the `runlist` parameter in `partition_simstat()` to guarantee sequential and deterministic partitioning across jobs
- **test_partitioning.py**: Added `test_partition_simstat_unsorted_runlist()` test case to verify that the function produces identical results when given sorted vs. reversed runlists

## Implementation Details
The fix ensures that event partitioning is deterministic by sorting the runlist at the beginning of the function. This prevents non-deterministic behavior when callers provide runlists in different orders, while maintaining backward compatibility since the function's output is now consistent regardless of input order.

https://claude.ai/code/session_01D4bse56NZqWDqAT4CHPCZZ