### PR TITLE
feat: add metadata-driven aoeresmod and psdcuts defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,11 @@ repos:
         language: pygrep
         entry: PyBind|Cmake|CCache|Github|PyTest
         exclude: .pre-commit-config.yaml
+      - id: disallow-end-fence
+        name: "disallow ::: fences not on their own line"
+        language: pygrep
+        entry: "[^\\n]:*:::\\n|[^\\n]:*:::\\{"
+        types_or: [markdown]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: "v0.24.1"

--- a/docs/source/developer.md
+++ b/docs/source/developer.md
@@ -147,8 +147,8 @@ submitting a pull request.
 ### Documentation conventions
 
 - Pages are written in Markdown using [MyST](https://myst-parser.readthedocs.io)
-  syntax. Use colon-fence (`:::`) for Sphinx admonitions (e.g. `:::{note}`,
-  `:::{tip}`, `:::{warning}`).
+  syntax. Use colon-fence directives for Sphinx admonitions (`:::` + `{note}`,
+  `{tip}`, `{warning}`, etc.).
 - Use `console` as the language tag for shell commands (enables copy-button and
   consistent rendering).
 - Python docstrings follow the

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -362,10 +362,27 @@ eresmod_default:
   parameters:
     a: 0.5
     b: 0.001
+
+aoeresmod_default:
+  expression: SigmaFit
+  parameters:
+    a: 0.0001
+    b: 0
+    c: 1
+
+psdcuts_default:
+  aoe:
+    low_side: -1.5
+    high_side: 3
 ```
 
 - `eresmod_default` — energy resolution model applied to non-ON detectors. See
   {ref}`build-tier-hit-energy-resolution` for when this fallback is triggered.
+- `aoeresmod_default` — A/E resolution model applied to detectors without a
+  per-detector entry. See {ref}`build-tier-hit-psd` for when this fallback is
+  triggered.
+- `psdcuts_default` — PSD cut values applied to detectors without a per-detector
+  entry. See {ref}`build-tier-hit-psd` for when this fallback is triggered.
 
 ## `pars/` — simulation parameters
 
@@ -436,4 +453,78 @@ Each entry must contain:
 - `parameters` — mapping of parameter names to their values
 
 See {ref}`hpge-eresmod-extraction` for a description of how these files are used
+at runtime.
+
+(aoeresmod-metadata-dir)=
+
+### HPGe A/E resolution model defaults
+
+An optional validity-based metadata directory providing HPGe-specific A/E
+resolution parameters. Follows the same structure and three-case logic as
+{ref}`eresmod-metadata-dir`.
+
+```{code-block} yaml
+:caption: simprod/config/pars/geds/aoeresmod/l200-p03-r%-T%-all-aoeresmod.yaml
+
+default:
+  expression: SigmaFit
+  parameters:
+    a: 0.0001
+    b: 0
+    c: 1
+
+# optional per-detector override
+V02160A:
+  expression: SigmaFit
+  parameters:
+    a: 0.0002
+    b: 0
+    c: 1
+```
+
+- `default` _(optional)_ — A/E resolution model applied to all HPGe detectors
+  not listed explicitly.
+- `<detector>` _(optional)_ — per-detector override.
+
+Each entry must contain:
+
+- `expression` — name of the A/E resolution function (e.g. `SigmaFit`)
+- `parameters` — mapping of parameter names to their values
+
+See {ref}`hpge-aoeresmod-extraction` for a description of how these files are
+used at runtime.
+
+(psdcuts-metadata-dir)=
+
+### HPGe PSD cut value defaults
+
+An optional validity-based metadata directory providing HPGe-specific PSD cut
+values. Follows the same structure and three-case logic as
+{ref}`eresmod-metadata-dir`.
+
+```{code-block} yaml
+:caption: simprod/config/pars/geds/psdcuts/l200-p03-r%-T%-all-psdcuts.yaml
+
+default:
+  aoe:
+    low_side: -1.5
+    high_side: 3.0
+
+# optional per-detector override
+V02160A:
+  aoe:
+    low_side: -1.4
+    high_side: 2.9
+```
+
+- `default` _(optional)_ — PSD cut values applied to all HPGe detectors not
+  listed explicitly.
+- `<detector>` _(optional)_ — per-detector override.
+
+Each entry must contain:
+
+- `aoe.low_side` — lower A/E classifier cut (in units of A/E σ)
+- `aoe.high_side` — upper A/E classifier cut (in units of A/E σ)
+
+See {ref}`hpge-psdcuts-extraction` for a description of how these files are used
 at runtime.

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -377,12 +377,12 @@ psdcuts_default:
 ```
 
 - `eresmod_default` — energy resolution model applied to non-ON detectors. See
-  {ref}`build-tier-hit-energy-resolution` for when this fallback is triggered.
+  {ref}`build-tier-hit-hpge` for when this fallback is triggered.
 - `aoeresmod_default` — A/E resolution model applied to detectors without a
-  per-detector entry. See {ref}`build-tier-hit-psd` for when this fallback is
+  per-detector entry. See {ref}`build-tier-hit-hpge` for when this fallback is
   triggered.
 - `psdcuts_default` — PSD cut values applied to detectors without a per-detector
-  entry. See {ref}`build-tier-hit-psd` for when this fallback is triggered.
+  entry. See {ref}`build-tier-hit-hpge` for when this fallback is triggered.
 
 ## `pars/` — simulation parameters
 
@@ -460,7 +460,7 @@ at runtime.
 ### HPGe A/E resolution model defaults
 
 An optional validity-based metadata directory providing HPGe-specific A/E
-resolution parameters. Follows the same structure and three-case logic as
+resolution parameters. Follows the same structure and four-case logic as
 {ref}`eresmod-metadata-dir`.
 
 ```{code-block} yaml
@@ -499,7 +499,7 @@ used at runtime.
 ### HPGe PSD cut value defaults
 
 An optional validity-based metadata directory providing HPGe-specific PSD cut
-values. Follows the same structure and three-case logic as
+values. Follows the same structure and four-case logic as
 {ref}`eresmod-metadata-dir`.
 
 ```{code-block} yaml

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -127,15 +127,9 @@ Supported fields per `simid`:
   - formatted as `~defines:NAME`, where `NAME` is defined in
     {ref}`generators.yaml`.
   - formatted as `~vertices:NAME`, where `NAME` references a vertices simulation
-    from the `vtx` tier (see {ref}`vtx-tier-meta`).
-
-    :::{note}
-
-    If vertices are selected as generator, it means that they include vertex
-    position _and_ kinematics. In this situation, the `confinement` key (see
-    below) is forbidden.
-
-    :::
+    from the `vtx` tier (see {ref}`vtx-tier-meta`). When vertices are used as
+    the generator they carry vertex position _and_ kinematics, so the
+    `confinement` key (see below) is forbidden.
 
 - `confinement` — one of:
   - `~defines:NAME` to reference a confinement block in {ref}`confinement.yaml`
@@ -386,7 +380,7 @@ psdcuts_default:
 
 ## `pars/` — simulation parameters
 
-### `simprod/config/pars/geds/dtmap/settings.yaml` — drift time map simulation parameters
+### HPGe drift time map simulation parameters
 
 A single shared YAML file (applies to all detectors and voltages) that overrides
 simulation control parameters for the
@@ -407,13 +401,13 @@ padding: 3
 | `ssd_refinement_limits` | list of float | `[0.2, 0.1, 0.05, 0.02]` | SSD adaptive-mesh refinement thresholds. Each entry drives one refinement pass; smaller values give a more accurate electric field at higher cost. **Overly coarse values can prevent full detector depletion — change with care.** |
 | `padding`               | int           | `3`                      | Number of pixel layers padded around the drift time map boundary to avoid grid edge effects.                                                                                                                                        |
 
-::::{tip}
+:::{tip}
 
 In test or CI environments, setting `grid_size_in_mm: 10.0` reduces the number
 of grid points by a factor of ~400 compared to the 0.5 mm production default,
 cutting script runtime from many minutes to seconds.
 
-::::
+:::
 
 (eresmod-metadata-dir)=
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -45,6 +45,36 @@ The exact sources used depend on what is configured:
 4. **HPGe-specific overrides with a `default` key, no `l200data`** — same as
    case 3. `l200data` is not required.
 
+(hpge-aoeresmod-extraction)=
+
+### HPGe A/E resolution (`extract_hpge_observables_models`)
+
+The same rule produces a per-detector YAML file for the A/E resolution model,
+following the same three-case logic as {ref}`hpge-eresmod-extraction`:
+
+1. **`l200data` only, no HPGe-specific overrides** — everything available in
+   `l200data` is collected, independent of detector status.
+
+2. **`l200data` + HPGe-specific overrides in {ref}`aoeresmod-metadata-dir`, no
+   `default` key** — everything available in `l200data` is collected as in case
+   1; the explicitly listed detectors are then overridden.
+
+3. **`l200data` + HPGe-specific overrides with a `default` key** — the metadata
+   takes over entirely: every HPGe detector in the channel map is expanded from
+   the `default` (with optional per-detector overrides). `l200data` is not
+   consulted.
+
+4. **HPGe-specific overrides with a `default` key, no `l200data`** — same as
+   case 3. `l200data` is not required.
+
+(hpge-psdcuts-extraction)=
+
+### HPGe PSD cuts (`extract_hpge_observables_models`)
+
+The same rule produces a per-detector YAML file for the PSD cut values,
+following the same three-case logic. See {ref}`aoeresmod-metadata-dir` and
+{ref}`psdcuts-metadata-dir` for the metadata format.
+
 ## `opt` — optical hit building
 
 :::{todo} Document the optical hit building step. :::
@@ -65,6 +95,17 @@ needed detectors are covered:
   {ref}`hit-tier-settings` with a warning. This fallback is never triggered when
   a `default` key is present in the eresmod metadata (cases 3 and 4 above),
   because all detectors are already covered.
+
+(build-tier-hit-psd)=
+
+### A/E resolution and PSD cuts (`build_tier_hit`)
+
+`build_tier_hit` applies A/E smearing and evaluates PSD classifiers using the
+per-run YAML files produced in the `par` step. Missing entries fall back to
+`aoeresmod_default` and `psdcuts_default` from {ref}`hit-tier-settings` with a
+warning. As with energy resolution, these fallbacks are never triggered when a
+`default` key is present in the corresponding metadata (cases 3 and 4 in
+{ref}`hpge-aoeresmod-extraction`).
 
 ## `evt` — event building
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -26,7 +26,7 @@ The `extract_hpge_observables_models` rule produces a per-detector YAML file
 mapping each HPGe detector to its energy resolution model. It is a _collection_
 step: it gathers what it can from the available sources and writes the result to
 disk. Completeness is validated downstream in `build_tier_hit` (see
-{ref}`build-tier-hit-energy-resolution`).
+{ref}`build-tier-hit-hpge`).
 
 The exact sources used depend on what is configured:
 
