### PR TITLE
feat: add skip_opt and skip_hit settings to evt tier

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -448,6 +448,8 @@ add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
 buffer_len: "50*MB"
+skip_opt: false
+skip_hit: false
 ```
 
 - `add_random_coincidences` (bool) — when `true`, random-coincidence (RC) SiPM
@@ -458,6 +460,18 @@ buffer_len: "50*MB"
   this value are discarded.
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"50*MB"`). Controls memory
   usage during processing; does not affect the output.
+- `skip_opt` (bool, default `false`) — when `true`, the `opt` (SiPM/LAr) tier is
+  skipped: the opt Snakemake rule is not run and the evt output contains only
+  HPGe data (no `spms` or `coincident/spms` tables).
+- `skip_hit` (bool, default `false`) — when `true`, the `hit` (HPGe) tier is
+  skipped: the hit Snakemake rule is not run and the evt output contains only
+  SiPM data (no `geds` or `coincident/geds` tables).
+
+:::{note}
+
+Setting both `skip_opt` and `skip_hit` to `true` simultaneously is an error.
+
+:::
 
 (cvt-tier-settings)=
 

--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -77,6 +77,15 @@ across detector subsystems into physics events. The output table is stored under
 designed to mirror the `evt` tier of the actual LEGEND-200 data (produced by
 [pygama](https://legend-pydataobj.readthedocs.io)) as closely as possible.
 
+:::{note}
+
+The `geds/` and `coincident/geds` subtables are absent when `skip_hit: true` is
+set in the evt tier settings (HPGe tier skipped). Similarly, the `spms/` and
+`coincident/spms` subtables are absent when `skip_opt: true` is set (SiPM/LAr
+tier skipped). See {ref}`evt-tier-settings-meta` for details.
+
+:::
+
 ### `trigger/` — event metadata
 
 Constant fields identifying each event.

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -143,6 +143,8 @@ add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
 buffer_len: "50*MB"
+skip_opt: false
+skip_hit: false
 ```
 
 - `add_random_coincidences` (bool) — when `true`, random-coincidence (RC) SiPM
@@ -153,6 +155,18 @@ buffer_len: "50*MB"
   this value are discarded.
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"50*MB"`). Controls memory
   usage during processing; does not affect the output.
+- `skip_opt` (bool, default `false`) — when `true`, the `opt` (SiPM/LAr) tier is
+  skipped: the opt Snakemake rule is not run and the evt output contains only
+  HPGe data (no `spms` or `coincident/spms` tables).
+- `skip_hit` (bool, default `false`) — when `true`, the `hit` (HPGe) tier is
+  skipped: the hit Snakemake rule is not run and the evt output contains only
+  SiPM data (no `geds` or `coincident/geds` tables).
+
+:::{note}
+
+Setting both `skip_opt` and `skip_hit` to `true` simultaneously is an error.
+
+:::
 
 ## `cvt` — event concatenation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ xfail_strict = true
 filterwarnings = [
   "error",
   "ignore:overflow encountered in divide:RuntimeWarning",
+  "ignore:overflow encountered in cast:RuntimeWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/l1000dsg01/settings.yaml
@@ -2,3 +2,5 @@ add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
 buffer_len: 50*MB
+skip_opt: false
+skip_hit: false

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/l200cfg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/l200cfg01/settings.yaml
@@ -2,3 +2,5 @@ add_random_coincidences: true
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
 buffer_len: 50*MB
+skip_opt: false
+skip_hit: false

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/legend/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/legend/settings.yaml
@@ -2,3 +2,5 @@ add_random_coincidences: true
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
 buffer_len: 50*MB
+skip_opt: false
+skip_hit: false

--- a/tests/scripts/test_tier_evt.py
+++ b/tests/scripts/test_tier_evt.py
@@ -155,3 +155,175 @@ def test_evt_script_cli(
     assert np.all(np.isin(run_vals, [0, 1])), (
         f"unexpected run values: {np.unique(run_vals)}"
     )
+
+
+@pytest.mark.needs_remage
+def test_evt_script_cli_skip_opt(
+    tmp_path,
+    monkeypatch,
+    legend_stp_path,
+    legend_hit_path,
+    legend_simstat_part_path,
+    legend_detector_usabilities_path,
+):
+    """--skip-opt: no opt file passed; geds table present, spms table absent."""
+    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
+    raw["paths"]["metadata"] = str(dummyprod / "inputs")
+    config_path = tmp_path / "simflow-config-l1000.yaml"
+    config_path.write_text(yaml.safe_dump(raw))
+
+    evt_file = tmp_path / "evt.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evt",
+            "--stp-file",
+            str(legend_stp_path),
+            "--hit-file",
+            str(legend_hit_path),
+            "--simstat-part-file",
+            str(legend_simstat_part_path),
+            "--detector-usabilities-file",
+            str(legend_detector_usabilities_path),
+            "--jobid",
+            "0000",
+            "--evt-file",
+            str(evt_file),
+            "--simflow-config",
+            str(config_path),
+            "--skip-opt",
+        ],
+    )
+    evt.main()
+
+    assert evt_file.exists(), "evt output file was not created"
+
+    evt_groups = lh5.ls(evt_file, "evt/")
+
+    # these groups must be present
+    for group in ("evt/trigger", "evt/geds", "evt/coincident"):
+        assert group in evt_groups, f"'{group}' missing from evt/; got {evt_groups}"
+
+    # spms table must be absent (opt tier was skipped)
+    assert "evt/spms" not in evt_groups, (
+        f"'evt/spms' should be absent when --skip-opt is set, got {evt_groups}"
+    )
+
+    coincident_fields = {
+        f.removeprefix("evt/coincident/") for f in lh5.ls(evt_file, "evt/coincident/")
+    }
+
+    # geds coincidence flag must be present
+    assert "geds" in coincident_fields, (
+        f"'coincident/geds' missing; got {coincident_fields}"
+    )
+    # spms coincidence flag must be absent (no opt data)
+    assert "spms" not in coincident_fields, (
+        f"'coincident/spms' should be absent when --skip-opt is set; got {coincident_fields}"
+    )
+
+
+@pytest.mark.needs_remage
+def test_evt_script_cli_skip_hit(
+    tmp_path,
+    monkeypatch,
+    legend_stp_path,
+    legend_opt_path,
+    legend_simstat_part_path,
+    legend_detector_usabilities_path,
+):
+    """--skip-hit: no hit file passed; spms table present, geds table absent.
+
+    The trigger fields must be sourced from the opt tier, so trigger/period
+    should still be 3 (p03 runs).
+    """
+    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
+    raw["paths"]["metadata"] = str(dummyprod / "inputs")
+    config_path = tmp_path / "simflow-config-l1000.yaml"
+    config_path.write_text(yaml.safe_dump(raw))
+
+    evt_file = tmp_path / "evt.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evt",
+            "--stp-file",
+            str(legend_stp_path),
+            "--opt-file",
+            str(legend_opt_path),
+            "--simstat-part-file",
+            str(legend_simstat_part_path),
+            "--detector-usabilities-file",
+            str(legend_detector_usabilities_path),
+            "--jobid",
+            "0000",
+            "--evt-file",
+            str(evt_file),
+            "--simflow-config",
+            str(config_path),
+            "--skip-hit",
+        ],
+    )
+    evt.main()
+
+    assert evt_file.exists(), "evt output file was not created"
+
+    evt_groups = lh5.ls(evt_file, "evt/")
+
+    # these groups must be present
+    for group in ("evt/trigger", "evt/spms", "evt/coincident"):
+        assert group in evt_groups, f"'{group}' missing from evt/; got {evt_groups}"
+
+    # geds table must be absent (hit tier was skipped)
+    assert "evt/geds" not in evt_groups, (
+        f"'evt/geds' should be absent when --skip-hit is set, got {evt_groups}"
+    )
+
+    coincident_fields = {
+        f.removeprefix("evt/coincident/") for f in lh5.ls(evt_file, "evt/coincident/")
+    }
+
+    # spms coincidence flag must be present
+    assert "spms" in coincident_fields, (
+        f"'coincident/spms' missing; got {coincident_fields}"
+    )
+    # geds coincidence flag must be absent (no hit data)
+    assert "geds" not in coincident_fields, (
+        f"'coincident/geds' should be absent when --skip-hit is set; got {coincident_fields}"
+    )
+
+    # with --skip-hit the trigger is sourced from the opt tier; the opt fixture
+    # uses l200-p03 runs so period must always be 3
+    period_vals = lh5.read_as("evt/trigger/period", str(evt_file), library="np")
+    assert np.all(period_vals == 3), (
+        f"expected period=3 (p03, from opt tier), got unique={np.unique(period_vals)}"
+    )
+
+
+def test_evt_script_cli_skip_both_raises(monkeypatch):
+    """Passing both --skip-opt and --skip-hit must cause an immediate SystemExit."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evt",
+            "--stp-file",
+            "dummy_stp.lh5",
+            "--simstat-part-file",
+            "dummy_simstat.yaml",
+            "--detector-usabilities-file",
+            "dummy_usabilities.yaml",
+            "--jobid",
+            "0000",
+            "--evt-file",
+            "dummy_evt.lh5",
+            "--simflow-config",
+            "dummy_config.yaml",
+            "--skip-opt",
+            "--skip-hit",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        evt.main()

--- a/tests/scripts/test_tier_pdf.py
+++ b/tests/scripts/test_tier_pdf.py
@@ -143,6 +143,195 @@ def test_pdf_script_cli(tmp_path, monkeypatch):
     assert _sum("pdf/fail/psd") == 1
 
 
+def _make_cvt_file_no_spms(path: Path) -> None:
+    """Write a minimal cvt LH5 file with no spms field in the coincident table.
+
+    Identical to ``_make_cvt_file`` except ``coincident`` carries only a
+    ``geds`` boolean array (no ``spms``).  This mirrors the on-disk structure
+    produced by evt.py when ``--skip-opt`` is passed.  pdf.py will see
+    ``has_spms_coinc=False`` and must omit the LAr histograms.
+    """
+    multiplicity = Array(np.array([1, 1, 1, 1, 2, 1], dtype=np.int32))
+    energy = VectorOfVectors(
+        data=[[500.0], [1000.0], [1500.0], [2000.0], [200.0, 300.0], [2500.0]]
+    )
+    is_good_channel = VectorOfVectors(
+        data=[[True], [True], [True], [True], [True, True], [True]]
+    )
+    is_good = VectorOfVectors(
+        data=[[True], [True], [False], [True], [True, True], [True]]
+    )
+    has_aoe = VectorOfVectors(
+        data=[[True], [True], [False], [True], [True, True], [False]]
+    )
+    is_single_site = VectorOfVectors(
+        data=[[True], [False], [False], [True], [True, True], [False]]
+    )
+    psd = Table(
+        col_dict={
+            "is_good": is_good,
+            "has_aoe": has_aoe,
+            "is_single_site": is_single_site,
+        }
+    )
+    geds = Table(
+        col_dict={
+            "energy": energy,
+            "is_good_channel": is_good_channel,
+            "multiplicity": multiplicity,
+            "psd": psd,
+        }
+    )
+    # coincident has only a geds flag — no spms → has_spms_coinc=False in pdf.py
+    coincident = Table(
+        col_dict={"geds": Array(np.array([True, False, True, True, False, True]))}
+    )
+    evt = Table(col_dict={"geds": geds, "coincident": coincident})
+    lh5.write(evt, "evt", path, wo_mode="write_safe")
+
+
+def _make_cvt_file_no_geds(path: Path) -> None:
+    """Write a minimal cvt LH5 file with no geds subtable.
+
+    The evt table contains only a ``coincident/spms`` boolean array.  This
+    mimics a production run with ``skip_hit: true``, where pdf.py will see
+    ``has_geds=False`` and ``has_spms_coinc=True``.
+    """
+    spms = Array(np.array([False, True, False, True, False, False]))
+    coincident = Table(col_dict={"spms": spms})
+    # no geds field at the evt level → has_geds=False
+    evt = Table(col_dict={"coincident": coincident})
+    lh5.write(evt, "evt", path, wo_mode="write_safe")
+
+
+def test_pdf_script_cli_skip_opt(tmp_path, monkeypatch):
+    """With no spms coincidence data (skip_opt), LAr histograms must be absent."""
+    config_path = tmp_path / "simflow-config.yaml"
+    raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
+    raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
+    config_path.write_text(yaml.safe_dump(raw_config))
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_file_no_spms(cvt_file)
+
+    pdf_file = tmp_path / "pdf.lh5"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pdf",
+            "--cvt-file",
+            str(cvt_file),
+            "--pdf-file",
+            str(pdf_file),
+            "--simid",
+            _SIMID_LEGEND,
+            "--simflow-config",
+            str(config_path),
+        ],
+    )
+    pdf.main()
+
+    assert pdf_file.exists()
+
+    inner_keys = lh5.ls(pdf_file, "pdf/")
+
+    # geds-based histograms must all be present
+    for name in ("pdf/hit", "pdf/mul", "pdf/mul_psd", "pdf/mul2", "pdf/fail"):
+        assert name in inner_keys, f"'{name}' missing from pdf/; got {inner_keys}"
+
+    fail_keys = lh5.ls(pdf_file, "pdf/fail/")
+    assert "pdf/fail/psd" in fail_keys, (
+        f"'pdf/fail/psd' missing from pdf/fail/; got {fail_keys}"
+    )
+
+    # LAr histograms must be absent: no spms coincidence data was present
+    for name in ("pdf/mul_lar", "pdf/mul_lar_psd"):
+        assert name not in inner_keys, (
+            f"'{name}' should be absent when has_spms_coinc=False; got {inner_keys}"
+        )
+    assert "pdf/fail/lar" not in fail_keys, (
+        f"'pdf/fail/lar' should be absent when has_spms_coinc=False; got {fail_keys}"
+    )
+
+
+def test_pdf_script_cli_skip_hit(tmp_path, monkeypatch):
+    """With no geds data (skip_hit), geds histograms absent; LAr histograms present with 0 counts.
+
+    pdf.py initialises mul_lar/mul_lar_psd/fail/lar whenever has_spms_coinc=True,
+    but only fills them inside the ``if has_geds:`` block.  When has_geds=False the
+    loop body takes the ``elif has_spms_coinc: pass`` branch, so all three histograms
+    are written to the output file with zero counts.
+    """
+    config_path = tmp_path / "simflow-config.yaml"
+    raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
+    raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
+    config_path.write_text(yaml.safe_dump(raw_config))
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_file_no_geds(cvt_file)
+
+    pdf_file = tmp_path / "pdf.lh5"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pdf",
+            "--cvt-file",
+            str(cvt_file),
+            "--pdf-file",
+            str(pdf_file),
+            "--simid",
+            _SIMID_LEGEND,
+            "--simflow-config",
+            str(config_path),
+        ],
+    )
+    pdf.main()
+
+    assert pdf_file.exists()
+
+    inner_keys = lh5.ls(pdf_file, "pdf/")
+
+    # geds-based histograms must be absent (never initialised when has_geds=False)
+    for name in ("pdf/hit", "pdf/mul", "pdf/mul_psd", "pdf/mul2"):
+        assert name not in inner_keys, (
+            f"'{name}' should be absent when has_geds=False; got {inner_keys}"
+        )
+
+    # LAr histograms must be present (initialised from has_spms_coinc=True guard)
+    for name in ("pdf/mul_lar", "pdf/mul_lar_psd"):
+        assert name in inner_keys, (
+            f"'{name}' missing from pdf/; expected when has_spms_coinc=True, got {inner_keys}"
+        )
+
+    fail_keys = lh5.ls(pdf_file, "pdf/fail/")
+    assert "pdf/fail/lar" in fail_keys, (
+        f"'pdf/fail/lar' missing from pdf/fail/; expected when has_spms_coinc=True, got {fail_keys}"
+    )
+
+    # fail/psd must be absent (needs geds data)
+    assert "pdf/fail/psd" not in fail_keys, (
+        f"'pdf/fail/psd' should be absent when has_geds=False; got {fail_keys}"
+    )
+
+    def _sum(path):
+        return lh5.read_as(path, pdf_file, "hist").sum()
+
+    # all LAr histograms were initialised but never filled → 0 counts
+    assert _sum("pdf/mul_lar") == 0, (
+        "pdf/mul_lar should have 0 counts when has_geds=False"
+    )
+    assert _sum("pdf/mul_lar_psd") == 0, (
+        "pdf/mul_lar_psd should have 0 counts when has_geds=False"
+    )
+    assert _sum("pdf/fail/lar") == 0, (
+        "pdf/fail/lar should have 0 counts when has_geds=False"
+    )
+
+
 @pytest.mark.needs_remage
 def test_pdf_script_cli_with_real_cvt(tmp_path, monkeypatch, legend_cvt_path):
     """Run the pdf script on a real cvt file produced by the full test pipeline."""

--- a/workflow/rules/evt.smk
+++ b/workflow/rules/evt.smk
@@ -1,4 +1,12 @@
 from legendsimflow import patterns, aggregate
+from legendsimflow.metadata import get_tier_settings
+
+_evt_settings = get_tier_settings(config, "evt")
+_skip_opt = _evt_settings.get("skip_opt", False)
+_skip_hit = _evt_settings.get("skip_hit", False)
+
+if _skip_opt and _skip_hit:
+    raise WorkflowError("evt: skip_opt and skip_hit cannot both be True")
 
 
 def _tier_setting(tier, key):
@@ -36,14 +44,32 @@ rule build_tier_evt:
         "Producing output file for job evt.{wildcards.simid}.{wildcards.jobid}"
     input:
         stp_file=patterns.output_simjob_filename(config, tier="stp"),
-        opt_file=patterns.output_simjob_filename(config, tier="opt"),
-        hit_file=patterns.output_simjob_filename(config, tier="hit"),
+        opt_file=lambda wc: (
+            []
+            if _skip_opt
+            else [
+                patterns.output_simjob_filename(
+                    config, tier="opt", simid=wc.simid, jobid=wc.jobid
+                )
+            ]
+        ),
+        hit_file=lambda wc: (
+            []
+            if _skip_hit
+            else [
+                patterns.output_simjob_filename(
+                    config, tier="hit", simid=wc.simid, jobid=wc.jobid
+                )
+            ]
+        ),
         simstat_part_file=patterns.simstat_part_filename(config),
         detector_usabilities=rules.cache_detector_usabilities.output,
     params:
         add_random_coincidences=_tier_setting("evt", "add_random_coincidences"),
         geds_energy_thr_kev=_tier_setting("evt", "geds_energy_thr_kev"),
         spms_energy_thr_pe=_tier_setting("evt", "spms_energy_thr_pe"),
+        skip_opt=_skip_opt,
+        skip_hit=_skip_hit,
     output:
         patterns.output_simjob_filename(config, tier="evt"),
     log:

--- a/workflow/src/legendsimflow/scripts/make_simstat_partition_file.py
+++ b/workflow/src/legendsimflow/scripts/make_simstat_partition_file.py
@@ -28,6 +28,7 @@ from snakemake_argparse_bridge import snakemake_compatible
 from legendsimflow import metadata as mutils
 from legendsimflow import nersc, utils
 from legendsimflow.partitioning import partition_simstat
+from legendsimflow.scripts import log_script_invocation
 
 
 @snakemake_compatible(
@@ -72,6 +73,7 @@ def main() -> None:
 
     # setup logging
     log = ldfs.utils.build_log(metadata.simprod.config.logging, log_file)
+    log_script_invocation(log, "make-simstat-partition-file", parser, args)
 
     # get full simulation event statistics
     n_events = {}

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -34,6 +34,7 @@ from legendsimflow.metadata import (
     encode_psd_usability,
     encode_usability,
     get_tier_settings,
+    parse_runid,
 )
 from legendsimflow.profile import make_profiler
 from legendsimflow.scripts import log_script_invocation
@@ -344,6 +345,18 @@ def main() -> None:
             # take them from the hit tier if available, otherwise from opt
             trigger_source = "opt" if skip_hit else "hit"
             for constant_field in ["run", "period", "evtid"]:
+                if skip_hit and constant_field in ("run", "period"):
+                    # opt TCM can be empty for events with no LAr deposit — reading
+                    # from opt would give NaN. Source run/period from the partition
+                    # runid instead, where they are always known.
+                    _, _period, _run, _ = parse_runid(runid)
+                    val = _period if constant_field == "period" else _run
+                    out_table.add_field(
+                        f"trigger/{constant_field}",
+                        Array(np.full(len(unified_tcm), val, dtype=np.float64)),
+                    )
+                    continue
+
                 data = _read_hits(tcm, trigger_source, constant_field)
 
                 # sanity check

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -47,22 +47,32 @@ VALID_PSD = encode_psd_usability("valid")
 @snakemake_compatible(
     mapping={
         "stp_file": "input.stp_file",
-        "opt_file": "input.opt_file",
-        "hit_file": "input.hit_file",
+        "opt_file": lambda snakemake: (
+            snakemake.input.opt_file[0] if snakemake.input.opt_file else None
+        ),
+        "hit_file": lambda snakemake: (
+            snakemake.input.hit_file[0] if snakemake.input.hit_file else None
+        ),
         "simstat_part_file": "input.simstat_part_file",
         "detector_usabilities_file": "input.detector_usabilities[0]",
         "jobid": "wildcards.jobid",
         "evt_file": "output[0]",
         "log_file": "log[0]",
         "add_random_coincidences": "params.add_random_coincidences",
+        "skip_opt": "params.skip_opt",
+        "skip_hit": "params.skip_hit",
         "simflow_config": "config",
     }
 )
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build the evt tier.")
     parser.add_argument("--stp-file", required=True, help="input stp tier file")
-    parser.add_argument("--opt-file", required=True, help="input opt tier file")
-    parser.add_argument("--hit-file", required=True, help="input hit tier file")
+    parser.add_argument(
+        "--opt-file", required=False, default=None, help="input opt tier file"
+    )
+    parser.add_argument(
+        "--hit-file", required=False, default=None, help="input hit tier file"
+    )
     parser.add_argument(
         "--simstat-part-file",
         required=True,
@@ -83,6 +93,18 @@ def main() -> None:
         help="add random-coincidence SiPM data from real evt files",
     )
     parser.add_argument(
+        "--skip-opt",
+        action="store_true",
+        default=False,
+        help="skip the opt (SiPM) tier; no spms table will be produced",
+    )
+    parser.add_argument(
+        "--skip-hit",
+        action="store_true",
+        default=False,
+        help="skip the hit (HPGe) tier; no geds table will be produced",
+    )
+    parser.add_argument(
         "--simflow-config",
         "--config",
         dest="simflow_config",
@@ -91,13 +113,24 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    skip_opt = args.skip_opt
+    skip_hit = args.skip_hit
+
+    if skip_opt and skip_hit:
+        parser.error("cannot set both --skip-opt and --skip-hit")
+    if not skip_opt and args.opt_file is None:
+        parser.error("--opt-file is required unless --skip-opt is set")
+    if not skip_hit and args.hit_file is None:
+        parser.error("--hit-file is required unless --skip-hit is set")
+
     config = utils.init_simflow_context(args.simflow_config, workflow=None).config
 
     stp_file = nersc.dvs_ro(config, args.stp_file)
-    hit_file = {
-        "opt": nersc.dvs_ro(config, args.opt_file),
-        "hit": nersc.dvs_ro(config, args.hit_file),
-    }
+    hit_file = {}
+    if not skip_opt:
+        hit_file["opt"] = nersc.dvs_ro(config, args.opt_file)
+    if not skip_hit:
+        hit_file["hit"] = nersc.dvs_ro(config, args.hit_file)
     evt_file = args.evt_file
     log_file = args.log_file
     metadata = config.metadata
@@ -121,29 +154,40 @@ def main() -> None:
 
     log.info("merging hit and opt TCMs")
     with perf_block("merge_tcms()"):
-        scintillator_uid = next(
-            uid
-            for uid, name in reboost_utils.get_remage_detector_uids(stp_file).items()
-            if name == "liquid_argon"
-        )
+        if skip_opt:
+            # No SiPM data: stream STP TCM directly into evt file
+            wo = "write_safe"
+            for chunk in lh5.LH5Iterator(str(stp_file), "tcm", buffer_len=buffer_len):
+                lh5.write(chunk, "tcm", str(evt_file), wo_mode=wo)
+                wo = "append"
+        else:
+            scintillator_uid = next(
+                uid
+                for uid, name in reboost_utils.get_remage_detector_uids(
+                    stp_file
+                ).items()
+                if name == "liquid_argon"
+            )
 
-        merge_stp_n_opt_tcms_to_lh5(
-            stp_file,
-            hit_file["opt"],
-            evt_file,
-            scintillator_uid=scintillator_uid,
-            buffer_len=buffer_len,
-        )
+            merge_stp_n_opt_tcms_to_lh5(
+                stp_file,
+                hit_file["opt"],
+                evt_file,
+                scintillator_uid=scintillator_uid,
+                buffer_len=buffer_len,
+            )
 
     # test that the evt tcm has the same amount of rows as the stp tcm
     if lh5.read_n_rows("tcm", stp_file) != lh5.read_n_rows("tcm", evt_file):
         msg = (
             "stp and evt tcm should have same number of rows not "
             f"stp={lh5.read_n_rows('tcm', stp_file)}, "
-            f"evt={lh5.read_n_rows('tcm', evt_file)}, "
-            f"hit={lh5.read_n_rows('tcm', hit_file['hit'])}, "
-            f"opt={lh5.read_n_rows('tcm', hit_file['opt'])}"
+            f"evt={lh5.read_n_rows('tcm', evt_file)}"
         )
+        if not skip_hit:
+            msg += f", hit={lh5.read_n_rows('tcm', hit_file['hit'])}"
+        if not skip_opt:
+            msg += f", opt={lh5.read_n_rows('tcm', hit_file['opt'])}"
         raise ValueError(msg)
 
     # get the mapping of detector name to uid
@@ -151,6 +195,9 @@ def main() -> None:
     # the hit tiers
     det2uid = {}
     for tier in ("opt", "hit"):
+        if (tier == "opt" and skip_opt) or (tier == "hit" and skip_hit):
+            det2uid[tier] = {}
+            continue
         det2uid[tier] = {
             name: uid
             for uid, name in reboost_utils.get_remage_detector_uids(
@@ -163,6 +210,9 @@ def main() -> None:
     # little helper to simplify the code below
     # TODO: move/fix in reboost
     def _read_hits(tcm_ak, tier, field):
+        if not det2uid[tier]:
+            return ak.Array([[] for _ in range(len(ak.num(tcm_ak[tier].row_in_table)))])
+
         msg = f"loading {field=} data from {tier=} (file {hit_file[tier]})"
         log.debug(msg)
 
@@ -236,10 +286,15 @@ def main() -> None:
 
         # canonical non-OFF SiPM channel UIDs for this run, in ascending order.
         # used to pad events with no edep in LAr photons
-        on_spms_uids = sorted(
-            uid
-            for det_name, uid in det2uid["opt"].items()
-            if (usabilities[runid].get(det_name) or {}).get("usability", "on") != "off"
+        on_spms_uids = (
+            sorted(
+                uid
+                for det_name, uid in det2uid["opt"].items()
+                if (usabilities[runid].get(det_name) or {}).get("usability", "on")
+                != "off"
+            )
+            if not skip_opt
+            else []
         )
 
         if add_random_coincidences:
@@ -286,18 +341,19 @@ def main() -> None:
             out_table.add_field("trigger", Table(size=len(unified_tcm)))
 
             # global fields that are constant over the full events
-            # let's take them from the hit tier
+            # take them from the hit tier if available, otherwise from opt
+            trigger_source = "opt" if skip_hit else "hit"
             for constant_field in ["run", "period", "evtid"]:
-                data = _read_hits(tcm, "hit", constant_field)
+                data = _read_hits(tcm, trigger_source, constant_field)
 
                 # sanity check
-                assert len(data) == len(tcm["hit"])
+                assert len(data) == len(tcm[trigger_source])
 
                 # replace the awkward missing values with NaN for LH5 compatibility
                 data = ak.fill_none(ak.firsts(data, axis=-1), np.nan)
                 out_table.add_field(f"trigger/{constant_field}", Array(data))
 
-            timestamp = _read_hits(tcm, "hit", "t0")
+            timestamp = _read_hits(tcm, trigger_source, "t0")
             timestamp = ak.fill_none(ak.firsts(timestamp, axis=-1), np.nan)
             out_table.add_field(
                 "trigger/timestamp",
@@ -306,185 +362,201 @@ def main() -> None:
 
             # HPGe table
             # ----------
-            out_table.add_field("geds", Table(size=len(unified_tcm)))
+            if not skip_hit:
+                out_table.add_field("geds", Table(size=len(unified_tcm)))
 
-            # first read usability and energy
-            usability = _read_hits(tcm, "hit", "usability")
-            psd_usability = _read_hits(tcm, "hit", "psd_usability")
-            energy = _read_hits(tcm, "hit", "energy")
+                # first read usability and energy
+                usability = _read_hits(tcm, "hit", "usability")
+                psd_usability = _read_hits(tcm, "hit", "psd_usability")
+                energy = _read_hits(tcm, "hit", "energy")
 
-            # we want to only store hits from events in ON and AC detectors and above
-            # our energy threshold
-            hitsel = (usability != OFF) & (energy > geds_energy_thr_kev)
+                # we want to only store hits from events in ON and AC detectors and above
+                # our energy threshold
+                hitsel = (usability != OFF) & (energy > geds_energy_thr_kev)
 
-            # we want to still be able to know which detectors are ON (and not AC)
-            out_table.add_field(
-                "geds/is_good_channel", VectorOfVectors(usability[hitsel] == ON)
-            )
-            out_table.add_field(
-                "geds/energy",
-                VectorOfVectors(
-                    ak.values_astype(energy[hitsel], np.float32), attrs={"units": "keV"}
-                ),
-            )
-            # NOTE: the energy sum does not include AC detectors
-            out_table.add_field(
-                "geds/energy_sum",
-                Array(
-                    np.asarray(
-                        ak.sum(energy[hitsel & (usability == ON)], axis=-1),
-                        dtype=np.float32,
+                # we want to still be able to know which detectors are ON (and not AC)
+                out_table.add_field(
+                    "geds/is_good_channel", VectorOfVectors(usability[hitsel] == ON)
+                )
+                out_table.add_field(
+                    "geds/energy",
+                    VectorOfVectors(
+                        ak.values_astype(energy[hitsel], np.float32),
+                        attrs={"units": "keV"},
                     ),
-                    attrs={"units": "keV"},
-                ),
-            )
+                )
+                # NOTE: the energy sum does not include AC detectors
+                out_table.add_field(
+                    "geds/energy_sum",
+                    Array(
+                        np.asarray(
+                            ak.sum(energy[hitsel & (usability == ON)], axis=-1),
+                            dtype=np.float32,
+                        ),
+                        attrs={"units": "keV"},
+                    ),
+                )
 
-            # fields to identify detectors and lookup stuff in the lower tiers
-            out_table.add_field(
-                "geds/rawid", VectorOfVectors(tcm["hit"].table_key[hitsel])
-            )
-            out_table.add_field(
-                "geds/hit_idx", VectorOfVectors(tcm["hit"].row_in_table[hitsel])
-            )
+                # fields to identify detectors and lookup stuff in the lower tiers
+                out_table.add_field(
+                    "geds/rawid", VectorOfVectors(tcm["hit"].table_key[hitsel])
+                )
+                out_table.add_field(
+                    "geds/hit_idx", VectorOfVectors(tcm["hit"].row_in_table[hitsel])
+                )
 
-            # PSD subtable
-            out_table.add_field("geds/psd", Table(size=len(unified_tcm)))
-            out_table.add_field(
-                "geds/psd/is_good", VectorOfVectors(psd_usability[hitsel] == VALID_PSD)
-            )
+                # PSD subtable
+                out_table.add_field("geds/psd", Table(size=len(unified_tcm)))
+                out_table.add_field(
+                    "geds/psd/is_good",
+                    VectorOfVectors(psd_usability[hitsel] == VALID_PSD),
+                )
 
-            aoe = _read_hits(tcm, "hit", "aoe")
-            out_table.add_field(
-                "geds/psd/aoe",
-                VectorOfVectors(ak.values_astype(aoe[hitsel], np.float32)),
-            )
-            out_table.add_field(
-                "geds/psd/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel]))
-            )
+                aoe = _read_hits(tcm, "hit", "aoe")
+                out_table.add_field(
+                    "geds/psd/aoe",
+                    VectorOfVectors(ak.values_astype(aoe[hitsel], np.float32)),
+                )
+                out_table.add_field(
+                    "geds/psd/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel]))
+                )
 
-            is_ss = _read_hits(tcm, "hit", "is_single_site")
-            out_table.add_field(
-                "geds/psd/is_single_site", VectorOfVectors(is_ss[hitsel])
-            )
+                is_ss = _read_hits(tcm, "hit", "is_single_site")
+                out_table.add_field(
+                    "geds/psd/is_single_site", VectorOfVectors(is_ss[hitsel])
+                )
 
-            # compute multiplicity
-            geds_multiplicity = ak.sum(hitsel, axis=-1)
-            out_table.add_field("geds/multiplicity", Array(geds_multiplicity))
+                # compute multiplicity
+                geds_multiplicity = ak.sum(hitsel, axis=-1)
+                out_table.add_field("geds/multiplicity", Array(geds_multiplicity))
+            else:
+                geds_multiplicity = ak.Array(np.zeros(len(unified_tcm), dtype=np.int64))
 
             # SiPM table
             # ----------
-            out_table.add_field("spms", Table(size=len(unified_tcm)))
+            if not skip_opt:
+                out_table.add_field("spms", Table(size=len(unified_tcm)))
 
-            # also here, we exclude the non usable channels. this is in line with what
-            # done in the evt tier in pygama
-            usability = _read_hits(tcm, "opt", "usability")
-            energy = _read_hits(tcm, "opt", "energy")
-            chansel = usability != OFF
-            # we also discard all pulses with amplitude below threshold
-            pesel = energy > spms_energy_thr_pe
+                # also here, we exclude the non usable channels. this is in line with what
+                # done in the evt tier in pygama
+                usability = _read_hits(tcm, "opt", "usability")
+                energy = _read_hits(tcm, "opt", "energy")
+                chansel = usability != OFF
+                # we also discard all pulses with amplitude below threshold
+                pesel = energy > spms_energy_thr_pe
 
-            # in simulation the opt TCM does not record events for which there is
-            # no energy in LAr. This means that in the unified TCM these events
-            # will be characterized by spms empty arrays.  pad those events with
-            # the canonical non-OFF channel list (empty PE arrays) to match the
-            # real-data convention where all non-OFF channels are always present.
-            # NOTE: the on_spms_uids ordering must match the ordering
-            # used by non-empty events (i.e. the TCM ordering). Currently both
-            # are ascending by UID.
-            n_events = len(unified_tcm)
-            is_empty_opt = ak.num(tcm["opt"].table_key) == 0
-            rawid = ak.Array([on_spms_uids] * n_events)
+                # in simulation the opt TCM does not record events for which there is
+                # no energy in LAr. This means that in the unified TCM these events
+                # will be characterized by spms empty arrays.  pad those events with
+                # the canonical non-OFF channel list (empty PE arrays) to match the
+                # real-data convention where all non-OFF channels are always present.
+                # NOTE: the on_spms_uids ordering must match the ordering
+                # used by non-empty events (i.e. the TCM ordering). Currently both
+                # are ascending by UID.
+                n_events = len(unified_tcm)
+                is_empty_opt = ak.num(tcm["opt"].table_key) == 0
+                rawid = ak.Array([on_spms_uids] * n_events)
 
-            # rawid is the same canonical list for every event (non-empty events
-            # already carry all non-OFF channels in ascending UID order)
-            out_table.add_field("spms/rawid", VectorOfVectors(rawid))
+                # rawid is the same canonical list for every event (non-empty events
+                # already carry all non-OFF channels in ascending UID order)
+                out_table.add_field("spms/rawid", VectorOfVectors(rawid))
 
-            energy_sel = energy[pesel][chansel]
-            # fill in empty arrays for events with no LAr edep
-            empty_energy = ak.Array([[[] for _ in on_spms_uids]] * n_events)
-            energy_sel = ak.where(is_empty_opt, empty_energy, energy_sel)
-            out_table.add_field(
-                "spms/energy",
-                VectorOfVectors(ak.values_astype(energy_sel, np.float32)),
-            )
-
-            is_saturated = _read_hits(tcm, "opt", "is_saturated")
-            is_saturated_sel = is_saturated[chansel]
-            # fill in Falses for events with no LAr edep
-            empty_is_saturated = ak.Array([[False for _ in on_spms_uids]] * n_events)
-            is_saturated_sel = ak.where(
-                is_empty_opt, empty_is_saturated, is_saturated_sel
-            )
-            out_table.add_field("spms/is_saturated", VectorOfVectors(is_saturated_sel))
-
-            hit_idx = tcm["opt"].row_in_table[chansel]
-            # fill in -1 hit index for events with no LAr edep
-            empty_hit_idx = ak.Array([[-1 for _ in on_spms_uids]] * n_events)
-            hit_idx = ak.where(is_empty_opt, empty_hit_idx, hit_idx)
-            out_table.add_field("spms/hit_idx", VectorOfVectors(hit_idx))
-
-            time = _read_hits(tcm, "opt", "time")
-            time_sel = time[pesel][chansel]
-            # fill in empty arrays for events with no LAr edep
-            empty_time = ak.Array([[[] for _ in on_spms_uids]] * n_events)
-            time_sel = ak.where(is_empty_opt, empty_time, time_sel)
-            out_table.add_field(
-                "spms/time",
-                VectorOfVectors(
-                    ak.values_astype(time_sel, np.float32), attrs={"units": "ns"}
-                ),
-            )
-
-            if add_random_coincidences:
-                with perf_block("get_chunk_rc_data()"):
-                    rc_chunk = spms_pars.get_chunk_rc_data(
-                        [str(f) for f in rc_evt_files],
-                        rc_file_state,
-                        len(unified_tcm),
-                        rc_index_lookup,
-                    )
-                # FIXME: this assertion fails because we haven't thought about
-                # cases when there is a DAQ recabling without hardware changes.
-                # right now this fails with p18 because SiPMs were recabled.
-                #
-                # assert rawid alignment: RC and simulation must use the same
-                # channel ordering (both are ascending by UID)
-                # assert ak.to_list(rc_chunk.rawid[0]) == on_spms_uids, (
-                #     "RC rawid does not match simulation spms/rawid: "
-                #     f"{rc_chunk.rawid[0].to_list()} != {on_spms_uids}"
-                # )
+                energy_sel = energy[pesel][chansel]
+                # fill in empty arrays for events with no LAr edep
+                empty_energy = ak.Array([[[] for _ in on_spms_uids]] * n_events)
+                energy_sel = ak.where(is_empty_opt, empty_energy, energy_sel)
                 out_table.add_field(
-                    "spms/rc_energy",
-                    VectorOfVectors(ak.values_astype(rc_chunk.npe, np.float32)),
+                    "spms/energy",
+                    VectorOfVectors(ak.values_astype(energy_sel, np.float32)),
+                )
+
+                is_saturated = _read_hits(tcm, "opt", "is_saturated")
+                is_saturated_sel = is_saturated[chansel]
+                # fill in Falses for events with no LAr edep
+                empty_is_saturated = ak.Array(
+                    [[False for _ in on_spms_uids]] * n_events
+                )
+                is_saturated_sel = ak.where(
+                    is_empty_opt, empty_is_saturated, is_saturated_sel
                 )
                 out_table.add_field(
-                    "spms/rc_time",
+                    "spms/is_saturated", VectorOfVectors(is_saturated_sel)
+                )
+
+                hit_idx = tcm["opt"].row_in_table[chansel]
+                # fill in -1 hit index for events with no LAr edep
+                empty_hit_idx = ak.Array([[-1 for _ in on_spms_uids]] * n_events)
+                hit_idx = ak.where(is_empty_opt, empty_hit_idx, hit_idx)
+                out_table.add_field("spms/hit_idx", VectorOfVectors(hit_idx))
+
+                time = _read_hits(tcm, "opt", "time")
+                time_sel = time[pesel][chansel]
+                # fill in empty arrays for events with no LAr edep
+                empty_time = ak.Array([[[] for _ in on_spms_uids]] * n_events)
+                time_sel = ak.where(is_empty_opt, empty_time, time_sel)
+                out_table.add_field(
+                    "spms/time",
                     VectorOfVectors(
-                        ak.values_astype(rc_chunk.t0, np.float32),
-                        attrs={"units": "ns"},
+                        ak.values_astype(time_sel, np.float32), attrs={"units": "ns"}
                     ),
                 )
 
-            # total amount of light per event
-            energy_sum = ak.sum(ak.sum(energy[pesel][chansel], axis=-1), axis=-1)
-            out_table.add_field(
-                "spms/energy_sum", Array(np.asarray(energy_sum, dtype=np.float32))
-            )
+                if add_random_coincidences:
+                    with perf_block("get_chunk_rc_data()"):
+                        rc_chunk = spms_pars.get_chunk_rc_data(
+                            [str(f) for f in rc_evt_files],
+                            rc_file_state,
+                            len(unified_tcm),
+                            rc_index_lookup,
+                        )
+                    # FIXME: this assertion fails because we haven't thought about
+                    # cases when there is a DAQ recabling without hardware changes.
+                    # right now this fails with p18 because SiPMs were recabled.
+                    #
+                    # assert rawid alignment: RC and simulation must use the same
+                    # channel ordering (both are ascending by UID)
+                    # assert ak.to_list(rc_chunk.rawid[0]) == on_spms_uids, (
+                    #     "RC rawid does not match simulation spms/rawid: "
+                    #     f"{rc_chunk.rawid[0].to_list()} != {on_spms_uids}"
+                    # )
+                    out_table.add_field(
+                        "spms/rc_energy",
+                        VectorOfVectors(ak.values_astype(rc_chunk.npe, np.float32)),
+                    )
+                    out_table.add_field(
+                        "spms/rc_time",
+                        VectorOfVectors(
+                            ak.values_astype(rc_chunk.t0, np.float32),
+                            attrs={"units": "ns"},
+                        ),
+                    )
 
-            # how many channels saw some light
-            spms_multiplicity = ak.sum(ak.any(chansel & pesel, axis=-1), axis=-1)
-            out_table.add_field("spms/multiplicity", Array(spms_multiplicity))
+                # total amount of light per event
+                energy_sum = ak.sum(ak.sum(energy[pesel][chansel], axis=-1), axis=-1)
+                out_table.add_field(
+                    "spms/energy_sum",
+                    Array(np.asarray(energy_sum, dtype=np.float32)),
+                )
+
+                # how many channels saw some light
+                spms_multiplicity = ak.sum(ak.any(chansel & pesel, axis=-1), axis=-1)
+                out_table.add_field("spms/multiplicity", Array(spms_multiplicity))
+            else:
+                energy_sum = ak.Array(np.zeros(len(unified_tcm), dtype=np.float32))
+                spms_multiplicity = ak.Array(np.zeros(len(unified_tcm), dtype=np.int64))
 
             # coincidences table
             # ------------------
             out_table.add_field("coincident", Table(size=len(unified_tcm)))
 
             # is there a signal in the HPGe array?
-            out_table.add_field("coincident/geds", Array(geds_multiplicity > 0))
+            if not skip_hit:
+                out_table.add_field("coincident/geds", Array(geds_multiplicity > 0))
 
             # is there a signal in the LAr instrumentation?
-            lar_veto = (spms_multiplicity >= 4) | (energy_sum >= 4)
-            out_table.add_field("coincident/spms", Array(lar_veto))
+            if not skip_opt:
+                lar_veto = (spms_multiplicity >= 4) | (energy_sum >= 4)
+                out_table.add_field("coincident/spms", Array(lar_veto))
 
             # now write down
             with perf_block("write_chunk()"):

--- a/workflow/src/legendsimflow/scripts/tier/pdf.py
+++ b/workflow/src/legendsimflow/scripts/tier/pdf.py
@@ -68,6 +68,15 @@ def main() -> None:
 
     log.info("... reading data from %s", cvt_file)
 
+    # detect what data is available in the cvt file
+    _cvt_file_str = str(cvt_file)
+    _evt_groups = {k.removeprefix("evt/") for k in lh5.ls(_cvt_file_str, "evt/")}
+    has_geds = "geds" in _evt_groups
+    has_spms_coinc = "coincident" in _evt_groups and "spms" in {
+        k.removeprefix("evt/coincident/")
+        for k in lh5.ls(_cvt_file_str, "evt/coincident/")
+    }
+
     # a single cvt file might be large, need to iterate
     iterator = lh5.LH5Iterator(
         str(cvt_file),
@@ -85,68 +94,84 @@ def main() -> None:
 
     # 1 keV/bin over 0-6000 keV; boost-histogram only provides Double (float64) storage
     h1 = hist.new.Reg(6000, 0, 6000).Double
-    histograms = {
-        "hit": h1(),
-        "mul": h1(),
-        "mul_lar": h1(),
-        "mul_psd": h1(),
-        "mul_lar_psd": h1(),
+    histograms = {}
+    fail_histograms = {}
+
+    if has_geds:
+        histograms["hit"] = h1()
+        histograms["mul"] = h1()
+        histograms["mul_psd"] = h1()
         # 2-D: (E_min, E_max) for multiplicity-2 events
-        "mul2": hist.new.Reg(6000, 0, 6000).Reg(6000, 0, 6000).Double(),
-    }
-    fail_histograms = {
-        "lar": h1(),
-        "psd": h1(),
-    }
+        histograms["mul2"] = hist.new.Reg(6000, 0, 6000).Reg(6000, 0, 6000).Double()
+        fail_histograms["psd"] = h1()
+
+    if has_spms_coinc:
+        histograms["mul_lar"] = h1()
+        histograms["mul_lar_psd"] = h1()
+        fail_histograms["lar"] = h1()
+
     log.info("... beginning iteration over cvt file")
 
     for chunk in iterator:
         data = chunk.view_as("ak")
 
-        # all-good-channel mask: every detector in the event must be usable
-        good_channel_mask = ak.all(data.geds.is_good_channel, axis=-1)
+        if has_geds:
+            # all-good-channel mask: every detector in the event must be usable
+            good_channel_mask = ak.all(data.geds.is_good_channel, axis=-1)
 
-        # hit: all energy deposits in good-channel events, no multiplicity requirement
-        data_hit = data[good_channel_mask]
-        histograms["hit"].fill(ak.flatten(data_hit.geds.energy))
+            # hit: all energy deposits in good-channel events, no multiplicity requirement
+            data_hit = data[good_channel_mask]
+            histograms["hit"].fill(ak.flatten(data_hit.geds.energy))
 
-        # multiplicity cut: keep only events where exactly one ON detector fired
-        data_m1 = data[(data.geds.multiplicity == 1) & good_channel_mask]
-        histograms["mul"].fill(ak.flatten(data_m1.geds.energy))
+            # multiplicity cut: keep only events where exactly one ON detector fired
+            data_m1 = data[(data.geds.multiplicity == 1) & good_channel_mask]
+            histograms["mul"].fill(ak.flatten(data_m1.geds.energy))
 
-        # LAr cut: coincident.spms is True when SiPMs detected scintillation light
-        # in liquid argon — such events are vetoed
-        data_m1_lar = data_m1[~data_m1.coincident.spms]
-        histograms["mul_lar"].fill(ak.flatten(data_m1_lar.geds.energy))
-        fail_histograms["lar"].fill(
-            ak.flatten(data_m1[data_m1.coincident.spms].geds.energy)
-        )
+            data_m1_lar = data_m1
+            if has_spms_coinc:
+                # LAr cut: coincident.spms is True when SiPMs detected scintillation light
+                # in liquid argon — such events are vetoed
+                data_m1_lar = data_m1[~data_m1.coincident.spms]
+                histograms["mul_lar"].fill(ak.flatten(data_m1_lar.geds.energy))
+                fail_histograms["lar"].fill(
+                    ak.flatten(data_m1[data_m1.coincident.spms].geds.energy)
+                )
 
-        # PSD cut: require valid PSD in data (is_good), simulated A/E observable
-        # (has_aoe), and single-site topology (is_single_site). Events where PSD is
-        # not valid or not simulated are classified as background and cut.
-        def _psd_mask(d):
-            return ak.all(
-                d.geds.psd.is_good & d.geds.psd.has_aoe & d.geds.psd.is_single_site,
-                axis=-1,
+            # PSD cut: require valid PSD in data (is_good), simulated A/E observable
+            # (has_aoe), and single-site topology (is_single_site). Events where PSD is
+            # not valid or not simulated are classified as background and cut.
+            def _psd_mask(d):
+                return ak.all(
+                    d.geds.psd.is_good & d.geds.psd.has_aoe & d.geds.psd.is_single_site,
+                    axis=-1,
+                )
+
+            histograms["mul_psd"].fill(
+                ak.flatten(data_m1[_psd_mask(data_m1)].geds.energy)
             )
 
-        histograms["mul_psd"].fill(ak.flatten(data_m1[_psd_mask(data_m1)].geds.energy))
-        histograms["mul_lar_psd"].fill(
-            ak.flatten(data_m1_lar[_psd_mask(data_m1_lar)].geds.energy)
-        )
+            if has_spms_coinc:
+                histograms["mul_lar_psd"].fill(
+                    ak.flatten(data_m1_lar[_psd_mask(data_m1_lar)].geds.energy)
+                )
 
-        # fail/psd: m1 events with valid and simulated PSD but failing single-site
-        psd_fail_mask = ak.all(
-            data_m1.geds.psd.is_good & data_m1.geds.psd.has_aoe, axis=-1
-        ) & ~_psd_mask(data_m1)
-        fail_histograms["psd"].fill(ak.flatten(data_m1[psd_fail_mask].geds.energy))
+            # fail/psd: m1 events with valid and simulated PSD but failing single-site
+            psd_fail_mask = ak.all(
+                data_m1.geds.psd.is_good & data_m1.geds.psd.has_aoe, axis=-1
+            ) & ~_psd_mask(data_m1)
+            fail_histograms["psd"].fill(ak.flatten(data_m1[psd_fail_mask].geds.energy))
 
-        # m2: events with exactly two detectors fired — fill 2D histogram with (E_low, E_high)
-        data_m2 = data[(data.geds.multiplicity == 2) & good_channel_mask]
-        histograms["mul2"].fill(
-            ak.min(data_m2.geds.energy, axis=-1), ak.max(data_m2.geds.energy, axis=-1)
-        )
+            # m2: events with exactly two detectors fired — fill 2D histogram with (E_low, E_high)
+            data_m2 = data[(data.geds.multiplicity == 2) & good_channel_mask]
+            histograms["mul2"].fill(
+                ak.min(data_m2.geds.energy, axis=-1),
+                ak.max(data_m2.geds.energy, axis=-1),
+            )
+
+        elif has_spms_coinc:
+            # no geds data but spms coincidence data exists: only fill LAr histograms
+            # (we cannot compute meaningful mul_lar without geds energy, so skip filling)
+            pass
 
     log.info("... convert histograms to lgdo")
 
@@ -160,22 +185,19 @@ def main() -> None:
         "fail/lar": "multiplicity-1 events failing the LAr veto",
         "fail/psd": "multiplicity-1 events with valid PSD failing the PSD cut",
     }
-    output = Struct(
-        {
-            name: Histogram(h, attrs={"description": _descriptions[name]})
-            for name, h in histograms.items()
-        }
-        | {
-            "fail": Struct(
-                {
-                    name: Histogram(
-                        h, attrs={"description": _descriptions[f"fail/{name}"]}
-                    )
-                    for name, h in fail_histograms.items()
-                }
-            )
-        }
-    )
+
+    output_dict = {
+        name: Histogram(h, attrs={"description": _descriptions[name]})
+        for name, h in histograms.items()
+    }
+    if fail_histograms:
+        output_dict["fail"] = Struct(
+            {
+                name: Histogram(h, attrs={"description": _descriptions[f"fail/{name}"]})
+                for name, h in fail_histograms.items()
+            }
+        )
+    output = Struct(output_dict)
     lh5.write(output, "pdf", pdf_file, wo_mode="w")
     lh5.write(
         Scalar(int(number_of_primaries)), "nr_sim_events", pdf_file, wo_mode="append"


### PR DESCRIPTION
## Summary

- Adds two optional boolean settings to the `evt` tier configuration: `skip_opt` (default `false`) and `skip_hit` (default `false`)
- When `skip_opt: true`, the `opt` (SiPM/LAr) Snakemake rule is skipped and the `evt` output contains only HPGe data (`geds`, `coincident/geds`); `spms` and `coincident/spms` are absent
- When `skip_hit: true`, the `hit` (HPGe) Snakemake rule is skipped and the `evt` output contains only SiPM data (`spms`, `coincident/spms`); `geds` and `coincident/geds` are absent; trigger fields are read from the `opt` tier instead
- Setting both to `true` simultaneously is a `WorkflowError`
- `pdf.py` detects available data from the cvt file structure at runtime and omits LAr-veto histograms (`mul_lar`, `mul_lar_psd`, `fail/lar`) when `coincident/spms` is absent
- Both settings are optional in the YAML (fall back to `false` when absent, so no existing configurations need updating)

## Test plan

- [ ] `pytest tests/tests/scripts/test_tier_evt.py::test_evt_script_cli_skip_both_raises` — no remage needed
- [ ] `pytest tests/tests/scripts/test_tier_pdf.py::test_pdf_script_cli_skip_opt` — no remage needed
- [ ] `pytest tests/tests/scripts/test_tier_pdf.py::test_pdf_script_cli_skip_hit` — no remage needed
- [ ] `pytest -m needs_remage tests/tests/scripts/test_tier_evt.py::test_evt_script_cli_skip_opt` — requires remage
- [ ] `pytest -m needs_remage tests/tests/scripts/test_tier_evt.py::test_evt_script_cli_skip_hit` — requires remage
- [ ] `pixi run test-python` — full suite, no regressions