### PR TITLE
feat: add gen_all_tier_par target rule for the par step

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -84,8 +84,10 @@ def gen_target_all():
             inputs.extend(rules.gen_all_tier_opt.input)
         elif step == "stp":
             inputs.extend(rules.gen_all_tier_stp.input)
-        elif step in ("vtx", "par"):
+        elif step == "vtx":
             pass
+        elif step == "par":
+            inputs.extend(rules.gen_all_tier_par.input)
 
     return inputs
 

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -18,6 +18,15 @@
 from legendsimflow import aggregate, hpge_pars, patterns
 
 
+rule gen_all_tier_par:
+    """Produce all `par` step outputs."""
+    input:
+        aggregate.gen_list_of_all_par_outputs(config),
+        lambda wc: aggregate.gen_list_of_all_plots_outputs(
+            config, tier="par", cache=smk_load_hpge_cache()
+        ),
+
+
 rule make_simstat_partition_file:
     """Create the simulation event statistics partitioning file.
 

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -85,6 +85,11 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str, **kw
         ]
     if tier == "stp":
         return [patterns.plot_tier_stp_vertices_filename(config, simid=simid)]
+    if tier == "par":
+        return [
+            *gen_list_of_dtmap_plots_outputs(config, simid, **kwargs),
+            *gen_list_of_currmod_plots_outputs(config, simid, **kwargs),
+        ]
     return []
 
 
@@ -448,6 +453,19 @@ def gen_list_of_psdcuts(config: SimflowConfig, simid: str) -> list[Path]:
         patterns.output_psdcuts_filename(config, runid=runid)
         for runid in get_runlist(config, simid)
     ]
+
+
+def gen_list_of_all_par_outputs(config: SimflowConfig) -> list[Path]:
+    """Generate the list of all (non-plot) ``par`` step output files in the Simflow."""
+    files: list[Path] = []
+    for simid in gen_list_of_all_simids(config):
+        files.append(patterns.simstat_part_filename(config, simid=simid))
+        files.extend(gen_list_of_merged_dtmaps(config, simid))
+        files.extend(gen_list_of_merged_currmods(config, simid))
+        files.extend(gen_list_of_eresmods(config, simid))
+        files.extend(gen_list_of_aoeresmods(config, simid))
+        files.extend(gen_list_of_psdcuts(config, simid))
+    return files
 
 
 # tier cvt


### PR DESCRIPTION
## Summary

- Add `gen_all_tier_par` aggregate rule in `par.smk`, analogous to `gen_all_tier_hit`, `gen_all_tier_stp`, etc. Its inputs are: simstat partition files, merged HPGe drift time maps, merged current pulse models, energy/A/E resolution models, PSD cut value files, and drift time map / current model validation plots.
- Wire the new rule into `gen_target_all()` in the Snakefile so `make_steps: [par]` (or any list including `par`) now includes par outputs in the default `all` target.
- Add `gen_list_of_all_par_outputs()` in `aggregate.py` to collect non-plot par outputs across all simids (resolved at parse time, no HPGe cache needed).
- Add a `par` branch to `gen_list_of_plots_outputs()` so that `gen_list_of_all_plots_outputs(config, tier="par", cache=...)` works naturally — the `archive_plots` rule picks up par plots for free.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `pixi run test-python` passes (197 tests)