@@ -50,30 +50,16 @@ The exact sources used depend on what is configured:
 ### HPGe A/E resolution (`extract_hpge_observables_models`)
 
 The same rule produces a per-detector YAML file for the A/E resolution model,
-following the same three-case logic as {ref}`hpge-eresmod-extraction`:
-
-1. **`l200data` only, no HPGe-specific overrides** — everything available in
-   `l200data` is collected, independent of detector status.
-
-2. **`l200data` + HPGe-specific overrides in {ref}`aoeresmod-metadata-dir`, no
-   `default` key** — everything available in `l200data` is collected as in case
-   1; the explicitly listed detectors are then overridden.
-
-3. **`l200data` + HPGe-specific overrides with a `default` key** — the metadata
-   takes over entirely: every HPGe detector in the channel map is expanded from
-   the `default` (with optional per-detector overrides). `l200data` is not
-   consulted.
-
-4. **HPGe-specific overrides with a `default` key, no `l200data`** — same as
-   case 3. `l200data` is not required.
+following the same four-case logic as {ref}`hpge-eresmod-extraction`. The
+metadata directory is described in {ref}`aoeresmod-metadata-dir`.
 
 (hpge-psdcuts-extraction)=
 
 ### HPGe PSD cuts (`extract_hpge_observables_models`)
 
 The same rule produces a per-detector YAML file for the PSD cut values,
-following the same three-case logic. See {ref}`aoeresmod-metadata-dir` and
-{ref}`psdcuts-metadata-dir` for the metadata format.
+following the same four-case logic as {ref}`hpge-eresmod-extraction`. The
+metadata directory is described in {ref}`psdcuts-metadata-dir`.
 
 ## `opt` — optical hit building
 
@@ -81,31 +67,29 @@ following the same three-case logic. See {ref}`aoeresmod-metadata-dir` and
 
 ## `hit` — hit tier building
 
-(build-tier-hit-energy-resolution)=
+(build-tier-hit-hpge)=
 
-### Energy resolution (`build_tier_hit`)
+### HPGe observable validation (`build_tier_hit`)
 
-`build_tier_hit` applies energy resolution smearing to each simulated detector.
-It reads the per-detector file produced in the `par` step and validates that all
-needed detectors are covered:
+`build_tier_hit` reads the per-detector YAML files produced in the `par` step
+and validates that every simulated detector has the parameters it needs. The
+hard-error vs. fallback policy differs slightly per observable:
 
-- **ON detectors** must always have a curve — a missing entry raises a hard
-  error.
-- **`off` and `ac` detectors** fall back to `eresmod_default` from
-  {ref}`hit-tier-settings` with a warning. This fallback is never triggered when
-  a `default` key is present in the eresmod metadata (cases 3 and 4 above),
-  because all detectors are already covered.
+| Observable        | Hard error                                                 | Fallback (+ warning) | Fallback key        |
+| ----------------- | ---------------------------------------------------------- | -------------------- | ------------------- |
+| Energy resolution | ON detector missing entry                                  | `off`/`ac` detector  | `eresmod_default`   |
+| A/E resolution    | ON detector with `psd_usability ≠ "missing"` missing entry | all other cases      | `aoeresmod_default` |
+| PSD cuts          | ON detector with `psd_usability ≠ "missing"` missing entry | all other cases      | `psdcuts_default`   |
 
