### PR TITLE
feat(pdf): per-detector-group histograms via configurable regex map

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -500,10 +500,23 @@ probability density functions from the concatenated event files.
 :caption: simprod/config/tier/pdf/{experiment}/settings.yaml
 
 buffer_len: "500*MB"
+
+# optional: split 1-D PDFs by detector group
+detector_groups:
+  icpc: "V.*"
+  bege: "B.*"
 ```
 
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"500*MB"`). Controls memory
   usage during processing; does not affect the output.
+- `detector_groups` (mapping, optional) — maps group names to Python regex
+  strings. Each regex is matched against LEGEND-200 detector names using
+  `re.fullmatch`, so `"V.*"` selects all detectors whose names start with `V`.
+  When this key is absent, only the implicit `all` group is emitted (equivalent
+  to `detector_groups: {all: ".*"}`). Specifying `detector_groups` extends the
+  output: every named group is produced in addition to `all`, which is always
+  emitted regardless of the config. See {ref}`pdf-tier` for the resulting output
+  schema.
 
 ## `pars/` — simulation parameters
 

--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -165,13 +165,16 @@ the same file. In the `evt` tier, the TCM is a _unified_ version that merges the
 `hit` and `opt` TCMs, so that a single TCM entry references hits across both
 HPGe and SiPM detector tables.
 
+(pdf-tier)=
+
 ## `pdf` tier — probability density functions
 
 The `pdf` tier reads the event-level data from the `cvt` tier and bins it into
 energy histograms. These histograms represent the probability density functions
 (PDFs) used as inputs to spectral fitting analyses. The output is a single LH5
 file containing a set of histograms, each corresponding to a different event
-selection, and a scalar recording the total number of simulated primary events.
+selection and detector group, and a scalar recording the total number of
+simulated primary events.
 
 The histograms apply a sequence of analysis cuts — multiplicity, LAr
 anti-coincidence, and pulse-shape discrimination — to produce PDFs for the most
@@ -186,22 +189,30 @@ attribute in the LH5 attrs.
 
 ### `pdf/` — histogram struct
 
-All histograms are stored under the `pdf/` key as an LH5 `Struct`. Each entry is
-an lgdo `Histogram` with a `description` attribute.
+The 1-D histograms are organised cut-first, then by detector group:
+`pdf/<cut>/<group>`. Each leaf is an lgdo `Histogram`. The detector groups are
+configured via the `detector_groups` setting (see {ref}`pdf-tier-settings`); the
+`all` group containing every detector is always present.
+
+For example, with `detector_groups: {icpc: "V.*", bege: "B.*"}`, the output
+contains `pdf/hit/icpc`, `pdf/hit/bege`, and `pdf/hit/all`, and similarly for
+every other cut.
 
 #### 1D histograms
 
-Each of the following is a 1D histogram of HPGe energy deposits. The
+Each of the following cuts produces one `Histogram` per detector group. The
 `good_channel_mask` applied before all cuts requires every channel in the event
-to be an ON detector (not AC or OFF).
+to be an ON detector (not AC or OFF). Per-group filtering restricts which
+detector energies are accumulated into the histogram; the event-level cuts
+themselves are unchanged and applied globally.
 
-| Key           | Description                                                                                                                                                                                                                    |
+| Cut           | Description                                                                                                                                                                                                                    |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `hit`         | All individual HPGe energy deposits in ON-channel events, with no multiplicity requirement.                                                                                                                                    |
 | `mul`         | Multiplicity-1 events: exactly one ON detector fired (`geds.multiplicity == 1`).                                                                                                                                               |
-| `mul_lar`     | Multiplicity-1 events passing the LAr anti-coincidence cut. Events are vetoed when `coincident.spms` is `True` (SiPMs detected scintillation light in liquid argon).                                                           |
+| `mul_lar`     | Multiplicity-1 events passing the LAr anti-coincidence cut. Events are vetoed when `coincident.spms` is `True` (SiPMs detected scintillation light in liquid argon). Present only when SiPM data is available.                 |
 | `mul_psd`     | Multiplicity-1 events passing the PSD single-site cut. Requires `psd.is_good`, `psd.has_aoe`, and `psd.is_single_site` for all hits. Events where PSD is not valid or not simulated are classified as background and excluded. |
-| `mul_lar_psd` | Multiplicity-1 events passing both the LAr anti-coincidence and PSD single-site cuts (combination of `mul_lar` and `mul_psd`).                                                                                                 |
+| `mul_lar_psd` | Multiplicity-1 events passing both the LAr anti-coincidence and PSD single-site cuts (combination of `mul_lar` and `mul_psd`). Present only when SiPM data is available.                                                       |
 
 :::{warning}
 
@@ -222,13 +233,18 @@ and `psd.has_aoe = True`.
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mul2` | Multiplicity-2 events with exactly two ON detectors fired. A 2D histogram with axes (E_low, E_high), where E_low ≤ E_high are the two hit energies sorted in ascending order. |
 
+`mul2` is a single global histogram and is **not** split by detector group.
+Per-channel or per-pair 2-D PDFs are out of scope for the current
+implementation.
+
 ### `pdf/fail/` — cut-failure histograms
 
 The `fail/` sub-struct contains histograms for multiplicity-1 events that are
 explicitly rejected by a cut, providing a way to characterise the vetoed
-background.
+background. Like the pass histograms, each cut contains one `Histogram` per
+detector group (`pdf/fail/<cut>/<group>`).
 
-| Key   | Description                                                                                                                                                                 |
+| Cut   | Description                                                                                                                                                                 |
 | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lar` | Multiplicity-1 events failing the LAr veto (`coincident.spms == True`).                                                                                                     |
