### PR TITLE
feat: add metadata-driven eresmod defaults, remove l200data dependency for hit tier

### DIFF
--- a/docs/source/manual/index.md
+++ b/docs/source/manual/index.md
@@ -5,6 +5,7 @@
 
 setup
 meta
+pipeline
 prod
 output
 sites

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -346,7 +346,28 @@ hpge_bulk_Rn222_to_Po214:
     - l200-p03-r004-phy
 ```
 
-## `pars/` simulation parameter overrides
+(hit-tier-settings)=
+
+#### `simprod/config/tier/hit/{experiment}/settings.yaml` — hit tier settings
+
+A static YAML file with hit-tier-specific settings that apply to all simulations
+for a given experiment configuration. When absent, accessing any field from it
+will raise an error.
+
+```{code-block} yaml
+:caption: simprod/config/tier/hit/{experiment}/settings.yaml
+
+eresmod_default:
+  expression: FWHMLinear
+  parameters:
+    a: 0.5
+    b: 0.001
+```
+
+- `eresmod_default` — energy resolution model applied to non-ON detectors. See
+  {ref}`build-tier-hit-energy-resolution` for when this fallback is triggered.
+
+## `pars/` — simulation parameters
 
 ### `simprod/config/pars/geds/dtmap/settings.yaml` — drift time map simulation parameters
 
@@ -376,3 +397,43 @@ of grid points by a factor of ~400 compared to the 0.5 mm production default,
 cutting script runtime from many minutes to seconds.
 
 ::::
+
+(eresmod-metadata-dir)=
+
+### HPGe energy resolution model defaults
+
+An optional validity-based metadata directory providing HPGe-specific energy
+resolution parameters. When present, it can supplement or fully replace
+`l200data` as the source of energy resolution parameters — enabling simulations
+for experiments that have not yet collected data (e.g. LEGEND-1000). The
+structure follows the same validity-based format as `pars/geds/opv/`.
+
+```{code-block} yaml
+:caption: simprod/config/pars/geds/eresmod/l200-p03-r%-T%-all-eresmod.yaml
+
+default:
+  expression: FWHMLinear
+  parameters:
+    a: 0.5
+    b: 0.001
+
+# optional per-detector override
+V02160A:
+  expression: FWHMLinear
+  parameters:
+    a: 0.3
+    b: 0.0009
+```
+
+- `default` _(optional)_ — energy resolution model applied to all HPGe detectors
+  not listed explicitly.
+- `<detector>` _(optional)_ — per-detector override; key is the detector name as
+  it appears in the channel map (e.g. `V02160A`).
+
+Each entry must contain:
+
+- `expression` — name of the energy resolution function (e.g. `FWHMLinear`)
+- `parameters` — mapping of parameter names to their values
+
+See {ref}`hpge-eresmod-extraction` for a description of how these files are used
+at runtime.

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -1,0 +1,79 @@
+# Pipeline steps
+
+This page describes what each step of the Simflow pipeline does and how it uses
+the metadata and configuration described in [](meta.md).
+
+## `vtx` — event vertex generation
+
+:::{todo} Document the vertex generation step. :::
+
+## `stp` — particle simulation
+
+:::{todo} Document the remage simulation step. :::
+
+## `par` — parameter extraction
+
+The `par` step extracts per-detector observable models for each data taking run
+before the `hit` tier is built. The results are written to per-run YAML files on
+disk so that `build_tier_hit` does not need to load the (potentially large) data
+production parameter database at processing time.
+
+(hpge-eresmod-extraction)=
+
+### HPGe energy resolution (`extract_hpge_observables_models`)
+
+The `extract_hpge_observables_models` rule produces a per-detector YAML file
+mapping each HPGe detector to its energy resolution model. It is a _collection_
+step: it gathers what it can from the available sources and writes the result to
+disk. Completeness is validated downstream in `build_tier_hit` (see
+{ref}`build-tier-hit-energy-resolution`).
+
+The exact sources used depend on what is configured:
+
+1. **`l200data` only, no HPGe-specific overrides** — everything available in
+   `l200data` is collected, independent of detector status.
+
+2. **`l200data` + HPGe-specific overrides in {ref}`eresmod-metadata-dir`, no
+   `default` key** — everything available in `l200data` is collected as in case
+   1; the explicitly listed detectors are then overridden.
+
+3. **`l200data` + HPGe-specific overrides with a `default` key** — the metadata
+   takes over entirely: every HPGe detector in the channel map is expanded from
+   the `default` (with optional per-detector overrides). `l200data` is not
+   consulted. All detectors, including non-ON ones, are present in the output.
+
+4. **HPGe-specific overrides with a `default` key, no `l200data`** — same as
+   case 3. `l200data` is not required.
+
+## `opt` — optical hit building
+
+:::{todo} Document the optical hit building step. :::
+
+## `hit` — hit tier building
+
+(build-tier-hit-energy-resolution)=
+
+### Energy resolution (`build_tier_hit`)
+
+`build_tier_hit` applies energy resolution smearing to each simulated detector.
+It reads the per-detector file produced in the `par` step and validates that all
+needed detectors are covered:
+
+- **ON detectors** must always have a curve — a missing entry raises a hard
+  error.
+- **`off` and `ac` detectors** fall back to `eresmod_default` from
+  {ref}`hit-tier-settings` with a warning. This fallback is never triggered when
+  a `default` key is present in the eresmod metadata (cases 3 and 4 above),
+  because all detectors are already covered.
+
+## `evt` — event building
+
+:::{todo} Document the event building step. :::
+
+## `cvt` — event concatenation
+
+:::{todo} Document the event concatenation step. :::
+
+## `pdf` — PDF generation
+
+:::{todo} Document the PDF generation step. :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ touch = { cmd = "snakemake --touch" }
 tier-cvt = { cmd = "python -m legendsimflow.scripts.tier.cvt" }
 tier-pdf = { cmd = "python -m legendsimflow.scripts.tier.pdf" }
 
+extract-hpge-obs-models = { cmd = "python -m legendsimflow.scripts.pars.extract_hpge_observables_models" }
+
 [tool.pixi.tasks.prod]
 cmd = "snakemake --verbose --logger {{ logger }} --workflow-profile workflow/profiles/{{ profile }}"
 args = [

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/l200-p02-r%-T%-all-eresmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/l200-p02-r%-T%-all-eresmod.yaml
@@ -1,0 +1,6 @@
+# no "default" key — used to test case 2: l200data base + per-detector overrides
+V02160A:
+  expression: FWHMLinear
+  parameters:
+    a: 0.3
+    b: 0.0009

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/l200-p03-r%-T%-all-eresmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/l200-p03-r%-T%-all-eresmod.yaml
@@ -1,0 +1,11 @@
+default:
+  expression: FWHMLinear
+  parameters:
+    a: 0.5
+    b: 0.001
+
+V02160A:
+  expression: FWHMLinear
+  parameters:
+    a: 0.3
+    b: 0.0009

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/eresmod/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-eresmod.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-eresmod.yaml

--- a/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
@@ -1,0 +1,5 @@
+eresmod_default:
+  expression: FWHMLinear
+  parameters:
+    a: 0.5
+    b: 0.001

--- a/tests/scripts/test_extract_hpge_observables_models.py
+++ b/tests/scripts/test_extract_hpge_observables_models.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from legendsimflow.scripts.pars import extract_hpge_observables_models
+
+dummyprod = Path(__file__).parent.parent / "dummyprod"
+
+# p03 runid: eresmod validity.yaml maps 20230312 → p03 file (has "default" + V02160A override)
+RUNID_P03 = "l200-p03-r000-phy"
+# p02 runid: eresmod validity.yaml maps 20220102 → p02 file (no "default", only V02160A override)
+RUNID_P02 = "l200-p02-r000-phy"
+
+# count of geds detectors in the p03 channelmap (grep "system: geds" gives 101 lines)
+N_GEDS_P03 = 101
+
+# fake l200data base returned by the mocked lookup_energy_res_metadata
+_FAKE_L200DATA_ERESMOD = {
+    "V05261A": {
+        "expression": "FWHMLinear",
+        "parameters": {"a": 0.7, "b": 0.002},
+        "uncertainties": {},
+    },
+    "V02160A": {
+        "expression": "FWHMLinear",
+        "parameters": {"a": 0.6, "b": 0.0015},
+        "uncertainties": {},
+    },
+}
+
+# keep RUNID as alias for backward compat within this module
+RUNID = RUNID_P03
+
+
+def _build_argv(
+    tmp_path: Path, runid: str = RUNID_P03, l200data: str | None = None
+) -> list[str]:
+    """Return sys.argv for the script under test."""
+    config_path = tmp_path / "simflow-config.yaml"
+    raw = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
+    raw["paths"]["metadata"] = str(dummyprod / "inputs")
+    if l200data is not None:
+        raw["paths"]["l200data"] = l200data
+    config_path.write_text(yaml.safe_dump(raw))
+
+    return [
+        "extract-hpge-obs-models",
+        "--runid",
+        runid,
+        "--eresmod-file",
+        str(tmp_path / "eresmod.yaml"),
+        "--aoeresmod-file",
+        str(tmp_path / "aoeresmod.yaml"),
+        "--psdcuts-file",
+        str(tmp_path / "psdcuts.yaml"),
+        "--simflow-config",
+        str(config_path),
+    ]
+
+
+def _run_with_mocks(
+    tmp_path: Path,
+    monkeypatch,
+    runid: str = RUNID_P03,
+    l200data: str | None = None,
+) -> Path:
+    """Patch sys.argv and the l200data-dependent helpers, then call main().
+
+    The eresmod path is exercised via metadata; the aoeresmod and psdcuts
+    paths are short-circuited by returning empty dicts so no l200data is needed.
+    Pass a non-None `l200data` to exercise the l200data extraction path (the
+    actual extraction is still mocked via lookup_energy_res_metadata).
+    """
+    monkeypatch.setattr(
+        sys, "argv", _build_argv(tmp_path, runid=runid, l200data=l200data)
+    )
+
+    with (
+        patch(
+            "legendsimflow.utils.get_hit_tier_name",
+            return_value="hit",
+        ),
+        patch(
+            "legendsimflow.utils.init_generated_pars_db",
+            return_value=None,
+        ),
+        patch(
+            "legendsimflow.hpge_pars.lookup_energy_res_metadata",
+            return_value=_FAKE_L200DATA_ERESMOD,
+        ),
+        patch(
+            "legendsimflow.hpge_pars.lookup_aoe_res_metadata",
+            return_value={},
+        ),
+        patch(
+            "legendsimflow.hpge_pars.lookup_psd_cut_values",
+            return_value={},
+        ),
+    ):
+        extract_hpge_observables_models.main()
+
+    return tmp_path / "eresmod.yaml"
+
+
+def test_extract_eresmod_from_metadata(tmp_path, monkeypatch):
+    """Metadata-driven path: eresmod.yaml must be expanded to per-detector entries."""
+    eresmod_file = _run_with_mocks(tmp_path, monkeypatch)
+
+    assert eresmod_file.exists(), "eresmod output file was not created"
+
+    with eresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "eresmod output must be a YAML mapping"
+
+    # "default" key must NOT appear — non-ON fallback comes from hit tier settings
+    assert "default" not in result, "eresmod output must not contain a 'default' key"
+
+    # every per-detector entry must carry expression and parameters with a and b
+    for det, entry in result.items():
+        assert "expression" in entry, f"{det}: missing 'expression'"
+        assert "parameters" in entry, f"{det}: missing 'parameters'"
+        assert "a" in entry["parameters"], f"{det}: missing parameter 'a'"
+        assert "b" in entry["parameters"], f"{det}: missing parameter 'b'"
+
+    # the per-detector override for V02160A must win over the default
+    assert "V02160A" in result, "V02160A must be present in the eresmod output"
+    assert result["V02160A"]["parameters"]["a"] == pytest.approx(0.3)
+    assert result["V02160A"]["parameters"]["b"] == pytest.approx(0.0009)
+
+    # at least one other geds detector must carry the default values
+    default_detectors = [
+        det
+        for det, entry in result.items()
+        if det != "V02160A"
+        and entry["parameters"]["a"] == pytest.approx(0.5)
+        and entry["parameters"]["b"] == pytest.approx(0.001)
+    ]
+    assert len(default_detectors) >= 1, (
+        "at least one geds detector must have the default a=0.5, b=0.001"
+    )
+
+
+def test_extract_eresmod_per_detector_count(tmp_path, monkeypatch):
+    """Metadata-driven path: one output entry per geds detector in the p03 channelmap."""
+    eresmod_file = _run_with_mocks(tmp_path, monkeypatch)
+
+    with eresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert len(result) == N_GEDS_P03, (
+        f"expected {N_GEDS_P03} geds detectors in eresmod output, got {len(result)}"
+    )
+
+
+def test_extract_eresmod_l200data_with_overrides(tmp_path, monkeypatch):
+    """Case 2: l200data base + per-detector overrides from metadata (no 'default' key).
+
+    The p02 eresmod file has only a V02160A override. The l200data base is
+    mocked to return V05261A and V02160A. The output must contain both detectors,
+    with V02160A replaced by the metadata value and V05261A kept from l200data.
+    """
+    eresmod_file = _run_with_mocks(
+        tmp_path, monkeypatch, runid=RUNID_P02, l200data="/fake/l200data"
+    )
+
+    with eresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "eresmod output must be a YAML mapping"
+    assert "default" not in result, "eresmod output must not contain a 'default' key"
+
+    # V05261A: not in metadata overrides — must keep l200data values
+    assert "V05261A" in result, "V05261A must be present (from l200data base)"
+    assert result["V05261A"]["parameters"]["a"] == pytest.approx(0.7)
+    assert result["V05261A"]["parameters"]["b"] == pytest.approx(0.002)
+
+    # V02160A: in metadata overrides — must be replaced by metadata values
+    assert "V02160A" in result, "V02160A must be present (overridden by metadata)"
+    assert result["V02160A"]["parameters"]["a"] == pytest.approx(0.3)
+    assert result["V02160A"]["parameters"]["b"] == pytest.approx(0.0009)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -29,6 +29,24 @@ def test_all(config):
         in metadata.simpars(config.metadata, "geds.opv", "l200-p02-r002-phy").V99000A
     )
 
+    # default= returns the default when the par directory does not exist
+    assert (
+        metadata.simpars(
+            config.metadata, "geds.nonexistent", "l200-p02-r002-phy", default=None
+        )
+        is None
+    )
+    assert (
+        metadata.simpars(
+            config.metadata, "geds.nonexistent", "l200-p02-r002-phy", default=42
+        )
+        == 42
+    )
+
+    # without default=, a missing par raises
+    with pytest.raises((KeyError, LookupError, FileNotFoundError)):
+        metadata.simpars(config.metadata, "geds.nonexistent", "l200-p02-r002-phy")
+
     assert isinstance(
         metadata.get_vtx_simconfig(config, "lar_hpge_shell_K42"), AttrsDict
     )

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -266,7 +266,7 @@ rule merge_current_pulse_model_pars:
 
 
 rule extract_hpge_observables_models:
-    """Extract from the LEGEND-200 data and store on disk models of the HPGe observables.
+    """Extract and store on disk models of the HPGe observables for a run.
 
     Stores YAML files with a mapping between HPGe detectors and respective
     information to reconstruct:
@@ -278,6 +278,11 @@ rule extract_hpge_observables_models:
     because the data production parameter database is large and we don't want
     to use a lot of memory in the `build_tier_hit` rule.
 
+    **Design:** this rule is a *collection* step, not a *validation* step. It
+    gathers what it can from l200data and ``simprod/config/pars/geds/eresmod/``;
+    the output may be incomplete. Completeness is validated downstream in
+    ``build_tier_hit``.
+
     Uses wildcard `runid`.
     """
     message:
@@ -288,51 +293,7 @@ rule extract_hpge_observables_models:
         eresmod_file=patterns.output_eresmod_filename(config),
         aoeresmod_file=patterns.output_aoeresmod_filename(config),
         psdcuts_file=patterns.output_psdcuts_filename(config),
-    run:
-        import dbetto
-        from legendsimflow import hpge_pars, utils
-
-        l200data = config.paths.l200data
-
-        hit_tier_name = utils.get_hit_tier_name(l200data)
-        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
-
-        eres_pars_dict = hpge_pars.lookup_energy_res_metadata(
-            l200data,
-            config.metadata,
-            wildcards.runid,
-            hit_tier_name=hit_tier_name,
-            pars_db=pars_db,
-        )
-
-        out_dict = dbetto.AttrsDict({})
-        fields = ["expression", "parameters", "uncertainties"]
-        for hpge, meta in eres_pars_dict.items():
-            out_dict[hpge] = {f: meta[f] for f in fields}
-
-        dbetto.utils.write_dict(out_dict.to_dict(), output.eresmod_file)
-
-        aoeres_pars_dict = hpge_pars.lookup_aoe_res_metadata(
-            l200data,
-            config.metadata,
-            wildcards.runid,
-            hit_tier_name=hit_tier_name,
-            pars_db=pars_db,
-        )
-
-        out_dict = dbetto.AttrsDict({})
-        fields = ["expression", "pars", "errs"]
-        for hpge, meta in aoeres_pars_dict.items():
-            out_dict[hpge] = {f: meta[f] for f in fields}
-
-        dbetto.utils.write_dict(out_dict.to_dict(), output.aoeresmod_file)
-
-        aoecuts_pars_dict = hpge_pars.lookup_psd_cut_values(
-            l200data,
-            config.metadata,
-            wildcards.runid,
-            hit_tier_name=hit_tier_name,
-            pars_db=pars_db,
-        )
-
-        dbetto.utils.write_dict(aoecuts_pars_dict, output.psdcuts_file)
+    log:
+        patterns.log_eresmod_filename(config),
+    script:
+        "../src/legendsimflow/scripts/pars/extract_hpge_observables_models.py"

--- a/workflow/src/legendsimflow/hpge_pars.py
+++ b/workflow/src/legendsimflow/hpge_pars.py
@@ -999,6 +999,27 @@ def build_energy_res_func(function: str) -> Callable:
     raise NotImplementedError
 
 
+def build_energy_res_func_from_entry(meta: dict | AttrsDict) -> Callable:
+    """Build a bound energy resolution callable from a single metadata entry.
+
+    Parameters
+    ----------
+    meta
+        A single detector's energy resolution metadata, with keys ``expression``
+        and ``parameters``. Same format as one value from
+        :func:`lookup_energy_res_metadata`.
+
+    Returns
+    -------
+    Callable that takes energy in keV and returns FWHM in keV.
+    """
+    if not isinstance(meta, AttrsDict):
+        meta = AttrsDict(meta)
+    func = build_energy_res_func(meta.expression)
+    base = functools.partial(func, **meta.parameters.to_dict())
+    return lambda E, base=base: base(E)
+
+
 def build_aoe_res_func(function: str) -> Callable:
     """A/E resolution function builder."""
     if function == "SigmaFit":

--- a/workflow/src/legendsimflow/metadata.py
+++ b/workflow/src/legendsimflow/metadata.py
@@ -247,7 +247,15 @@ def reference_cal_run(metadata: LegendMetadata, runid: str) -> str:
             return f"{exp}-{period}-{prev_r}-cal"
 
 
-def simpars(metadata: LegendMetadata, par: str, runid: str) -> AttrsDict:
+_MISSING = object()
+
+
+def simpars(
+    metadata: LegendMetadata,
+    par: str,
+    runid: str,
+    default: object = _MISSING,
+) -> AttrsDict:
     """Extract simflow parameters for a certain LEGEND run.
 
     Queries the simflow parameters database stored under
@@ -264,12 +272,22 @@ def simpars(metadata: LegendMetadata, par: str, runid: str) -> AttrsDict:
         allowed separators.
     runid
         a run identifier in the format ``<experiment>-<period>-<run>-<datatype>``.
+    default
+        value to return when the parameter directory is not found in the
+        database or no validity entry matches `runid`. If not provided, such
+        cases raise ``KeyError`` or ``LookupError``. Other errors (e.g.
+        malformed YAML) are always re-raised regardless of this argument.
 
     """
     par = par.replace(".", "/")
     datatype = re.split(r"\W+", runid)[-1]
-    directory = metadata["simprod/config/pars"][par]
-    return directory.on(runinfo(metadata, runid).start_key, system=datatype)
+    try:
+        directory = metadata["simprod/config/pars"][par]
+        return directory.on(runinfo(metadata, runid).start_key, system=datatype)
+    except (KeyError, LookupError, FileNotFoundError):
+        if default is _MISSING:
+            raise
+        return default
 
 
 def get_vtx_simconfig(config: SimflowConfig, simid: str) -> AttrsDict:

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -331,6 +331,12 @@ def plot_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
 # hpge energy resolution
 
 
+def log_eresmod_filename(config: SimflowConfig, **kwargs) -> Path:
+    """The log file path for HPGe observables model extraction for a `runid`."""
+    pat = log_dirname(config) / "hpge/eresmod/{runid}-model.log"
+    return _expand(pat, **kwargs)
+
+
 def output_eresmod_filename(config: SimflowConfig, **kwargs) -> Path:
     """The path to the HPGe energy resolution model parameter file for a `runid`."""
     return _expand(

--- a/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
+++ b/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
@@ -1,0 +1,174 @@
+# ruff: noqa: I002
+
+# Copyright (C) 2025 Luigi Pertoldi <gipert@pm.me>,
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+
+import dbetto
+import legenddataflowscripts as ldfs
+import legenddataflowscripts.utils
+from snakemake_argparse_bridge import snakemake_compatible
+
+from legendsimflow import hpge_pars, utils
+from legendsimflow import metadata as mutils
+from legendsimflow.scripts import log_script_invocation
+
+
+@snakemake_compatible(
+    mapping={
+        "runid": "wildcards.runid",
+        "eresmod_file": "output.eresmod_file",
+        "aoeresmod_file": "output.aoeresmod_file",
+        "psdcuts_file": "output.psdcuts_file",
+        "log_file": "log[0]",
+        "simflow_config": "config",
+    }
+)
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract HPGe observable models for a LEGEND run."
+    )
+    parser.add_argument(
+        "--runid",
+        required=True,
+        help="LEGEND run identifier (e.g. l200-p03-r000-phy)",
+    )
+    parser.add_argument(
+        "--eresmod-file",
+        required=True,
+        help="output YAML file for energy resolution model parameters",
+    )
+    parser.add_argument(
+        "--aoeresmod-file",
+        required=True,
+        help="output YAML file for A/E resolution model parameters",
+    )
+    parser.add_argument(
+        "--psdcuts-file",
+        required=True,
+        help="output YAML file for PSD cut values",
+    )
+    parser.add_argument("--log-file", default=None, help="log file")
+    parser.add_argument(
+        "--simflow-config",
+        "--config",
+        dest="simflow_config",
+        required=True,
+        help="simflow config YAML path",
+    )
+    args = parser.parse_args()
+
+    config = utils.init_simflow_context(args.simflow_config, workflow=None).config
+    metadata = config.metadata
+
+    log = ldfs.utils.build_log(metadata.simprod.config.logging, args.log_file)
+    log_script_invocation(log, "extract-hpge-obs-models", parser, args)
+
+    runid = args.runid
+    l200data = config.paths.get("l200data", None)
+
+    # --- energy resolution model ---
+    # Collection step: gather what is available; completeness checked in hit.py.
+    # Behaviour depends on simprod/config/pars/geds/eresmod/:
+    #  - absent: use l200data only
+    #  - present, no "default": l200data base + per-detector overrides
+    #  - present, with "default": expand all channelmap geds detectors;
+    #    l200data not consulted
+    raw = mutils.simpars(metadata, "geds.eresmod", runid, default=None)
+    default_entry = raw.get("default", None) if raw is not None else None
+
+    if default_entry is not None:
+        # metadata with default: expand all channelmap geds detectors
+        msg = f"using eresmod defaults from simprod/config/pars for {runid}"
+        log.info(msg)
+        tstamp = mutils.runinfo(metadata, runid).start_key
+        chmap = metadata.channelmap(tstamp, skip_version_check=True)
+        eresmod_dict = {
+            name: raw.get(name, default_entry).to_dict()
+            for name, info in chmap.items()
+            if getattr(info, "system", None) == "geds"
+        }
+        dbetto.utils.write_dict(eresmod_dict, args.eresmod_file)
+    else:
+        # l200data base (always), then apply per-detector metadata overrides if any
+        if l200data is None:
+            msg = (
+                "l200data is not configured and no eresmod metadata with a 'default' "
+                "key was found — cannot extract energy resolution model"
+            )
+            raise RuntimeError(msg)
+        msg = f"extracting eresmod from l200data for {runid}"
+        log.info(msg)
+        hit_tier_name = utils.get_hit_tier_name(l200data)
+        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
+
+        eres_pars_dict = hpge_pars.lookup_energy_res_metadata(
+            l200data,
+            metadata,
+            runid,
+            hit_tier_name=hit_tier_name,
+            pars_db=pars_db,
+        )
+
+        out_dict = dbetto.AttrsDict({})
+        fields = ["expression", "parameters", "uncertainties"]
+        for hpge, meta in eres_pars_dict.items():
+            out_dict[hpge] = {f: meta[f] for f in fields}
+
+        if raw is not None:
+            msg = "applying per-detector eresmod overrides from simprod/config/pars"
+            log.info(msg)
+            for hpge, meta in raw.items():
+                out_dict[hpge] = meta.to_dict()
+
+        dbetto.utils.write_dict(out_dict.to_dict(), args.eresmod_file)
+
+    # --- A/E resolution model and PSD cuts (l200data only for now) ---
+    hit_tier_name = utils.get_hit_tier_name(l200data)
+    pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
+
+    msg = f"extracting aoeresmod from l200data for {runid}"
+    log.info(msg)
+    aoeres_pars_dict = hpge_pars.lookup_aoe_res_metadata(
+        l200data,
+        metadata,
+        runid,
+        hit_tier_name=hit_tier_name,
+        pars_db=pars_db,
+    )
+
+    out_dict = dbetto.AttrsDict({})
+    fields = ["expression", "pars", "errs"]
+    for hpge, meta in aoeres_pars_dict.items():
+        out_dict[hpge] = {f: meta[f] for f in fields}
+
+    dbetto.utils.write_dict(out_dict.to_dict(), args.aoeresmod_file)
+
+    msg = f"extracting PSD cut values from l200data for {runid}"
+    log.info(msg)
+    aoecuts_pars_dict = hpge_pars.lookup_psd_cut_values(
+        l200data,
+        metadata,
+        runid,
+        hit_tier_name=hit_tier_name,
+        pars_db=pars_db,
+    )
+
+    dbetto.utils.write_dict(aoecuts_pars_dict, args.psdcuts_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -55,18 +55,20 @@ hpge_currmods_files = args.input.hpge_currmods
 # hpge_aoeresmods_files = args.input.hpge_aoeresmods
 # hpge_psdcuts_files = args.input.hpge_psdcuts
 simstat_part_file = args.input.simstat_part_file
-l200data = args.config.paths.l200data
+l200data = args.config.paths.get("l200data", None)
 usabilities = AttrsDict(load_dict(args.input.detector_usabilities[0]))
+
+# default energy resolution for non-ON detectors, sourced from hit tier settings
+tier_hit_settings = metadata.simprod.config.tier.hit[args.config.experiment].settings
+eresmod_default = hpge_pars.build_energy_res_func_from_entry(
+    tier_hit_settings.eresmod_default
+)
 
 hit_file, move2cfs = nersc.make_on_scratch(args.config, hit_file)
 
 BUFFER_LEN = "500*MB"
 
 u = pint.UnitRegistry()
-
-
-def DEFAULT_ENERGY_RES_FUNC(energy):
-    return 2.5 * np.sqrt(energy / 2039)  # FWHM
 
 
 def DEFAULT_AoE_RES_FUNC(energy):
@@ -277,8 +279,9 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
             edep_active = chunk.edep * _activeness
             energy_true = ak.sum(edep_active, axis=-1)
 
-            # pars strategy: complain if detector is ON and there are no pars
-            # otherwise use defaults and warn
+            # Validation counterpart to the collection in
+            # extract_hpge_observables_models: ON detectors must have curves
+            # (hard error); others fall back to eresmod_default (soft warning).
             # TODO: move to a separate function to clean up
 
             if det_name in energy_res_func:
@@ -294,10 +297,10 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                 msg = (
                     f"{det_name} is marked as '{usability}' and no "
                     "energy resolution curves are available. "
-                    "using default values"
+                    "using eresmod_default from hit tier settings"
                 )
                 log.warning(msg)
-                energy_res = DEFAULT_ENERGY_RES_FUNC(energy_true)
+                energy_res = eresmod_default(energy_true)
 
             if det_name in aoe_res_func:
                 aoe_res = aoe_res_func[det_name](energy_true)


### PR DESCRIPTION
## Summary

- Add support for configuring HPGe energy resolution model parameters directly in \`simprod/config/pars/geds/eresmod/\` using the same validity-based format as \`pars/geds/opv/\`. When present, these files can supplement or fully replace \`l200data\` as the source of energy resolution parameters — enabling simulations for experiments that have not yet collected data (e.g. LEGEND-1000).
- Refactor \`extract_hpge_observables_models\` from an inline Snakemake \`run:\` block into a standalone script with \`snakemake_argparse_bridge\`, independently invocable via a new \`extract-hpge-obs-models\` pixi task.
- Replace the hardcoded \`DEFAULT_ENERGY_RES_FUNC\` fallback in \`hit.py\` with \`eresmod_default\` from \`simprod/config/tier/hit/{experiment}/settings.yaml\`, making the non-ON detector fallback an explicit user choice.
- Add \`default=\` parameter to \`simpars()\` to return a value instead of raising when a par directory is not found, avoiding broad \`try/except\` blocks at call sites.
- Add a new \`pipeline.md\` docs page describing the behaviour of each pipeline step, with a dedicated section on the four HPGe energy resolution extraction scenarios.
- Make \`l200data\` optional throughout the hit-tier code path.

## Four extraction scenarios

The \`extract_hpge_observables_models\` rule is a *collection* step: it gathers what it can from the available sources and writes the result to disk. Completeness is validated downstream in \`build_tier_hit\`.

| | \`l200data\` | \`pars/geds/eresmod/\` | \`default\` key | Result |
|---|---|---|---|---|
| 1 | ✓ | — | — | everything available in \`l200data\` is collected |
| 2 | ✓ | ✓ | — | \`l200data\` base + per-detector overrides from metadata |
| 3 | ✓ | ✓ | ✓ | metadata expands all detectors from channelmap; \`l200data\` not consulted |
| 4 | — | ✓ | ✓ | fully metadata-driven; \`l200data\` not required |

Non-ON (\`off\`, \`ac\`) detectors fall back to \`eresmod_default\` from \`simprod/config/tier/hit/{experiment}/settings.yaml\` with a warning. This fallback is never triggered in cases 3 and 4, because all detectors are already covered.

## Follow-up

- Metadata-driven defaults for \`aoeresmod\` and \`psdcuts\` in a subsequent PR.

## Test plan

- [ ] \`pixi run test-python\` passes
- [ ] \`pre-commit run --all-files\` passes
- [ ] New tests cover: case 2 (l200data base + metadata overrides), case 3/4 (metadata with \`default\`), per-detector override, exact detector count (101 geds in p03 channelmap), \`simpars(default=)\` behaviour