-(build-tier-hit-psd)=
+The fallback keys are read from {ref}`hit-tier-settings`. They are never
+triggered when a `default` key is present in the corresponding metadata (cases 3
+and 4 of the extraction steps above), because all detectors are already covered
+in that case.
 
-### A/E resolution and PSD cuts (`build_tier_hit`)
-
-`build_tier_hit` applies A/E smearing and evaluates PSD classifiers using the
-per-run YAML files produced in the `par` step. Missing entries fall back to
-`aoeresmod_default` and `psdcuts_default` from {ref}`hit-tier-settings` with a
-warning. As with energy resolution, these fallbacks are never triggered when a
-`default` key is present in the corresponding metadata (cases 3 and 4 in
-{ref}`hpge-aoeresmod-extraction`).
+:::{note} An ON detector with `psd_usability = "missing"` explicitly signals
+that PSD data are unavailable for that detector (e.g. a known hardware issue).
+It is therefore acceptable to fall back to the default A/E resolution and PSD
+cuts for such detectors rather than raising a hard error. :::
 
 ## `evt` — event building
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -5,11 +5,19 @@ the metadata and configuration described in [](meta.md).
 
 ## `vtx` — event vertex generation
 
-:::{todo} Document the vertex generation step. :::
+:::{todo}
+
+Document the vertex generation step.
+
+:::
 
 ## `stp` — particle simulation
 
-:::{todo} Document the remage simulation step. :::
+:::{todo}
+
+Document the remage simulation step.
+
+:::
 
 ## `par` — parameter extraction
 
@@ -63,7 +71,11 @@ metadata directory is described in {ref}`psdcuts-metadata-dir`.
 
 ## `opt` — optical hit building
 
-:::{todo} Document the optical hit building step. :::
+:::{todo}
+
+Document the optical hit building step.
+
+:::
 
 ## `hit` — hit tier building
 
@@ -86,19 +98,35 @@ triggered when a `default` key is present in the corresponding metadata (cases 3
 and 4 of the extraction steps above), because all detectors are already covered
 in that case.
 
-:::{note} An ON detector with `psd_usability = "missing"` explicitly signals
-that PSD data are unavailable for that detector (e.g. a known hardware issue).
-It is therefore acceptable to fall back to the default A/E resolution and PSD
-cuts for such detectors rather than raising a hard error. :::
+:::{note}
+
+An ON detector with `psd_usability = "missing"` explicitly signals that PSD data
+are unavailable for that detector (e.g. a known hardware issue). It is therefore
+acceptable to fall back to the default A/E resolution and PSD cuts for such
+detectors rather than raising a hard error.
+
+:::
 
 ## `evt` — event building
 
-:::{todo} Document the event building step. :::
+:::{todo}
+
+Document the event building step.
+
+:::
 
 ## `cvt` — event concatenation
 
-:::{todo} Document the event concatenation step. :::
+:::{todo}
+
+Document the event concatenation step.
+
+:::
 
 ## `pdf` — PDF generation
 
-:::{todo} Document the PDF generation step. :::
+:::{todo}
+
+Document the PDF generation step.
+
+:::

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/l200-p02-r%-T%-all-aoeresmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/l200-p02-r%-T%-all-aoeresmod.yaml
@@ -1,0 +1,6 @@
+V02160A:
+  expression: SigmaFit
+  parameters:
+    a: 0.0002
+    b: 0
+    c: 1

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/l200-p03-r%-T%-all-aoeresmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/l200-p03-r%-T%-all-aoeresmod.yaml
@@ -1,0 +1,12 @@
+default:
+  expression: SigmaFit
+  parameters:
+    a: 0.0001
+    b: 0
+    c: 1
+V02160A:
+  expression: SigmaFit
+  parameters:
+    a: 0.0002
+    b: 0
+    c: 1

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/aoeresmod/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-aoeresmod.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-aoeresmod.yaml

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/l200-p02-r%-T%-all-psdcuts.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/l200-p02-r%-T%-all-psdcuts.yaml
@@ -1,0 +1,4 @@
+V02160A:
+  aoe:
+    low_side: -1.4
+    high_side: 2.9

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/l200-p03-r%-T%-all-psdcuts.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/l200-p03-r%-T%-all-psdcuts.yaml
@@ -1,0 +1,8 @@
+default:
+  aoe:
+    low_side: -1.5
+    high_side: 3.0
+V02160A:
+  aoe:
+    low_side: -1.4
+    high_side: 2.9

--- a/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/geds/psdcuts/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-psdcuts.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-psdcuts.yaml

--- a/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
@@ -3,3 +3,15 @@ eresmod_default:
   parameters:
     a: 0.5
     b: 0.001
+
+aoeresmod_default:
+  expression: SigmaFit
+  parameters:
+    a: 0.0001
+    b: 0
+    c: 1
+
+psdcuts_default:
+  aoe:
+    low_side: -1.5
+    high_side: 3

--- a/tests/scripts/test_extract_hpge_observables_models.py
+++ b/tests/scripts/test_extract_hpge_observables_models.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from dbetto import AttrsDict
 
 from legendsimflow.scripts.pars import extract_hpge_observables_models
 
@@ -40,13 +41,13 @@ RUNID = RUNID_P03
 _FAKE_L200DATA_AOERESMOD = {
     "V05261A": {
         "expression": "SigmaFit",
-        "pars": {"a": 0.0003, "b": 0, "c": 1},
-        "errs": {},
+        "parameters": {"a": 0.0003, "b": 0, "c": 1},
+        "uncertainties": {},
     },
     "V02160A": {
         "expression": "SigmaFit",
-        "pars": {"a": 0.0004, "b": 0, "c": 1},
-        "errs": {},
+        "parameters": {"a": 0.0004, "b": 0, "c": 1},
+        "uncertainties": {},
     },
 }
 
@@ -384,3 +385,72 @@ def test_extract_psdcuts_l200data_with_overrides(tmp_path, monkeypatch):
     # V02160A: in metadata overrides — must be replaced by metadata values (low_side=-1.4)
     assert "V02160A" in result, "V02160A must be present (overridden by metadata)"
     assert result["V02160A"]["aoe"]["low_side"] == pytest.approx(-1.4)