+| `lar` | Multiplicity-1 events failing the LAr veto (`coincident.spms == True`). Present only when SiPM data is available.                                                           |
 | `psd` | Multiplicity-1 events with valid PSD (`psd.is_good == True`) that fail the single-site cut (`psd.is_single_site == False`). Events without valid PSD are not included here. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,9 @@ snakemake-nersc = { cmd = "snakemake-nersc", depends-on = ["precompile"] }
 dry = { cmd = "snakemake --dry-run" }
 touch = { cmd = "snakemake --touch" }
 
+tier-opt = { cmd = "python -m legendsimflow.scripts.tier.opt" }
 tier-hit = { cmd = "python -m legendsimflow.scripts.tier.hit" }
+tier-evt = { cmd = "python -m legendsimflow.scripts.tier.evt" }
 tier-cvt = { cmd = "python -m legendsimflow.scripts.tier.cvt" }
 tier-pdf = { cmd = "python -m legendsimflow.scripts.tier.pdf" }
 

--- a/tests/scripts/test_tier_pdf.py
+++ b/tests/scripts/test_tier_pdf.py
@@ -1,36 +1,90 @@
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
 import yaml
-from lgdo import Array, Table, VectorOfVectors, lh5
+from lgdo import Array, Scalar, Struct, Table, VectorOfVectors, lh5
 
 from legendsimflow.scripts.tier import pdf
 
 dummyprod = Path(__file__).parent.parent / "dummyprod"
 
+
+def _write_detector_uids(path: Path, names: list[str], uids: list[int]) -> None:
+    detector_uids = Struct(
+        {name: Scalar(int(uid)) for name, uid in zip(names, uids, strict=True)}
+    )
+    lh5.write(detector_uids, "detector_uids", path, wo_mode="append")
+
+
 _SIMID_LEGEND = "birds_nest_K40"
 _SIMID_L1000 = "ultem_insulators_Pb214_to_Po214"
 
 
-def _make_cvt_file(path: Path) -> None:
-    """Write a minimal cvt LH5 file with the fields expected by the pdf script.
+def _make_metadata_with_pdf_settings(tmp_path: Path, extra_pdf_settings: dict) -> Path:
+    """Copy dummyprod inputs to tmp_path and patch the pdf/legend/settings.yaml."""
+    meta_dir = tmp_path / "inputs"
+    shutil.copytree(dummyprod / "inputs", meta_dir)
+    settings_path = (
+        meta_dir / "simprod" / "config" / "tier" / "pdf" / "legend" / "settings.yaml"
+    )
+    base = yaml.safe_load(settings_path.read_text())
+    base.update(extra_pdf_settings)
+    settings_path.write_text(yaml.safe_dump(base))
+    return meta_dir
 
-    6 events:
-    - event 0: m1, 500 keV,      spms=False, PSD valid+simulated+single-site → passes all cuts
-    - event 1: m1, 1000 keV,     spms=False, PSD valid+simulated+multi-site  → fail/psd
-    - event 2: m1, 1500 keV,     spms=False, PSD not valid                   → cut (no observable)
-    - event 3: m1, 2000 keV,     spms=True,  PSD valid+simulated+single-site → fail/lar
-    - event 4: m2, 200+300 keV,  spms=False
-    - event 5: m1, 2500 keV,     spms=False, PSD valid+not simulated         → cut (no observable)
-    """
+
+def _run_pdf(
+    tmp_path: Path,
+    monkeypatch,
+    cvt_file: Path,
+    meta_dir: Path | None = None,
+    simid: str = _SIMID_LEGEND,
+    config_template: str = "simflow-config.yaml",
+) -> Path:
+    config_path = tmp_path / config_template
+    raw_config = yaml.safe_load((dummyprod / config_template).read_text())
+    raw_config["paths"]["metadata"] = str(meta_dir or (dummyprod / "inputs"))
+    config_path.write_text(yaml.safe_dump(raw_config))
+
+    pdf_file = tmp_path / "pdf.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pdf",
+            "--cvt-file",
+            str(cvt_file),
+            "--pdf-file",
+            str(pdf_file),
+            "--simid",
+            simid,
+            "--simflow-config",
+            str(config_path),
+        ],
+    )
+    pdf.main()
+    return pdf_file
+
+
+def _make_cvt_file(path: Path) -> None:
+    """Write a minimal cvt LH5 file with the fields expected by the pdf script."""
+    # 6 events:
+    # - event 0: m1, 500 keV,      spms=False, PSD valid+simulated+single-site → passes all cuts
+    # - event 1: m1, 1000 keV,     spms=False, PSD valid+simulated+multi-site  → fail/psd
+    # - event 2: m1, 1500 keV,     spms=False, PSD not valid                   → cut (no observable)
+    # - event 3: m1, 2000 keV,     spms=True,  PSD valid+simulated+single-site → fail/lar
+    # - event 4: m2, 200+300 keV,  spms=False
+    # - event 5: m1, 2500 keV,     spms=False, PSD valid+not simulated         → cut (no observable)
     multiplicity = Array(np.array([1, 1, 1, 1, 2, 1], dtype=np.int32))
     energy = VectorOfVectors(
         data=[[500.0], [1000.0], [1500.0], [2000.0], [200.0, 300.0], [2500.0]]
     )
+    rawid = VectorOfVectors(data=[[1], [1], [1], [1], [1, 2], [1]])
     is_good_channel = VectorOfVectors(
         data=[[True], [True], [True], [True], [True, True], [True]]
     )
