### PR TITLE
feat(evt): move PSD fields into geds/psd/ subtable

### DIFF
--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -100,16 +100,16 @@ and are from non-OFF detectors.
 | `rawid`           | `VectorOfVectors` | —     | Detector channel UID for each hit, matching the channel identifiers used in LEGEND-200 data. Variable-length per event. |
 | `hit_idx`         | `VectorOfVectors` | —     | Row index in the `hit`-tier table, for looking up additional hit-level fields. Variable-length per event.               |
 | `is_good_channel` | `VectorOfVectors` | —     | Boolean. `True` if the detector usability is ON (not AC or OFF). Variable-length per event.                             |
-| `aoe`             | `VectorOfVectors` | —     | A/E classifier values forwarded from the `hit` tier. Variable-length per event.                                         |
-| `has_aoe`         | `VectorOfVectors` | —     | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed). Variable-length per event.                       |
-| `is_single_site`  | `VectorOfVectors` | —     | Boolean PSD flag forwarded from the `hit` tier. Variable-length per event.                                              |
 | `multiplicity`    | `Array`           | —     | Number of HPGe hits above threshold per event. Scalar per event.                                                        |
 
 #### `geds/psd/` — PSD quality
 
-| Field     | Type              | Units | Description                                                                                       |
-| --------- | ----------------- | ----- | ------------------------------------------------------------------------------------------------- |
-| `is_good` | `VectorOfVectors` | —     | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data. Variable-length per event. |
+| Field            | Type              | Units | Description                                                                                       |
+| ---------------- | ----------------- | ----- | ------------------------------------------------------------------------------------------------- |
+| `is_good`        | `VectorOfVectors` | —     | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data. Variable-length per event. |
+| `aoe`            | `VectorOfVectors` | —     | A/E classifier values forwarded from the `hit` tier. Variable-length per event.                   |
+| `has_aoe`        | `VectorOfVectors` | —     | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed). Variable-length per event. |
+| `is_single_site` | `VectorOfVectors` | —     | Boolean PSD flag forwarded from the `hit` tier. Variable-length per event.                        |
 
 ### `spms/` — SiPM (LAr scintillation) array
 

--- a/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
@@ -119,24 +119,24 @@ base_mask = (  # noqa: E731
     lambda evt: evt.coincident.geds
     & (evt.geds.multiplicity == 1)
     & evt.geds.is_good_channel
-    & evt.geds.has_aoe
+    & evt.geds.psd.has_aoe
     & evt.geds.psd.is_good
 )
 _plot_ehist(
     ax,
     base_mask,
     color="silver",
-    label="geds.is_good_channel & geds.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
+    label="geds.is_good_channel & geds.psd.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
 )
 _plot_ehist(
     ax,
-    lambda evt: base_mask(evt) & evt.geds.is_single_site,
+    lambda evt: base_mask(evt) & evt.geds.psd.is_single_site,
     color="tab:green",
-    label="... geds.is_single_site",
+    label="... geds.psd.is_single_site",
 )
 _plot_ehist(
     ax,
-    lambda evt: base_mask(evt) & evt.geds.is_single_site & ~evt.coincident.spms,
+    lambda evt: base_mask(evt) & evt.geds.psd.is_single_site & ~evt.coincident.spms,
     color="tab:red",
     label="... ~coincident.spms",
 )

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -285,18 +285,18 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
             "geds/hit_idx", VectorOfVectors(tcm["hit"].row_in_table[hitsel])
         )
 
-        # simply forward some fields
-        aoe = _read_hits(tcm, "hit", "aoe")
-        out_table.add_field("geds/aoe", VectorOfVectors(aoe[hitsel]))
-        out_table.add_field("geds/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel])))
-
-        is_ss = _read_hits(tcm, "hit", "is_single_site")
-        out_table.add_field("geds/is_single_site", VectorOfVectors(is_ss[hitsel]))
-
+        # PSD subtable
         out_table.add_field("geds/psd", Table(size=len(unified_tcm)))
         out_table.add_field(
             "geds/psd/is_good", VectorOfVectors(psd_usability[hitsel] == VALID_PSD)
         )
+
+        aoe = _read_hits(tcm, "hit", "aoe")
+        out_table.add_field("geds/psd/aoe", VectorOfVectors(aoe[hitsel]))
+        out_table.add_field("geds/psd/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel])))
+
+        is_ss = _read_hits(tcm, "hit", "is_single_site")
+        out_table.add_field("geds/psd/is_single_site", VectorOfVectors(is_ss[hitsel]))
 
         # compute multiplicity
         geds_multiplicity = ak.sum(hitsel, axis=-1)


### PR DESCRIPTION
## Summary

- Move `aoe`, `has_aoe`, and `is_single_site` from the flat `geds/` table into the `geds/psd/` subtable in the `evt` tier
- All PSD-related quantities (`is_good`, `aoe`, `has_aoe`, `is_single_site`) are now grouped under `geds/psd/`
- Docs updated accordingly

## Test plan

- [x] Check that the evt tier output has the fields under `geds/psd/` as expected
- [x] Verify CI passes