+
+
+# ---------------------------------------------------------------------------
+# Error-path tests: no l200data and no metadata default
+# ---------------------------------------------------------------------------
+
+
+def _make_eresmod_default():
+    return AttrsDict(
+        {
+            "default": AttrsDict(
+                {
+                    "expression": "FWHMLinear",
+                    "parameters": AttrsDict({"a": 0.5, "b": 0.001}),
+                }
+            )
+        }
+    )
+
+
+def _make_aoeresmod_default():
+    return AttrsDict(
+        {
+            "default": AttrsDict(
+                {
+                    "expression": "SigmaFit",
+                    "parameters": AttrsDict({"a": 0.0001, "b": 0, "c": 1}),
+                }
+            )
+        }
+    )
+
+
+def test_extract_aoeresmod_raises_without_l200data_and_default(tmp_path, monkeypatch):
+    """RuntimeError when l200data is absent and no aoeresmod 'default' key exists."""
+    monkeypatch.setattr(
+        sys, "argv", _build_argv(tmp_path, runid=RUNID_P03, l200data=None)
+    )
+
+    def _simpars(_metadata, par, _runid, **_kw):
+        if par == "geds.eresmod":
+            return _make_eresmod_default()
+        return None
+
+    with (
+        patch("legendsimflow.metadata.simpars", side_effect=_simpars),
+        pytest.raises(RuntimeError, match="aoeresmod"),
+    ):
+        extract_hpge_observables_models.main()
+
+
+def test_extract_psdcuts_raises_without_l200data_and_default(tmp_path, monkeypatch):
+    """RuntimeError when l200data is absent and no psdcuts 'default' key exists."""
+    monkeypatch.setattr(
+        sys, "argv", _build_argv(tmp_path, runid=RUNID_P03, l200data=None)
+    )
+
+    def _simpars(_metadata, par, _runid, **_kw):
+        if par == "geds.eresmod":
+            return _make_eresmod_default()
+        if par == "geds.aoeresmod":
+            return _make_aoeresmod_default()
+        return None
+
+    with (
+        patch("legendsimflow.metadata.simpars", side_effect=_simpars),
+        pytest.raises(RuntimeError, match="psdcuts"),
+    ):
+        extract_hpge_observables_models.main()

--- a/tests/scripts/test_extract_hpge_observables_models.py
+++ b/tests/scripts/test_extract_hpge_observables_models.py
@@ -37,6 +37,25 @@ _FAKE_L200DATA_ERESMOD = {
 RUNID = RUNID_P03
 
 
+_FAKE_L200DATA_AOERESMOD = {
+    "V05261A": {
+        "expression": "SigmaFit",
+        "pars": {"a": 0.0003, "b": 0, "c": 1},
+        "errs": {},
+    },
+    "V02160A": {
+        "expression": "SigmaFit",
+        "pars": {"a": 0.0004, "b": 0, "c": 1},
+        "errs": {},
+    },
+}
+
+_FAKE_L200DATA_PSDCUTS = {
+    "V05261A": {"aoe": {"low_side": -2.0, "high_side": 4.0}},
+    "V02160A": {"aoe": {"low_side": -1.9, "high_side": 3.9}},
+}
+
+
 def _build_argv(
     tmp_path: Path, runid: str = RUNID_P03, l200data: str | None = None
 ) -> list[str]:
@@ -68,14 +87,25 @@ def _run_with_mocks(
     monkeypatch,
     runid: str = RUNID_P03,
     l200data: str | None = None,
-) -> Path:
+    fake_aoeresmod: dict | None = None,
+    fake_psdcuts: dict | None = None,
+) -> tuple[Path, Path, Path]:
     """Patch sys.argv and the l200data-dependent helpers, then call main().
 
-    The eresmod path is exercised via metadata; the aoeresmod and psdcuts
+    Returns a tuple of (eresmod_file, aoeresmod_file, psdcuts_file) paths.
+
+    The eresmod path is exercised via metadata; by default aoeresmod and psdcuts
     paths are short-circuited by returning empty dicts so no l200data is needed.
-    Pass a non-None `l200data` to exercise the l200data extraction path (the
-    actual extraction is still mocked via lookup_energy_res_metadata).
+    Pass ``fake_aoeresmod`` or ``fake_psdcuts`` to control what the l200data
+    lookup mocks return (used when testing the l200data extraction path).
+    Pass a non-None ``l200data`` to exercise the l200data extraction path (the
+    actual extraction is still mocked via the lookup_* helpers).
     """
+    if fake_aoeresmod is None:
+        fake_aoeresmod = {}
+    if fake_psdcuts is None:
+        fake_psdcuts = {}
+
     monkeypatch.setattr(
         sys, "argv", _build_argv(tmp_path, runid=runid, l200data=l200data)
     )
@@ -95,21 +125,25 @@ def _run_with_mocks(
         ),
         patch(
             "legendsimflow.hpge_pars.lookup_aoe_res_metadata",
-            return_value={},
+            return_value=fake_aoeresmod,
         ),
         patch(
             "legendsimflow.hpge_pars.lookup_psd_cut_values",
-            return_value={},
+            return_value=fake_psdcuts,
         ),
     ):
         extract_hpge_observables_models.main()
 
-    return tmp_path / "eresmod.yaml"
+    return (
+        tmp_path / "eresmod.yaml",
+        tmp_path / "aoeresmod.yaml",
+        tmp_path / "psdcuts.yaml",
+    )
 
 
 def test_extract_eresmod_from_metadata(tmp_path, monkeypatch):
     """Metadata-driven path: eresmod.yaml must be expanded to per-detector entries."""
-    eresmod_file = _run_with_mocks(tmp_path, monkeypatch)
+    eresmod_file, _aoe, _psd = _run_with_mocks(tmp_path, monkeypatch)
 
     assert eresmod_file.exists(), "eresmod output file was not created"
 
@@ -148,7 +182,7 @@ def test_extract_eresmod_from_metadata(tmp_path, monkeypatch):
 
 def test_extract_eresmod_per_detector_count(tmp_path, monkeypatch):
     """Metadata-driven path: one output entry per geds detector in the p03 channelmap."""
-    eresmod_file = _run_with_mocks(tmp_path, monkeypatch)
+    eresmod_file, _aoe, _psd = _run_with_mocks(tmp_path, monkeypatch)
 
     with eresmod_file.open() as f:
         result = yaml.safe_load(f)