@@ -55,6 +109,7 @@ def _make_cvt_file(path: Path) -> None:
     geds = Table(
         col_dict={
             "energy": energy,
+            "rawid": rawid,
             "is_good_channel": is_good_channel,
             "multiplicity": multiplicity,
             "psd": psd,
@@ -63,35 +118,13 @@ def _make_cvt_file(path: Path) -> None:
     coincident = Table(col_dict={"spms": spms})
     evt = Table(col_dict={"geds": geds, "coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
+    _write_detector_uids(path, ["V01", "B02"], [1, 2])
 
 
 def test_pdf_script_cli(tmp_path, monkeypatch):
-    config_path = tmp_path / "simflow-config.yaml"
-    raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
-    raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path.write_text(yaml.safe_dump(raw_config))
-
     cvt_file = tmp_path / "cvt.lh5"
     _make_cvt_file(cvt_file)
-
-    pdf_file = tmp_path / "pdf.lh5"
-
-    # use a simid that exists in the dummyprod stp simconfig
-    simid = _SIMID_LEGEND
-
-    argv = [
-        "pdf",
-        "--cvt-file",
-        str(cvt_file),
-        "--pdf-file",
-        str(pdf_file),
-        "--simid",
-        simid,
-        "--simflow-config",
-        str(config_path),
-    ]
-    monkeypatch.setattr(sys, "argv", argv)
-    pdf.main()
+    pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file)
 
     assert pdf_file.exists()
     root_keys = lh5.ls(pdf_file)
@@ -119,42 +152,37 @@ def test_pdf_script_cli(tmp_path, monkeypatch):
         return lh5.read_as(path, pdf_file, "hist").sum()
 
     # 7 per-detector deposits: 5 m1 + 2 m2
-    assert _sum("pdf/hit") == 7
+    assert _sum("pdf/hit/all") == 7
 
     # 5 m1 events
-    assert _sum("pdf/mul") == 5
+    assert _sum("pdf/mul/all") == 5
 
     # event 3 (spms=True) is vetoed: 4 survive
-    assert _sum("pdf/mul_lar") == 4
+    assert _sum("pdf/mul_lar/all") == 4
 
     # events 0 and 3 pass PSD (valid+simulated+SS); events 1 (MS), 2 (invalid), 5 (not simulated) cut
-    assert _sum("pdf/mul_psd") == 2
+    assert _sum("pdf/mul_psd/all") == 2
 
     # event 3 also fails LAr, so only event 0 survives both
-    assert _sum("pdf/mul_lar_psd") == 1
+    assert _sum("pdf/mul_lar_psd/all") == 1
 
     # 1 m2 event
     assert _sum("pdf/mul2") == 1
 
     # event 3 fails LAr
-    assert _sum("pdf/fail/lar") == 1
+    assert _sum("pdf/fail/lar/all") == 1
 
     # event 1 (valid+simulated PSD, multi-site) fails PSD; event 5 (not simulated) excluded
-    assert _sum("pdf/fail/psd") == 1
+    assert _sum("pdf/fail/psd/all") == 1
 
 
 def _make_cvt_file_no_spms(path: Path) -> None:
-    """Write a minimal cvt LH5 file with no spms field in the coincident table.
-
-    Identical to ``_make_cvt_file`` except ``coincident`` carries only a
-    ``geds`` boolean array (no ``spms``).  This mirrors the on-disk structure
-    produced by evt.py when ``--skip-opt`` is passed.  pdf.py will see
-    ``has_spms_coinc=False`` and must omit the LAr histograms.
-    """
+    """Write a minimal cvt LH5 file with no spms field (mimics ``--skip-opt``)."""
     multiplicity = Array(np.array([1, 1, 1, 1, 2, 1], dtype=np.int32))
     energy = VectorOfVectors(
         data=[[500.0], [1000.0], [1500.0], [2000.0], [200.0, 300.0], [2500.0]]
     )
+    rawid = VectorOfVectors(data=[[1], [1], [1], [1], [1, 2], [1]])
     is_good_channel = VectorOfVectors(
         data=[[True], [True], [True], [True], [True, True], [True]]
     )
@@ -177,6 +205,7 @@ def _make_cvt_file_no_spms(path: Path) -> None:
     geds = Table(
         col_dict={
             "energy": energy,
+            "rawid": rawid,
             "is_good_channel": is_good_channel,
             "multiplicity": multiplicity,
             "psd": psd,
@@ -188,50 +217,25 @@ def _make_cvt_file_no_spms(path: Path) -> None:
     )
     evt = Table(col_dict={"geds": geds, "coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
+    _write_detector_uids(path, ["V01", "B02"], [1, 2])
 
 
 def _make_cvt_file_no_geds(path: Path) -> None:
-    """Write a minimal cvt LH5 file with no geds subtable.
-
-    The evt table contains only a ``coincident/spms`` boolean array.  This
-    mimics a production run with ``skip_hit: true``, where pdf.py will see
-    ``has_geds=False`` and ``has_spms_coinc=True``.
-    """
+    """Write a minimal cvt LH5 file with no geds subtable (mimics ``skip_hit: true``)."""
     spms = Array(np.array([False, True, False, True, False, False]))
     coincident = Table(col_dict={"spms": spms})
     # no geds field at the evt level → has_geds=False
     evt = Table(col_dict={"coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
+    # detector_uids is still present (skip_hit produces an empty mapping at evt tier)
+    _write_detector_uids(path, [], [])
 
 
 def test_pdf_script_cli_skip_opt(tmp_path, monkeypatch):
     """With no spms coincidence data (skip_opt), LAr histograms must be absent."""
-    config_path = tmp_path / "simflow-config.yaml"
-    raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
-    raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path.write_text(yaml.safe_dump(raw_config))
-
     cvt_file = tmp_path / "cvt.lh5"
     _make_cvt_file_no_spms(cvt_file)
-
-    pdf_file = tmp_path / "pdf.lh5"
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "pdf",
-            "--cvt-file",
-            str(cvt_file),
-            "--pdf-file",
-            str(pdf_file),
-            "--simid",
-            _SIMID_LEGEND,
-            "--simflow-config",
-            str(config_path),
-        ],
-    )
-    pdf.main()
+    pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file)
 
     assert pdf_file.exists()
 
@@ -256,40 +260,14 @@ def test_pdf_script_cli_skip_opt(tmp_path, monkeypatch):
     )
 
 
-def test_pdf_script_cli_skip_hit(tmp_path, monkeypatch):
-    """With no geds data (skip_hit), geds histograms absent; LAr histograms present with 0 counts.
-
-    pdf.py initialises mul_lar/mul_lar_psd/fail/lar whenever has_spms_coinc=True,
-    but only fills them inside the ``if has_geds:`` block.  When has_geds=False the
-    loop body takes the ``elif has_spms_coinc: pass`` branch, so all three histograms
-    are written to the output file with zero counts.
-    """
-    config_path = tmp_path / "simflow-config.yaml"
-    raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
-    raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path.write_text(yaml.safe_dump(raw_config))
-
+def test_pdf_script_cli_skip_hit(tmp_path, monkeypatch, caplog):
+    """With no geds data (skip_hit), geds histograms absent; LAr histograms present with 0 counts."""
     cvt_file = tmp_path / "cvt.lh5"
     _make_cvt_file_no_geds(cvt_file)
-
-    pdf_file = tmp_path / "pdf.lh5"
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "pdf",
-            "--cvt-file",
-            str(cvt_file),
-            "--pdf-file",
-            str(pdf_file),
-            "--simid",
-            _SIMID_LEGEND,
-            "--simflow-config",
-            str(config_path),
-        ],
-    )
-    pdf.main()
+    with caplog.at_level("WARNING"):
+        pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file)
+    # spurious "matches no detectors" warning is suppressed when has_geds=False
+    assert "matches no detectors" not in caplog.text
 
     assert pdf_file.exists()
 
@@ -321,13 +299,13 @@ def test_pdf_script_cli_skip_hit(tmp_path, monkeypatch):
         return lh5.read_as(path, pdf_file, "hist").sum()
 
     # all LAr histograms were initialised but never filled → 0 counts
-    assert _sum("pdf/mul_lar") == 0, (
+    assert _sum("pdf/mul_lar/all") == 0, (
         "pdf/mul_lar should have 0 counts when has_geds=False"
     )
-    assert _sum("pdf/mul_lar_psd") == 0, (
+    assert _sum("pdf/mul_lar_psd/all") == 0, (
         "pdf/mul_lar_psd should have 0 counts when has_geds=False"
     )
-    assert _sum("pdf/fail/lar") == 0, (
+    assert _sum("pdf/fail/lar/all") == 0, (
         "pdf/fail/lar should have 0 counts when has_geds=False"
     )
 
@@ -335,29 +313,13 @@ def test_pdf_script_cli_skip_hit(tmp_path, monkeypatch):
 @pytest.mark.needs_remage
 def test_pdf_script_cli_with_real_cvt(tmp_path, monkeypatch, legend_cvt_path):
     """Run the pdf script on a real cvt file produced by the full test pipeline."""
-    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path = tmp_path / "simflow-config-l1000.yaml"
-    config_path.write_text(yaml.safe_dump(raw))
-
-    pdf_file = tmp_path / "pdf.lh5"
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "pdf",
-            "--cvt-file",
-            str(legend_cvt_path),
-            "--pdf-file",
-            str(pdf_file),
-            "--simid",
-            _SIMID_L1000,
-            "--simflow-config",
-            str(config_path),
-        ],
+    pdf_file = _run_pdf(
+        tmp_path,
+        monkeypatch,
+        legend_cvt_path,
+        simid=_SIMID_L1000,
+        config_template="simflow-config-l1000.yaml",
     )
-    pdf.main()
 
     assert pdf_file.exists(), "pdf output file was not created"
 
@@ -385,9 +347,114 @@ def test_pdf_script_cli_with_real_cvt(tmp_path, monkeypatch, legend_cvt_path):
         return lh5.read_as(path, pdf_file, "hist").sum()
 
     # cut hierarchy must be non-increasing
-    n_mul = _sum("pdf/mul")
-    assert _sum("pdf/hit") >= n_mul
-    assert _sum("pdf/mul_lar") <= n_mul
-    assert _sum("pdf/mul_psd") <= n_mul
-    assert _sum("pdf/mul_lar_psd") <= _sum("pdf/mul_lar")
-    assert _sum("pdf/mul_lar_psd") <= _sum("pdf/mul_psd")
+    n_mul = _sum("pdf/mul/all")
+    assert _sum("pdf/hit/all") >= n_mul
+    assert _sum("pdf/mul_lar/all") <= n_mul
+    assert _sum("pdf/mul_psd/all") <= n_mul
+    assert _sum("pdf/mul_lar_psd/all") <= _sum("pdf/mul_lar/all")
+    assert _sum("pdf/mul_lar_psd/all") <= _sum("pdf/mul_psd/all")
+
+
+def test_pdf_detector_groups_schema(tmp_path, monkeypatch):
+    """With detector_groups configured, output has per-group and 'all' histograms for every cut."""
+    meta_dir = _make_metadata_with_pdf_settings(
+        tmp_path, {"detector_groups": {"icpc": "V.*", "bege": "B.*"}}
+    )
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_file(cvt_file)
+
+    pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file, meta_dir=meta_dir)
+    assert pdf_file.exists()
+
+    root_keys = lh5.ls(str(pdf_file))
+    assert "pdf" in root_keys
+    assert "nr_sim_events" in root_keys
+    assert "mul2" not in root_keys  # mul2 is under pdf/, not root
+
+    inner_keys = lh5.ls(str(pdf_file), "pdf/")
+    assert "pdf/mul2" in inner_keys  # global, not split by group
+
+    for cut in ("hit", "mul", "mul_lar", "mul_psd", "mul_lar_psd"):
+        assert f"pdf/{cut}" in inner_keys, f"pdf/{cut} missing"
+        cut_keys = lh5.ls(str(pdf_file), f"pdf/{cut}/")
+        for group in ("icpc", "bege", "all"):
+            assert f"pdf/{cut}/{group}" in cut_keys, (
+                f"pdf/{cut}/{group} missing; got {cut_keys}"
+            )
+
+    fail_keys = lh5.ls(str(pdf_file), "pdf/fail/")
+    for fail_cut in ("psd", "lar"):
+        assert f"pdf/fail/{fail_cut}" in fail_keys, f"pdf/fail/{fail_cut} missing"
+        fc_keys = lh5.ls(str(pdf_file), f"pdf/fail/{fail_cut}/")
+        for group in ("icpc", "bege", "all"):
+            assert f"pdf/fail/{fail_cut}/{group}" in fc_keys, (
+                f"pdf/fail/{fail_cut}/{group} missing; got {fc_keys}"
+            )
+
+
+def test_pdf_no_detector_groups_schema(tmp_path, monkeypatch):
+    """Without detector_groups, output has only 'all' histograms for every cut."""
+    meta_dir = _make_metadata_with_pdf_settings(tmp_path, {})
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_file(cvt_file)
+
+    pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file, meta_dir=meta_dir)
+    assert pdf_file.exists()
+
+    inner_keys = lh5.ls(str(pdf_file), "pdf/")
+    assert "pdf/mul2" in inner_keys
+
+    for cut in ("hit", "mul", "mul_lar", "mul_psd", "mul_lar_psd"):
+        assert f"pdf/{cut}" in inner_keys, f"pdf/{cut} missing"
+        cut_keys = lh5.ls(str(pdf_file), f"pdf/{cut}/")
+        assert f"pdf/{cut}/all" in cut_keys, f"pdf/{cut}/all missing"
+        for group in ("icpc", "bege"):
+            assert f"pdf/{cut}/{group}" not in cut_keys, (
+                f"pdf/{cut}/{group} should be absent without detector_groups; got {cut_keys}"
+            )
+
+    fail_keys = lh5.ls(str(pdf_file), "pdf/fail/")
+    for fail_cut in ("psd", "lar"):
+        assert f"pdf/fail/{fail_cut}" in fail_keys
+        fc_keys = lh5.ls(str(pdf_file), f"pdf/fail/{fail_cut}/")
+        assert f"pdf/fail/{fail_cut}/all" in fc_keys
+        for group in ("icpc", "bege"):
+            assert f"pdf/fail/{fail_cut}/{group}" not in fc_keys, (
+                f"pdf/fail/{fail_cut}/{group} should be absent without detector_groups"
+            )
+
+
+def test_pdf_detector_groups_sum_equals_all(tmp_path, monkeypatch):
+    """For non-overlapping groups that partition all detectors, sum of groups equals 'all'."""
+    meta_dir = _make_metadata_with_pdf_settings(
+        tmp_path, {"detector_groups": {"icpc": "V.*", "bege": "B.*"}}
+    )
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_file(cvt_file)
+
+    pdf_file = _run_pdf(tmp_path, monkeypatch, cvt_file, meta_dir=meta_dir)
+
+    def _counts(path):
+        return lh5.read_as(path, str(pdf_file), "hist").values()
+
+    cuts_to_check = [
+        "hit",
+        "mul",
+        "mul_lar",
+        "mul_psd",
+        "mul_lar_psd",
+        "fail/psd",
+        "fail/lar",
+    ]
+    for cut in cuts_to_check:
+        icpc = _counts(f"pdf/{cut}/icpc")
+        bege = _counts(f"pdf/{cut}/bege")
+        all_counts = _counts(f"pdf/{cut}/all")
+        np.testing.assert_array_equal(
+            icpc + bege,
+            all_counts,
+            err_msg=f"sum(icpc + bege) != all for cut '{cut}'",
+        )

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -26,7 +26,7 @@ from legendsimflow import aggregate, nersc, utils
 
 logger.info("Initializing workflow context")
 
-SIMFLOW_CONTEXT = utils.init_simflow_context(config, workflow)
+SIMFLOW_CONTEXT = utils.init_simflow_context(config, workflow, logger=logger)
 config = SIMFLOW_CONTEXT.config
 
 # sanitize the make_steps field

--- a/workflow/rules/evt.smk
+++ b/workflow/rules/evt.smk
@@ -38,6 +38,10 @@ rule build_tier_evt:
       added as `spms/rc_energy` and `spms/rc_time` (controlled by
       ``add_random_coincidences`` in ``tier/evt/{experiment}/settings.yaml``).
 
+    A top-level `detector_uids` struct mapping detector names to reboost UIDs
+    (union of hit and opt tiers) is also written, to enable downstream
+    per-group filtering in the `pdf` tier.
+
     Uses wildcards `simid` and `jobid`.
     """
     message:

--- a/workflow/rules/pdf.smk
+++ b/workflow/rules/pdf.smk
@@ -1,6 +1,9 @@
 from pathlib import Path
 
 from legendsimflow import aggregate, patterns
+from legendsimflow.metadata import get_tier_settings
+
+_pdf_settings = get_tier_settings(config, "pdf")
 
 
 rule gen_all_tier_pdf:
@@ -50,6 +53,9 @@ rule build_tier_pdf:
         "Producing output file for job pdf.{wildcards.simid}"
     input:
         cvt_file=patterns.output_tier_cvt_filename(config),
+    params:
+        # surfaced so Snakemake invalidates outputs when the regex map changes
+        detector_groups=_pdf_settings.get("detector_groups", None),
     output:
         patterns.output_tier_pdf_filename(config),
     log:

--- a/workflow/src/legendsimflow/cli.py
+++ b/workflow/src/legendsimflow/cli.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import random
 import shlex
 import signal
@@ -27,6 +28,8 @@ from legenddataflowscripts.workflow.utils import subst_vars
 from legendmeta import LegendMetadata
 
 from . import aggregate
+
+log = logging.getLogger(__name__)
 
 
 def _partition(xs, n):
@@ -84,6 +87,10 @@ def snakemake_nersc_cli():
     metadata = LegendMetadata(config.paths.metadata, lazy=True)
 
     if "legend_metadata_version" in config:
+        log.info(
+            "checking out legend-metadata version %s",
+            config.legend_metadata_version,
+        )
         metadata.checkout(config.legend_metadata_version)
 
     config["metadata"] = metadata

--- a/workflow/src/legendsimflow/scripts/tier/cvt.py
+++ b/workflow/src/legendsimflow/scripts/tier/cvt.py
@@ -68,7 +68,25 @@ def main() -> None:
     if len(evt_files) == 1:
         shutil.copy(evt_files[0], cvt_file)
     else:
+        # detector_uids must be identical across all evt inputs; merging would
+        # silently mask mismatches, so assert before copying.
+        ref = lh5.read("detector_uids", evt_files[0])
+        ref_map = {name: int(ref[name].value) for name in ref}
+        for f in evt_files[1:]:
+            other = lh5.read("detector_uids", f)
+            other_map = {name: int(other[name].value) for name in other}
+            if other_map != ref_map:
+                msg = (
+                    f"detector_uids in {f} disagrees with {evt_files[0]}; "
+                    "cvt merge requires all evt inputs to share the same "
+                    "name->rawid mapping"
+                )
+                raise ValueError(msg)
+        lh5.write(ref, "detector_uids", cvt_file, wo_mode="write_safe")
+
         for table in lh5.ls(evt_files[0]):
+            if table == "detector_uids":
+                continue
             for chunk in lh5.LH5Iterator(evt_files, table, buffer_len=buffer_len):
                 lh5.write(chunk, table, cvt_file, wo_mode="append")
 

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -24,7 +24,7 @@ import legenddataflowscripts.utils
 import numpy as np
 from dbetto import AttrsDict
 from dbetto.utils import load_dict
-from lgdo import Array, Table, VectorOfVectors, lh5
+from lgdo import Array, Scalar, Struct, Table, VectorOfVectors, lh5
 from snakemake_argparse_bridge import snakemake_compatible
 
 from legendsimflow import nersc, spms_pars, utils
@@ -577,6 +577,18 @@ def main() -> None:
                 evt_wo_mode = "append"
 
         print_stats_since_last()
+
+    # always written (empty when both skip_hit and skip_opt) so cvt can rely on
+    # a stable schema. Reboost UIDs are disjoint between systems so the union
+    # is unambiguous.
+    detector_uids = Struct(
+        {
+            name: Scalar(int(uid))
+            for tier in ("hit", "opt")
+            for name, uid in det2uid[tier].items()
+        }
+    )
+    lh5.write(detector_uids, "detector_uids", evt_file, wo_mode="append")
 
     with perf_block("move_to_cfs()"):
         move2cfs()

--- a/workflow/src/legendsimflow/scripts/tier/pdf.py
+++ b/workflow/src/legendsimflow/scripts/tier/pdf.py
@@ -16,11 +16,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
+import re
 
 import awkward as ak
 import hist
 import legenddataflowscripts as ldfs
 import legenddataflowscripts.utils
+import numpy as np
 from lgdo import Histogram, Scalar, Struct, lh5
 from snakemake_argparse_bridge import snakemake_compatible
 
@@ -77,6 +79,27 @@ def main() -> None:
         for k in lh5.ls(_cvt_file_str, "evt/coincident/")
     }
 
+    # resolve detector-group regexes against the name->uid map written at
+    # evt-tier build time; the implicit "all" group is always emitted.
+    detector_uids = lh5.read("detector_uids", str(cvt_file))
+    name_to_uid = {name: int(detector_uids[name].value) for name in detector_uids}
+
+    groups: dict[str, str] = dict(tier_pdf_settings.get("detector_groups", {}))
+    if "all" in groups:
+        log.warning(
+            "detector_groups contains an 'all' key; it will be overridden by the implicit all-detector group"
+        )
+    groups["all"] = ".*"
+
+    group_uids: dict[str, np.ndarray] = {}
+    for gname, pat in groups.items():
+        rgx = re.compile(pat)
+        matched = sorted(uid for n, uid in name_to_uid.items() if rgx.fullmatch(n))
+        # skip_hit upstream produces an empty detector_uids by design; warning would be spurious.
+        if not matched and has_geds:
+            log.warning("detector group %r matches no detectors", gname)
+        group_uids[gname] = np.asarray(matched, dtype=np.int64)
+
     # a single cvt file might be large, need to iterate
     iterator = lh5.LH5Iterator(
         str(cvt_file),
@@ -94,83 +117,118 @@ def main() -> None:
 
     # 1 keV/bin over 0-6000 keV; boost-histogram only provides Double (float64) storage
     h1 = hist.new.Reg(6000, 0, 6000).Double
-    histograms = {}
-    fail_histograms = {}
+
+    # 1-D histograms are split per detector group; mul2 stays global.
+    histograms: dict[str, dict[str, hist.Hist]] = {}
+    fail_histograms: dict[str, dict[str, hist.Hist]] = {}
+    mul2_hist = None
 
     if has_geds:
-        histograms["hit"] = h1()
-        histograms["mul"] = h1()
-        histograms["mul_psd"] = h1()
-        # 2-D: (E_min, E_max) for multiplicity-2 events
-        histograms["mul2"] = hist.new.Reg(6000, 0, 6000).Reg(6000, 0, 6000).Double()
-        fail_histograms["psd"] = h1()
+        for cut in ("hit", "mul", "mul_psd"):
+            histograms[cut] = {g: h1() for g in groups}
+        fail_histograms["psd"] = {g: h1() for g in groups}
+        # 2-D: (E_min, E_max) for multiplicity-2 events; not split by group
+        mul2_hist = hist.new.Reg(6000, 0, 6000).Reg(6000, 0, 6000).Double()
 
     if has_spms_coinc:
-        histograms["mul_lar"] = h1()
-        histograms["mul_lar_psd"] = h1()
-        fail_histograms["lar"] = h1()
+        for cut in ("mul_lar", "mul_lar_psd"):
+            histograms[cut] = {g: h1() for g in groups}
+        fail_histograms["lar"] = {g: h1() for g in groups}
 
     log.info("... beginning iteration over cvt file")
+
+    def _fill_per_group(
+        per_group_hists: dict[str, hist.Hist],
+        energy: ak.Array,
+        det_mask: dict[str, ak.Array],
+    ) -> None:
+        for g in groups:
+            per_group_hists[g].fill(ak.flatten(energy[det_mask[g]]))
+
+    # events without a valid or simulated A/E are classified as background (cut).
+    def _psd_mask(d: ak.Array) -> ak.Array:
+        return ak.all(
+            d.geds.psd.is_good & d.geds.psd.has_aoe & d.geds.psd.is_single_site,
+            axis=-1,
+        )
 
     for chunk in iterator:
         data = chunk.view_as("ak")
 
         if has_geds:
-            # all-good-channel mask: every detector in the event must be usable
+            # awkward 2.x has no ak.isin: build per-group masks via flatten / np.isin / unflatten.
+            counts = ak.num(data.geds.rawid)
+            flat_rawid = ak.flatten(data.geds.rawid)
+            det_in_group = {
+                g: ak.unflatten(np.isin(flat_rawid, uids), counts)
+                for g, uids in group_uids.items()
+            }
+
             good_channel_mask = ak.all(data.geds.is_good_channel, axis=-1)
 
-            # hit: all energy deposits in good-channel events, no multiplicity requirement
             data_hit = data[good_channel_mask]
-            histograms["hit"].fill(ak.flatten(data_hit.geds.energy))
+            det_hit = {g: m[good_channel_mask] for g, m in det_in_group.items()}
+            _fill_per_group(histograms["hit"], data_hit.geds.energy, det_hit)
 
-            # multiplicity cut: keep only events where exactly one ON detector fired
-            data_m1 = data[(data.geds.multiplicity == 1) & good_channel_mask]
-            histograms["mul"].fill(ak.flatten(data_m1.geds.energy))
+            m1_event_mask = (data.geds.multiplicity == 1) & good_channel_mask
+            data_m1 = data[m1_event_mask]
+            det_m1 = {g: m[m1_event_mask] for g, m in det_in_group.items()}
+            _fill_per_group(histograms["mul"], data_m1.geds.energy, det_m1)
 
             data_m1_lar = data_m1
+            det_m1_lar = det_m1
             if has_spms_coinc:
-                # LAr cut: coincident.spms is True when SiPMs detected scintillation light
-                # in liquid argon — such events are vetoed
-                data_m1_lar = data_m1[~data_m1.coincident.spms]
-                histograms["mul_lar"].fill(ak.flatten(data_m1_lar.geds.energy))
-                fail_histograms["lar"].fill(
-                    ak.flatten(data_m1[data_m1.coincident.spms].geds.energy)
+                lar_pass_m1 = ~data_m1.coincident.spms
+                data_m1_lar = data_m1[lar_pass_m1]
+                det_m1_lar = {g: m[lar_pass_m1] for g, m in det_m1.items()}
+                _fill_per_group(
+                    histograms["mul_lar"], data_m1_lar.geds.energy, det_m1_lar
                 )
 
-            # PSD cut: require valid PSD in data (is_good), simulated A/E observable
-            # (has_aoe), and single-site topology (is_single_site). Events where PSD is
-            # not valid or not simulated are classified as background and cut.
-            def _psd_mask(d):
-                return ak.all(
-                    d.geds.psd.is_good & d.geds.psd.has_aoe & d.geds.psd.is_single_site,
-                    axis=-1,
+                lar_fail_m1 = data_m1.coincident.spms
+                data_m1_lar_fail = data_m1[lar_fail_m1]
+                det_m1_lar_fail = {g: m[lar_fail_m1] for g, m in det_m1.items()}
+                _fill_per_group(
+                    fail_histograms["lar"],
+                    data_m1_lar_fail.geds.energy,
+                    det_m1_lar_fail,
                 )
 
-            histograms["mul_psd"].fill(
-                ak.flatten(data_m1[_psd_mask(data_m1)].geds.energy)
+            psd_pass_m1 = _psd_mask(data_m1)
+            data_m1_psd = data_m1[psd_pass_m1]
+            det_m1_psd = {g: m[psd_pass_m1] for g, m in det_m1.items()}
+            _fill_per_group(histograms["mul_psd"], data_m1_psd.geds.energy, det_m1_psd)
+
+            if has_spms_coinc:
+                psd_pass_m1_lar = _psd_mask(data_m1_lar)
+                data_m1_lar_psd = data_m1_lar[psd_pass_m1_lar]
+                det_m1_lar_psd = {g: m[psd_pass_m1_lar] for g, m in det_m1_lar.items()}
+                _fill_per_group(
+                    histograms["mul_lar_psd"],
+                    data_m1_lar_psd.geds.energy,
+                    det_m1_lar_psd,
+                )
+
+            psd_fail_mask = (
+                ak.all(data_m1.geds.psd.is_good & data_m1.geds.psd.has_aoe, axis=-1)
+                & ~psd_pass_m1
+            )
+            data_m1_psd_fail = data_m1[psd_fail_mask]
+            det_m1_psd_fail = {g: m[psd_fail_mask] for g, m in det_m1.items()}
+            _fill_per_group(
+                fail_histograms["psd"],
+                data_m1_psd_fail.geds.energy,
+                det_m1_psd_fail,
             )
 
-            if has_spms_coinc:
-                histograms["mul_lar_psd"].fill(
-                    ak.flatten(data_m1_lar[_psd_mask(data_m1_lar)].geds.energy)
-                )
-
-            # fail/psd: m1 events with valid and simulated PSD but failing single-site
-            psd_fail_mask = ak.all(
-                data_m1.geds.psd.is_good & data_m1.geds.psd.has_aoe, axis=-1
-            ) & ~_psd_mask(data_m1)
-            fail_histograms["psd"].fill(ak.flatten(data_m1[psd_fail_mask].geds.energy))
-
-            # m2: events with exactly two detectors fired — fill 2D histogram with (E_low, E_high)
             data_m2 = data[(data.geds.multiplicity == 2) & good_channel_mask]
-            histograms["mul2"].fill(
+            assert mul2_hist is not None
+            mul2_hist.fill(
                 ak.min(data_m2.geds.energy, axis=-1),
                 ak.max(data_m2.geds.energy, axis=-1),
             )
 
         elif has_spms_coinc:
-            # no geds data but spms coincidence data exists: only fill LAr histograms
-            # (we cannot compute meaningful mul_lar without geds energy, so skip filling)
             pass
 
     log.info("... convert histograms to lgdo")
@@ -186,16 +244,32 @@ def main() -> None:
         "fail/psd": "multiplicity-1 events with valid PSD failing the PSD cut",
     }
 
-    output_dict = {
-        name: Histogram(h, attrs={"description": _descriptions[name]})
-        for name, h in histograms.items()
+    output_dict: dict[str, Struct | Histogram] = {
+        cut: Struct(
+            {
+                g: Histogram(h, attrs={"description": _descriptions[cut]})
+                for g, h in per_group.items()
+            }
+        )
+        for cut, per_group in histograms.items()
     }
     if fail_histograms:
         output_dict["fail"] = Struct(
             {
-                name: Histogram(h, attrs={"description": _descriptions[f"fail/{name}"]})
-                for name, h in fail_histograms.items()
+                cut: Struct(
+                    {
+                        g: Histogram(
+                            h, attrs={"description": _descriptions[f"fail/{cut}"]}
+                        )
+                        for g, h in per_group.items()
+                    }
+                )
+                for cut, per_group in fail_histograms.items()
             }
+        )
+    if mul2_hist is not None:
+        output_dict["mul2"] = Histogram(
+            mul2_hist, attrs={"description": _descriptions["mul2"]}
         )
     output = Struct(output_dict)
     lh5.write(output, "pdf", pdf_file, wo_mode="w")

--- a/workflow/src/legendsimflow/utils.py
+++ b/workflow/src/legendsimflow/utils.py
@@ -103,7 +103,9 @@ def apply_path_defaults(paths: dict) -> None:
 
 
 def init_simflow_context(
-    raw_config: dict | AttrsDict | str | Path, workflow=None
+    raw_config: dict | AttrsDict | str | Path,
+    workflow=None,
+    logger: logging.Logger | None = None,
 ) -> AttrsDict:
     """Pre-process and sanitize the Simflow configuration.
 
@@ -127,8 +129,12 @@ def init_simflow_context(
         Snakemake workflow instance. If None, occurrences of ``$_`` in the
         configuration will be replaced with the path to the current working
         directory.
+    logger
+        Logger to use for status messages (e.g. the Snakemake logger when
+        called from a Snakefile). Defaults to the module logger.
 
     """
+    log_ = logger if logger is not None else log
     if not raw_config:
         msg = "you must set a config file with --configfile"
         raise RuntimeError(msg)
@@ -182,10 +188,14 @@ def init_simflow_context(
         metadata = LegendMetadata(config.paths.metadata, lazy=True)
 
         if "legend_metadata_version" in config:
+            log_.info(
+                "checking out legend-metadata version %s",
+                config.legend_metadata_version,
+            )
             try:
                 metadata.checkout(config.legend_metadata_version)
             except GitCommandError as e:
-                log.warning("could not checkout legend-metadata version: %s", e)
+                log_.warning("could not checkout legend-metadata version: %s", e)
 
         # NOTE: read only path on NERSC, we are not going to modify the db
         # NOTE: don't use lazy=True, we need a fully functional TextDB


### PR DESCRIPTION
## Summary

- Add an optional `detector_groups` block to the PDF tier settings that maps group names to Python regexes on LEGEND-200 detector names. The PDF tier emits one set of 1-D histograms per group at `pdf/<cut>/<group>/`. An implicit `all` group is always present.
- Cuts (good-channel, m=1, m=2, PSD single-site, LAr veto, fail masks) are computed globally and unchanged; per-group filtering only restricts which detector energies enter each group's histogram.
- The 2-D `mul2` histogram intentionally stays at the top level — per-group/per-pair 2-D splitting is out of scope for this iteration.
- The evt tier writes a top-level `detector_uids` LH5 `Struct` mapping detector names (union of hit and opt tiers) to reboost UIDs; cvt asserts agreement across inputs and propagates it. The PDF tier reads it once at startup, so it never deals with raw UIDs itself.
- `build_tier_pdf` gains a `params: detector_groups=...` block so config changes invalidate downstream outputs.

### Configuration

```yaml
# inputs/simprod/config/tier/pdf/<exp>/settings.yaml
detector_groups:
  icpc: "V.*"
  bege: "B.*"
```

### `detector_uids` layout in evt/cvt files

```
detector_uids · struct{V01,B02,...}
├── V01  · scalar<int64>     # reboost UID
├── B02  · scalar<int64>
└── ...
```

### Breaking change

PDF tier output schema changes from `pdf/<cut>` to `pdf/<cut>/<group>` (with `pdf/fail/<cut>/<group>` for fails). Downstream consumers must read the `all` group to preserve prior behaviour. External consumers (legend-pdfs, fits) are out of scope here.

## Test plan

- [x] `pixi run test-python` — full Python suite green (218 passed; pre-existing `test_dag` sandbox failure unrelated).
- [x] `pre-commit run --all-files` — clean on all touched files.
- [x] `cd docs && make` — clean build, no warnings.
- [x] Three new tests: schema with `detector_groups`, schema without (only `all`), and `sum(per-group) == all` cross-check on a non-overlapping `V.*`/`B.*` partition.
- [x] `caplog` assertion that the empty-group warning is silent on the `skip_hit` path.