@@ -165,7 +199,7 @@ def test_extract_eresmod_l200data_with_overrides(tmp_path, monkeypatch):
     mocked to return V05261A and V02160A. The output must contain both detectors,
     with V02160A replaced by the metadata value and V05261A kept from l200data.
     """
-    eresmod_file = _run_with_mocks(
+    eresmod_file, _aoe, _psd = _run_with_mocks(
         tmp_path, monkeypatch, runid=RUNID_P02, l200data="/fake/l200data"
     )
 
@@ -184,3 +218,169 @@ def test_extract_eresmod_l200data_with_overrides(tmp_path, monkeypatch):
     assert "V02160A" in result, "V02160A must be present (overridden by metadata)"
     assert result["V02160A"]["parameters"]["a"] == pytest.approx(0.3)
     assert result["V02160A"]["parameters"]["b"] == pytest.approx(0.0009)
+
+
+# ---------------------------------------------------------------------------
+# A/E resolution model (aoeresmod) tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_aoeresmod_from_metadata(tmp_path, monkeypatch):
+    """Metadata-driven path: aoeresmod.yaml must be expanded to per-detector entries."""
+    _eres, aoeresmod_file, _psd = _run_with_mocks(tmp_path, monkeypatch)
+
+    assert aoeresmod_file.exists(), "aoeresmod output file was not created"
+
+    with aoeresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "aoeresmod output must be a YAML mapping"
+
+    # "default" key must NOT appear in the expanded per-detector output
+    assert "default" not in result, "aoeresmod output must not contain a 'default' key"
+
+    # every per-detector entry must carry expression and parameters with a, b, c
+    for det, entry in result.items():
+        assert "expression" in entry, f"{det}: missing 'expression'"
+        assert "parameters" in entry, f"{det}: missing 'parameters'"
+        assert "a" in entry["parameters"], f"{det}: missing parameter 'a'"
+
+    # the per-detector override for V02160A must win over the default (a=0.0001)
+    assert "V02160A" in result, "V02160A must be present in the aoeresmod output"
+    assert result["V02160A"]["parameters"]["a"] == pytest.approx(0.0002)
+
+    # at least one other geds detector must carry the default values (a=0.0001)
+    default_detectors = [
+        det
+        for det, entry in result.items()
+        if det != "V02160A" and entry["parameters"]["a"] == pytest.approx(0.0001)
+    ]
+    assert len(default_detectors) >= 1, (
+        "at least one geds detector must have the default a=0.0001"
+    )
+
+
+def test_extract_aoeresmod_per_detector_count(tmp_path, monkeypatch):
+    """Metadata-driven path: one output entry per geds detector in the p03 channelmap."""
+    _eres, aoeresmod_file, _psd = _run_with_mocks(tmp_path, monkeypatch)
+
+    with aoeresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert len(result) == N_GEDS_P03, (
+        f"expected {N_GEDS_P03} geds detectors in aoeresmod output, got {len(result)}"
+    )
+
+
+def test_extract_aoeresmod_l200data_with_overrides(tmp_path, monkeypatch):
+    """Case 2: l200data base + per-detector overrides from metadata (no 'default' key).
+
+    The p02 aoeresmod file has only a V02160A override. The l200data base is
+    mocked to return V05261A and V02160A. The output must contain both detectors,
+    with V02160A replaced by the metadata value (a=0.0002) and V05261A kept
+    from l200data (a=0.0003).
+    """
+    _, aoeresmod_file, _ = _run_with_mocks(
+        tmp_path,
+        monkeypatch,
+        runid=RUNID_P02,
+        l200data="/fake/l200data",
+        fake_aoeresmod=_FAKE_L200DATA_AOERESMOD,
+    )
+
+    with aoeresmod_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "aoeresmod output must be a YAML mapping"
+    assert "default" not in result, "aoeresmod output must not contain a 'default' key"
+
+    # V05261A: not in metadata overrides — must keep l200data values (a=0.0003)
+    assert "V05261A" in result, "V05261A must be present (from l200data base)"
+    assert result["V05261A"]["parameters"]["a"] == pytest.approx(0.0003)
+
+    # V02160A: in metadata overrides — must be replaced by metadata values (a=0.0002)
+    assert "V02160A" in result, "V02160A must be present (overridden by metadata)"
+    assert result["V02160A"]["parameters"]["a"] == pytest.approx(0.0002)
+
+
+# ---------------------------------------------------------------------------
+# PSD cut values (psdcuts) tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_psdcuts_from_metadata(tmp_path, monkeypatch):
+    """Metadata-driven path: psdcuts.yaml must be expanded to per-detector entries."""
+    _eres, _aoe, psdcuts_file = _run_with_mocks(tmp_path, monkeypatch)
+
+    assert psdcuts_file.exists(), "psdcuts output file was not created"
+
+    with psdcuts_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "psdcuts output must be a YAML mapping"
+
+    # "default" key must NOT appear in the expanded per-detector output
+    assert "default" not in result, "psdcuts output must not contain a 'default' key"
+
+    # every per-detector entry must carry an aoe sub-dict with low_side and high_side
+    for det, entry in result.items():
+        assert "aoe" in entry, f"{det}: missing 'aoe' key"
+        assert "low_side" in entry["aoe"], f"{det}: missing 'aoe.low_side'"
+        assert "high_side" in entry["aoe"], f"{det}: missing 'aoe.high_side'"
+
+    # the per-detector override for V02160A must win over the default (low_side=-1.5)
+    assert "V02160A" in result, "V02160A must be present in the psdcuts output"
+    assert result["V02160A"]["aoe"]["low_side"] == pytest.approx(-1.4)
+
+    # at least one other geds detector must carry the default values (low_side=-1.5)
+    default_detectors = [
+        det
+        for det, entry in result.items()
+        if det != "V02160A" and entry["aoe"]["low_side"] == pytest.approx(-1.5)
+    ]
+    assert len(default_detectors) >= 1, (
+        "at least one geds detector must have the default aoe.low_side=-1.5"
+    )
+
+
+def test_extract_psdcuts_per_detector_count(tmp_path, monkeypatch):
+    """Metadata-driven path: one output entry per geds detector in the p03 channelmap."""
+    _eres, _aoe, psdcuts_file = _run_with_mocks(tmp_path, monkeypatch)
+
+    with psdcuts_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert len(result) == N_GEDS_P03, (
+        f"expected {N_GEDS_P03} geds detectors in psdcuts output, got {len(result)}"
+    )
+
+
+def test_extract_psdcuts_l200data_with_overrides(tmp_path, monkeypatch):
+    """Case 2: l200data base + per-detector overrides from metadata (no 'default' key).
+
+    The p02 psdcuts file has only a V02160A override. The l200data base is
+    mocked to return V05261A and V02160A. The output must contain both detectors,
+    with V02160A replaced by the metadata value (low_side=-1.4) and V05261A kept
+    from l200data (low_side=-2.0).
+    """
+    _, _, psdcuts_file = _run_with_mocks(
+        tmp_path,
+        monkeypatch,
+        runid=RUNID_P02,
+        l200data="/fake/l200data",
+        fake_psdcuts=_FAKE_L200DATA_PSDCUTS,
+    )
+
+    with psdcuts_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert isinstance(result, dict), "psdcuts output must be a YAML mapping"
+    assert "default" not in result, "psdcuts output must not contain a 'default' key"
+
+    # V05261A: not in metadata overrides — must keep l200data values (low_side=-2.0)
+    assert "V05261A" in result, "V05261A must be present (from l200data base)"
+    assert result["V05261A"]["aoe"]["low_side"] == pytest.approx(-2.0)
+
+    # V02160A: in metadata overrides — must be replaced by metadata values (low_side=-1.4)
+    assert "V02160A" in result, "V02160A must be present (overridden by metadata)"
+    assert result["V02160A"]["aoe"]["low_side"] == pytest.approx(-1.4)

--- a/tests/test_hpge_pars.py
+++ b/tests/test_hpge_pars.py
@@ -401,7 +401,7 @@ def test_lookup_aoeres(config, test_l200data):
     for k, v in meta.items():
         assert isinstance(k, str)
         assert "expression" in v
-        assert "pars" in v
+        assert "parameters" in v
 
     meta = hpge_pars.lookup_aoe_res_metadata(
         test_l200data / "v3.0.0",
@@ -414,12 +414,21 @@ def test_lookup_aoeres(config, test_l200data):
     for k, v in meta.items():
         assert isinstance(k, str)
         assert "expression" in v
-        assert "pars" in v
+        assert "parameters" in v
 
 
 def test_aoeres_func():
     f = hpge_pars.build_aoe_res_func("SigmaFit")
     assert isinstance(f, Callable)
+
+
+def test_build_aoe_res_func_from_entry():
+    entry = {"expression": "SigmaFit", "parameters": {"a": 0.0001, "b": 0, "c": 1}}
+    f = hpge_pars.build_aoe_res_func_from_entry(entry)
+    assert isinstance(f, Callable)
+    # SigmaFit with b=0: sigma = sqrt(a) = sqrt(0.0001) = 0.01, constant across E
+    assert f(2039) == pytest.approx(0.01, abs=1e-6)
+    assert f(500) == pytest.approx(0.01, abs=1e-6)
 
 
 def test_build_aoeres_funcs(config, test_l200data):

--- a/workflow/src/legendsimflow/hpge_pars.py
+++ b/workflow/src/legendsimflow/hpge_pars.py
@@ -1028,6 +1028,26 @@ def build_aoe_res_func(function: str) -> Callable:
     raise NotImplementedError
 
 
+def build_aoe_res_func_from_entry(meta: dict | AttrsDict) -> Callable:
+    """Build a bound A/E resolution callable from a single metadata entry.
+
+    Parameters
+    ----------
+    meta
+        A single detector's A/E resolution metadata, with keys ``expression``
+        and ``parameters``.
+
+    Returns
+    -------
+    Callable that takes energy in keV and returns the A/E resolution (sigma).
+    """
+    if not isinstance(meta, AttrsDict):
+        meta = AttrsDict(meta)
+    func = build_aoe_res_func(meta.expression)
+    base = functools.partial(func, **meta.parameters.to_dict())
+    return lambda E, base=base: base(E)
+
+
 def build_energy_res_func_dict(
     l200data: str | Path,
     metadata: LegendMetadata,
@@ -1134,12 +1154,16 @@ def build_aoe_res_func_dict(
 
     aoe_res_sigma_func = {}
     for hpge, meta in aoe_res_pars.items():
+        # support both "parameters" (output file format) and "pars" (l200data format)
+        pars = meta.get("parameters", None) or meta.get("pars", None)
+        if not isinstance(pars, AttrsDict):
+            pars = AttrsDict(pars)
         # use functools.partial correctly freeze the parameters into the function
         base = functools.partial(
             _func_full,
-            a=meta.pars.a,
-            b=meta.pars.b,
-            c=meta.pars.c,
+            a=pars.a,
+            b=pars.b,
+            c=pars.c,
         )
 
         def _aoeres(E, base=base):

--- a/workflow/src/legendsimflow/hpge_pars.py
+++ b/workflow/src/legendsimflow/hpge_pars.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import functools
 import itertools
 import logging
+import math
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -984,7 +985,12 @@ def lookup_aoe_res_metadata(
         )
         par = _getpar(detmeta, "results.aoe.correction_fit_results.SigmaFits")
         if par is not None:
-            out_dict[hpge] = par
+            # normalise to "parameters"/"uncertainties" for consistency with eresmod
+            out_dict[hpge] = {
+                "expression": par["expression"],
+                "parameters": par["pars"],
+                "uncertainties": par.get("errs", {}),
+            }
 
     return AttrsDict(out_dict)
 
@@ -1154,16 +1160,12 @@ def build_aoe_res_func_dict(
 
     aoe_res_sigma_func = {}
     for hpge, meta in aoe_res_pars.items():
-        # support both "parameters" (output file format) and "pars" (l200data format)
-        pars = meta.get("parameters", None) or meta.get("pars", None)
-        if not isinstance(pars, AttrsDict):
-            pars = AttrsDict(pars)
         # use functools.partial correctly freeze the parameters into the function
         base = functools.partial(
             _func_full,
-            a=pars.a,
-            b=pars.b,
-            c=pars.c,
+            a=meta.parameters.a,
+            b=meta.parameters.b,
+            c=meta.parameters.c,
         )
 
         def _aoeres(E, base=base):
@@ -1220,11 +1222,14 @@ def lookup_psd_cut_values(
         hpge = (
             chmap.map("daq.rawid")[int(key[2:])].name if key.startswith("ch") else key
         )
-        out_dict[hpge] = {
-            "aoe": {
-                "low_side": _getpar(detmeta, "results.aoe.low_cut"),
-                "high_side": _getpar(detmeta, "results.aoe.high_cut"),
-            }
-        }
+        low = _getpar(detmeta, "results.aoe.low_cut")
+        high = _getpar(detmeta, "results.aoe.high_cut")
+        # l200data may store NaN for missing cuts; treat as absent so that
+        # sanitize_dict_with_defaults (called in hit.py) can substitute the default
+        if low is not None and math.isnan(low):
+            low = None
+        if high is not None and math.isnan(high):
+            high = None
+        out_dict[hpge] = {"aoe": {"low_side": low, "high_side": high}}
 
     return AttrsDict(out_dict)

--- a/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
+++ b/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
@@ -80,24 +80,43 @@ def main() -> None:
     runid = args.runid
     l200data = config.paths.get("l200data", None)
 
-    # --- energy resolution model ---
     # Collection step: gather what is available; completeness checked in hit.py.
-    # Behaviour depends on simprod/config/pars/geds/eresmod/:
+    # For each observable, behaviour depends on simprod/config/pars/geds/<obs>/:
     #  - absent: use l200data only
     #  - present, no "default": l200data base + per-detector overrides
     #  - present, with "default": expand all channelmap geds detectors;
     #    l200data not consulted
-    raw = mutils.simpars(metadata, "geds.eresmod", runid, default=None)
-    default_entry = raw.get("default", None) if raw is not None else None
+    raw_eresmod = mutils.simpars(metadata, "geds.eresmod", runid, default=None)
+    raw_aoeresmod = mutils.simpars(metadata, "geds.aoeresmod", runid, default=None)
+    raw_psdcuts = mutils.simpars(metadata, "geds.psdcuts", runid, default=None)
 
-    if default_entry is not None:
+    eresmod_default = (
+        raw_eresmod.get("default", None) if raw_eresmod is not None else None
+    )
+    aoeresmod_default = (
+        raw_aoeresmod.get("default", None) if raw_aoeresmod is not None else None
+    )
+    psdcuts_default = (
+        raw_psdcuts.get("default", None) if raw_psdcuts is not None else None
+    )
+
+    # resolve the channelmap once if any observable needs to expand all geds detectors
+    chmap = None
+    if (
+        eresmod_default is not None
+        or aoeresmod_default is not None
+        or psdcuts_default is not None
+    ):
+        tstamp = mutils.runinfo(metadata, runid).start_key
+        chmap = metadata.channelmap(tstamp, skip_version_check=True)
+
+    # --- energy resolution model ---
+    if eresmod_default is not None:
         # metadata with default: expand all channelmap geds detectors
         msg = f"using eresmod defaults from simprod/config/pars for {runid}"
         log.info(msg)
-        tstamp = mutils.runinfo(metadata, runid).start_key
-        chmap = metadata.channelmap(tstamp, skip_version_check=True)
         eresmod_dict = {
-            name: raw.get(name, default_entry).to_dict()
+            name: raw_eresmod.get(name, eresmod_default).to_dict()
             for name, info in chmap.items()
             if getattr(info, "system", None) == "geds"
         }
@@ -128,46 +147,99 @@ def main() -> None:
         for hpge, meta in eres_pars_dict.items():
             out_dict[hpge] = {f: meta[f] for f in fields}
 
-        if raw is not None:
+        if raw_eresmod is not None:
             msg = "applying per-detector eresmod overrides from simprod/config/pars"
             log.info(msg)
-            for hpge, meta in raw.items():
+            for hpge, meta in raw_eresmod.items():
                 out_dict[hpge] = meta.to_dict()
 
         dbetto.utils.write_dict(out_dict.to_dict(), args.eresmod_file)
 
-    # --- A/E resolution model and PSD cuts (l200data only for now) ---
-    hit_tier_name = utils.get_hit_tier_name(l200data)
-    pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
+    # --- A/E resolution model ---
+    if aoeresmod_default is not None:
+        msg = f"using aoeresmod defaults from simprod/config/pars for {runid}"
+        log.info(msg)
+        aoeresmod_dict = {
+            name: raw_aoeresmod.get(name, aoeresmod_default).to_dict()
+            for name, info in chmap.items()
+            if getattr(info, "system", None) == "geds"
+        }
+        dbetto.utils.write_dict(aoeresmod_dict, args.aoeresmod_file)
+    else:
+        if l200data is None:
+            msg = (
+                "l200data is not configured and no aoeresmod metadata with a 'default' "
+                "key was found — cannot extract A/E resolution model"
+            )
+            raise RuntimeError(msg)
+        msg = f"extracting aoeresmod from l200data for {runid}"
+        log.info(msg)
+        hit_tier_name = utils.get_hit_tier_name(l200data)
+        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
 
-    msg = f"extracting aoeresmod from l200data for {runid}"
-    log.info(msg)
-    aoeres_pars_dict = hpge_pars.lookup_aoe_res_metadata(
-        l200data,
-        metadata,
-        runid,
-        hit_tier_name=hit_tier_name,
-        pars_db=pars_db,
-    )
+        aoeres_pars_dict = hpge_pars.lookup_aoe_res_metadata(
+            l200data,
+            metadata,
+            runid,
+            hit_tier_name=hit_tier_name,
+            pars_db=pars_db,
+        )
 
-    out_dict = dbetto.AttrsDict({})
-    fields = ["expression", "pars", "errs"]
-    for hpge, meta in aoeres_pars_dict.items():
-        out_dict[hpge] = {f: meta[f] for f in fields}
+        out_dict = dbetto.AttrsDict({})
+        for hpge, meta in aoeres_pars_dict.items():
+            out_dict[hpge] = {
+                "expression": meta["expression"],
+                "parameters": meta["pars"],
+                "errs": meta["errs"],
+            }
 
-    dbetto.utils.write_dict(out_dict.to_dict(), args.aoeresmod_file)
+        if raw_aoeresmod is not None:
+            msg = "applying per-detector aoeresmod overrides from simprod/config/pars"
+            log.info(msg)
+            for hpge, meta in raw_aoeresmod.items():
+                out_dict[hpge] = meta.to_dict()
 
-    msg = f"extracting PSD cut values from l200data for {runid}"
-    log.info(msg)
-    aoecuts_pars_dict = hpge_pars.lookup_psd_cut_values(
-        l200data,
-        metadata,
-        runid,
-        hit_tier_name=hit_tier_name,
-        pars_db=pars_db,
-    )
+        dbetto.utils.write_dict(out_dict.to_dict(), args.aoeresmod_file)
 
-    dbetto.utils.write_dict(aoecuts_pars_dict, args.psdcuts_file)
+    # --- PSD cut values ---
+    if psdcuts_default is not None:
+        msg = f"using psdcuts defaults from simprod/config/pars for {runid}"
+        log.info(msg)
+        psdcuts_dict = {
+            name: raw_psdcuts.get(name, psdcuts_default).to_dict()
+            for name, info in chmap.items()
+            if getattr(info, "system", None) == "geds"
+        }
+        dbetto.utils.write_dict(psdcuts_dict, args.psdcuts_file)
+    else:
+        if l200data is None:
+            msg = (
+                "l200data is not configured and no psdcuts metadata with a 'default' "
+                "key was found — cannot extract PSD cut values"
+            )
+            raise RuntimeError(msg)
+        msg = f"extracting PSD cut values from l200data for {runid}"
+        log.info(msg)
+        hit_tier_name = utils.get_hit_tier_name(l200data)
+        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
+
+        aoecuts_pars_dict = hpge_pars.lookup_psd_cut_values(
+            l200data,
+            metadata,
+            runid,
+            hit_tier_name=hit_tier_name,
+            pars_db=pars_db,
+        )
+
+        out_dict = dbetto.AttrsDict(aoecuts_pars_dict)
+
+        if raw_psdcuts is not None:
+            msg = "applying per-detector psdcuts overrides from simprod/config/pars"
+            log.info(msg)
+            for hpge, meta in raw_psdcuts.items():
+                out_dict[hpge] = meta.to_dict()
+
+        dbetto.utils.write_dict(out_dict.to_dict(), args.psdcuts_file)
 
 
 if __name__ == "__main__":

--- a/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
+++ b/workflow/src/legendsimflow/scripts/pars/extract_hpge_observables_models.py
@@ -110,6 +110,15 @@ def main() -> None:
         tstamp = mutils.runinfo(metadata, runid).start_key
         chmap = metadata.channelmap(tstamp, skip_version_check=True)
 
+    # pre-compute l200data helpers once if any observable needs the l200data path
+    hit_tier_name = None
+    pars_db = None
+    if (
+        eresmod_default is None or aoeresmod_default is None or psdcuts_default is None
+    ) and l200data is not None:
+        hit_tier_name = utils.get_hit_tier_name(l200data)
+        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
+
     # --- energy resolution model ---
     if eresmod_default is not None:
         # metadata with default: expand all channelmap geds detectors
@@ -131,9 +140,6 @@ def main() -> None:
             raise RuntimeError(msg)
         msg = f"extracting eresmod from l200data for {runid}"
         log.info(msg)
-        hit_tier_name = utils.get_hit_tier_name(l200data)
-        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
-
         eres_pars_dict = hpge_pars.lookup_energy_res_metadata(
             l200data,
             metadata,
@@ -174,9 +180,6 @@ def main() -> None:
             raise RuntimeError(msg)
         msg = f"extracting aoeresmod from l200data for {runid}"
         log.info(msg)
-        hit_tier_name = utils.get_hit_tier_name(l200data)
-        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
-
         aoeres_pars_dict = hpge_pars.lookup_aoe_res_metadata(
             l200data,
             metadata,
@@ -186,12 +189,9 @@ def main() -> None:
         )
 
         out_dict = dbetto.AttrsDict({})
+        fields = ["expression", "parameters", "uncertainties"]
         for hpge, meta in aoeres_pars_dict.items():
-            out_dict[hpge] = {
-                "expression": meta["expression"],
-                "parameters": meta["pars"],
-                "errs": meta["errs"],
-            }
+            out_dict[hpge] = {f: meta[f] for f in fields}
 
         if raw_aoeresmod is not None:
             msg = "applying per-detector aoeresmod overrides from simprod/config/pars"
@@ -220,10 +220,7 @@ def main() -> None:
             raise RuntimeError(msg)
         msg = f"extracting PSD cut values from l200data for {runid}"
         log.info(msg)
-        hit_tier_name = utils.get_hit_tier_name(l200data)
-        pars_db = utils.init_generated_pars_db(l200data, tier=hit_tier_name, lazy=True)
-
-        aoecuts_pars_dict = hpge_pars.lookup_psd_cut_values(
+        psdcuts_pars_dict = hpge_pars.lookup_psd_cut_values(
             l200data,
             metadata,
             runid,
@@ -231,7 +228,7 @@ def main() -> None:
             pars_db=pars_db,
         )
 
-        out_dict = dbetto.AttrsDict(aoecuts_pars_dict)
+        out_dict = dbetto.AttrsDict(psdcuts_pars_dict)
 
         if raw_psdcuts is not None:
             msg = "applying per-detector psdcuts overrides from simprod/config/pars"

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -278,10 +278,7 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                 energy_res = energy_res_func[det_name](energy_true)
 
             elif usability == "on":
-                msg = (
-                    f"{det_name} is marked as ON but no energy resolution"
-                    "curves are available. this is unacceptable!"
-                )
+                msg = f"{det_name} is ON but no energy resolution curves are available"
                 raise RuntimeError(msg)
             else:
                 msg = (
@@ -315,10 +312,13 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                         psdcuts_default,
                     )
                 )
+            elif usability == "on" and psd_usability != "missing":
+                msg = f"{det_name} is ON with valid PSD but no PSD cut values are available"
+                raise RuntimeError(msg)
             else:
                 msg = (
-                    f"{det_name} is marked as '{usability}' and no "
-                    "PSD cut values are available. using default values"
+                    f"{det_name} is marked as '{usability}' (psd_usability='{psd_usability}') "
+                    "and no PSD cut values are available. using psdcuts_default"
                 )
                 log.warning(msg)
                 psdcuts = AttrsDict(psdcuts_default)

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -58,31 +58,21 @@ simstat_part_file = args.input.simstat_part_file
 l200data = args.config.paths.get("l200data", None)
 usabilities = AttrsDict(load_dict(args.input.detector_usabilities[0]))
 
-# default energy resolution for non-ON detectors, sourced from hit tier settings
+# default resolutions/cuts for non-ON detectors, sourced from hit tier settings
 tier_hit_settings = metadata.simprod.config.tier.hit[args.config.experiment].settings
 eresmod_default = hpge_pars.build_energy_res_func_from_entry(
     tier_hit_settings.eresmod_default
 )
+aoeresmod_default = hpge_pars.build_aoe_res_func_from_entry(
+    tier_hit_settings.aoeresmod_default
+)
+psdcuts_default = tier_hit_settings.psdcuts_default.to_dict()
 
 hit_file, move2cfs = nersc.make_on_scratch(args.config, hit_file)
 
 BUFFER_LEN = "500*MB"
 
 u = pint.UnitRegistry()
-
-
-def DEFAULT_AoE_RES_FUNC(energy):
-    return 0.01 * np.sqrt(energy / 2039)
-
-
-DEFAULT_PSD_CUTS = AttrsDict(
-    {
-        "aoe": {
-            "low_side": -1.5,
-            "high_side": 3,
-        }
-    }
-)
 
 
 # setup logging
@@ -304,25 +294,19 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
 
             if det_name in aoe_res_func:
                 aoe_res = aoe_res_func[det_name](energy_true)
-                psdcuts = AttrsDict(
-                    utils.sanitize_dict_with_defaults(
-                        psdcuts_all[det_name],
-                        DEFAULT_PSD_CUTS,
-                    )
-                )
             else:
                 msg = (
                     f"{det_name} is marked as '{usability}' and no "
                     "A/E resolution curves are available. using default values"
                 )
                 log.warning(msg)
-                aoe_res = DEFAULT_AoE_RES_FUNC(energy_true)
+                aoe_res = aoeresmod_default(energy_true)
 
             if det_name in psdcuts_all:
                 psdcuts = AttrsDict(
                     utils.sanitize_dict_with_defaults(
                         psdcuts_all[det_name],
-                        DEFAULT_PSD_CUTS,
+                        psdcuts_default,
                     )
                 )
             else:
@@ -331,7 +315,7 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
                     "PSD cut values are available. using default values"
                 )
                 log.warning(msg)
-                psdcuts = DEFAULT_PSD_CUTS
+                psdcuts = AttrsDict(psdcuts_default)
 
             # smear energy with detector resolution
             energy = reboost_utils.gauss_smear(

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -294,10 +294,16 @@ for runid_idx, (runid, evt_idx_range) in enumerate(partitions.items()):
 
             if det_name in aoe_res_func:
                 aoe_res = aoe_res_func[det_name](energy_true)
+            elif usability == "on" and psd_usability != "missing":
+                msg = (
+                    f"{det_name} is ON with valid PSD but no A/E resolution "
+                    "curves are available"
+                )
+                raise RuntimeError(msg)
             else:
                 msg = (
-                    f"{det_name} is marked as '{usability}' and no "
-                    "A/E resolution curves are available. using default values"
+                    f"{det_name} is marked as '{usability}' (psd_usability='{psd_usability}') "
+                    "and no A/E resolution curves are available. using aoeresmod_default"
                 )
                 log.warning(msg)
                 aoe_res = aoeresmod_default(energy_true)


### PR DESCRIPTION
## Summary

Extends the three-case metadata-driven extraction pattern from #205 (eresmod) to the A/E resolution model and PSD cut values, enabling fully l200data-free simulations (e.g. for LEGEND-1000).

- `extract_hpge_observables_models` now supports the same three cases for `aoeresmod` and `psdcuts` as for `eresmod`: l200data only / l200data + per-detector metadata overrides / fully metadata-driven (no l200data needed)
- `build_aoe_res_func_dict()` normalises both `parameters` (output file format) and `pars` (l200data format) keys
- `hit.py`: `aoeresmod_default` and `psdcuts_default` are loaded from the hit tier `settings.yaml`; `DEFAULT_AoE_RES_FUNC` and `DEFAULT_PSD_CUTS` removed
- aoeresmod output file now uses `parameters` key (consistent with eresmod)
- channelmap is resolved once and shared across all three observables when any of them has a `default` key
- 6 new tests covering the three extraction cases for `aoeresmod` and `psdcuts`
- docs: `meta.md` and `pipeline.md` updated with `aoeresmod` and `psdcuts` sections

## Test plan

- [ ] `pixi run test-python` — all 206 tests pass
- [ ] `pre-commit run --all-files` — clean
- [ ] `cd docs && make` — clean build, no warnings