### PR TITLE
feat(utils): symlink overridden paths into default locations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "dspeed",
     "pygama >=2.3.6",
     "pylegendmeta >=1.4.1",
+    "pyyaml",
     "reboost >=0.10.3,<0.11",
     "revertex >=0.1.2",
     "ruamel.yaml",
@@ -122,6 +123,7 @@ matplotlib = "*"
 numpy = "*"
 pylegendmeta = ">=1.4.1,<1.5"
 psutil = "*"
+pyyaml = "*"
 "ruamel.yaml" = "*"
 
 # execution

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from legendmeta import LegendMetadata
 from lgdo import Array, Table, lh5
 
 from legendsimflow import hpge_pars, utils
+
+_REPO_TEMPLATES = Path(__file__).resolve().parents[1] / "templates"
 
 
 def test_get_parameter_dict():
@@ -451,3 +454,184 @@ def test_get_dict_value():
     assert utils.get_dict_value(d, "a.b") == 3
     assert utils.get_dict_value(d, "a.b.d") is None
     assert utils.get_dict_value(d, "a.b.d", 69) == 69
+
+
+@pytest.fixture
+def link_setup(tmp_path, monkeypatch):
+    """Fake simflow source repo + a prod cycle as cwd + a config of all-default paths."""
+    repo = tmp_path / "simflow"
+    workflow_basedir = repo / "workflow"
+    workflow_basedir.mkdir(parents=True)
+    (repo / "templates").mkdir()
+    shutil.copy(_REPO_TEMPLATES / "default.yaml", repo / "templates" / "default.yaml")
+
+    cycle = tmp_path / "cycle"
+    cycle.mkdir()
+    monkeypatch.chdir(cycle)
+
+    config = AttrsDict(
+        {
+            "paths": AttrsDict(
+                {
+                    "pars": cycle / "generated/pars",
+                    "macros": cycle / "generated/macros",
+                    "geom": cycle / "generated/pars/geom",
+                    "dtmaps": cycle / "generated/pars/hpge/dtmaps",
+                    "tier": AttrsDict(
+                        {
+                            t: cycle / f"generated/tier/{t}"
+                            for t in (
+                                "vtx",
+                                "stp",
+                                "par",
+                                "opt",
+                                "hit",
+                                "evt",
+                                "cvt",
+                                "pdf",
+                            )
+                        }
+                    ),
+                }
+            )
+        }
+    )
+    return workflow_basedir, cycle, config
+
+
+def test_link_external_paths_links_overrides(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    ext_hit = tmp_path / "external" / "hit"
+    ext_opt = tmp_path / "external" / "opt"
+    ext_pars = tmp_path / "external" / "pars"
+    for d in (ext_hit, ext_opt, ext_pars):
+        d.mkdir(parents=True)
+    config.paths.tier["hit"] = ext_hit
+    config.paths.tier["opt"] = ext_opt
+    config.paths["pars"] = ext_pars
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    for default, target in (
+        (cycle / "generated/tier/hit", ext_hit),
+        (cycle / "generated/tier/opt", ext_opt),
+        (cycle / "generated/pars", ext_pars),
+    ):
+        assert default.is_symlink()
+        assert not default.readlink().is_absolute()
+        assert default.resolve() == target.resolve()
+
+    assert not (cycle / "generated/tier/evt").exists()
+
+
+def test_link_external_paths_noop_when_at_default(link_setup):
+    workflow_basedir, cycle, config = link_setup
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    for tier in ("hit", "opt", "evt"):
+        assert not (cycle / f"generated/tier/{tier}").exists()
+    assert not (cycle / "generated/pars").exists()
+
+
+def test_link_external_paths_skips_real_default_directories(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    ext_hit = tmp_path / "external" / "hit"
+    ext_hit.mkdir(parents=True)
+    config.paths.tier["hit"] = ext_hit
+
+    real = cycle / "generated/tier/hit"
+    real.mkdir(parents=True)
+    (real / "data.lh5").touch()
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    assert not real.is_symlink()
+    assert (real / "data.lh5").is_file()
+
+
+def test_link_external_paths_is_idempotent(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    ext_hit = tmp_path / "external" / "hit"
+    ext_hit.mkdir(parents=True)
+    config.paths.tier["hit"] = ext_hit
+
+    utils.link_external_paths(config, workflow_basedir)
+    default = cycle / "generated/tier/hit"
+    target1 = default.readlink()
+
+    utils.link_external_paths(config, workflow_basedir)
+    target2 = default.readlink()
+
+    assert target1 == target2
+
+
+def test_link_external_paths_replaces_wrong_symlink(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    ext_hit = tmp_path / "external" / "hit"
+    ext_hit.mkdir(parents=True)
+    config.paths.tier["hit"] = ext_hit
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    default = cycle / "generated/tier/hit"
+    default.parent.mkdir(parents=True)
+    default.symlink_to(elsewhere)
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    assert default.is_symlink()
+    assert default.resolve() == ext_hit.resolve()
+
+
+def test_link_external_paths_removes_stale_symlink(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    default = cycle / "generated/tier/hit"
+    default.parent.mkdir(parents=True)
+    default.symlink_to(elsewhere)
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    assert not default.is_symlink()
+    assert not default.exists()
+
+
+def test_link_external_paths_geom_dtmaps_default(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+    del config.paths["pars"]
+    ext_geom = tmp_path / "external" / "geom"
+    ext_dtmaps = tmp_path / "external" / "dtmaps"
+    ext_geom.mkdir(parents=True)
+    ext_dtmaps.mkdir(parents=True)
+    config.paths["geom"] = ext_geom
+    config.paths["dtmaps"] = ext_dtmaps
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    default_geom = cycle / "generated/pars/geom"
+    default_dtmaps = cycle / "generated/pars/hpge/dtmaps"
+    assert default_geom.is_symlink()
+    assert default_geom.resolve() == ext_geom.resolve()
+    assert default_dtmaps.is_symlink()
+    assert default_dtmaps.resolve() == ext_dtmaps.resolve()
+
+
+def test_link_external_paths_creates_intermediate_dirs(link_setup, tmp_path):
+    workflow_basedir, cycle, config = link_setup
+
+    ext_hit = tmp_path / "external" / "hit"
+    ext_hit.mkdir(parents=True)
+    config.paths.tier["hit"] = ext_hit
+
+    assert not (cycle / "generated").exists()
+
+    utils.link_external_paths(config, workflow_basedir)
+
+    assert (cycle / "generated/tier/hit").is_symlink()

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -53,6 +53,8 @@ wildcard_constraints:
 onstart:
     utils.setup_logdir_link(config)
 
+    utils.link_external_paths(config, workflow.basedir, logger=logger)
+
     logger.info("Starting workflow")
 
 

--- a/workflow/src/legendsimflow/utils.py
+++ b/workflow/src/legendsimflow/utils.py
@@ -32,6 +32,7 @@ import h5py
 import legenddataflowscripts as ldfs
 import lgdo
 import numpy as np
+import yaml
 from dbetto import AttrsDict, TextDB
 from git.exc import GitCommandError
 from legendmeta import LegendMetadata
@@ -100,6 +101,129 @@ def apply_path_defaults(paths: dict) -> None:
         paths["geom"] = paths["pars"] / "geom"
     if "dtmaps" not in paths:
         paths["dtmaps"] = paths["pars"] / "hpge/dtmaps"
+
+
+def link_external_paths(
+    config: AttrsDict,
+    workflow_basedir: str | Path,
+    *,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Symlink user-overridden paths back into their default locations.
+
+    When the user has manually overridden a ``paths.<key>`` entry in
+    ``simflow-config.yaml`` to point outside the current production cycle
+    (e.g. reusing the ``hit`` tier from another production), this function
+    creates a symlink at the canonical default location pointing to the
+    override. Snakemake rules keep reading ``config.paths.<key>``
+    directly; the symlink only exists so the prod cycle's own
+    ``generated/`` tree shows the external data in the standard layout.
+
+    The default locations are computed from the simflow's own template at
+    ``<workflow_basedir>/../templates/default.yaml``, with ``$_``
+    substituted to the current working directory (the prod cycle root in
+    the standard Snakemake invocation). Created symlinks are relative to
+    the destination's parent, keeping the prod cycle portable.
+
+    For each supported key:
+
+    - if ``config.paths.<key>`` resolves to the default location, no
+      override is in effect; any stale symlink at that location is removed;
+    - otherwise a symlink is created (or refreshed) at the default
+      location pointing to ``config.paths.<key>``.
+
+    Real directories at the default location are never touched. The call
+    is a safe no-op when ``<workflow_basedir>/../templates/default.yaml``
+    does not exist.
+
+    Supported keys (relative to ``paths``): every ``tier.<name>``,
+    ``pars``, ``macros``, ``geom`` and ``dtmaps``. Default paths for
+    ``geom`` and ``dtmaps`` fall back to ``<pars>/geom`` and
+    ``<pars>/hpge/dtmaps`` when absent from the template (mirroring
+    :func:`apply_path_defaults`).
+
+    Parameters
+    ----------
+    config
+        Simflow configuration as returned by :func:`init_simflow_context`.
+    workflow_basedir
+        Snakemake workflow basedir (``workflow.basedir`` in a Snakefile).
+        Used only to locate the simflow's default template.
+    logger
+        Logger to use for status messages (e.g. the Snakemake logger when
+        called from a Snakefile). Defaults to the module logger.
+
+    """
+    log_ = logger if logger is not None else log
+    template = Path(workflow_basedir).parent / "templates" / "default.yaml"
+    if not template.is_file():
+        return
+
+    default_cfg = yaml.safe_load(template.read_text())
+    if not isinstance(default_cfg, dict):
+        return
+    ldfs.subst_vars(
+        default_cfg,
+        var_values={"_": str(Path.cwd().resolve())},
+        ignore_missing=True,
+    )
+    default_paths_d = default_cfg.get("paths", {})
+    # mirrors apply_path_defaults() — geom/dtmaps are commented out by default
+    if "pars" in default_paths_d:
+        default_paths_d.setdefault("geom", str(Path(default_paths_d["pars"]) / "geom"))
+        default_paths_d.setdefault(
+            "dtmaps", str(Path(default_paths_d["pars"]) / "hpge/dtmaps")
+        )
+
+    candidates: list[tuple[Any, Any]] = []
+    for tier_name, current in config.paths.get("tier", {}).items():
+        candidates.append((current, (default_paths_d.get("tier") or {}).get(tier_name)))
+    for key in ("pars", "macros", "geom", "dtmaps"):
+        if key in config.paths:
+            candidates.append((config.paths[key], default_paths_d.get(key)))
+
+    for current_str, default_str in candidates:
+        if default_str is None:
+            continue
+        current = Path(current_str)
+        default = Path(default_str)
+
+        # compare absolute paths without resolving symlinks: otherwise a
+        # symlink we just installed at `default` would make resolve() equal
+        # current and look like a "no override".
+        # `os.path.abspath` (not Path.resolve) on purpose: don't follow symlinks
+        if os.path.abspath(current) == os.path.abspath(default):  # noqa: PTH100
+            if default.is_symlink():
+                default.unlink()
+            continue
+
+        # current path is an override: ensure a symlink at the default points to it
+        if default.is_symlink():
+            if (default.parent / default.readlink()).resolve() == current.resolve():
+                continue
+            default.unlink()
+        elif default.exists():
+            log_.warning(
+                "%s is an existing non-symlink path; ignoring override -> %s",
+                default,
+                current,
+            )
+            continue
+
+        if not current.exists():
+            log_.warning(
+                "override target %s does not exist; %s will be a broken symlink",
+                current,
+                default,
+            )
+        elif not current.is_dir():
+            log_.warning(
+                "override target %s is not a directory; linking anyway", current
+            )
+
+        rel = Path(os.path.relpath(current, start=default.parent))
+        default.parent.mkdir(parents=True, exist_ok=True)
+        default.symlink_to(rel, target_is_directory=True)
 
 
 def init_simflow_context(


### PR DESCRIPTION
## Summary

- Add `legendsimflow.utils.link_external_paths(config, workflow_basedir, *, logger=None)` that, when the user has manually overridden a `paths.<key>` entry in `simflow-config.yaml` to point at another production, creates a symlink at the canonical default location pointing to the override. Snakemake rules continue to read `config.paths.<key>` directly; the symlinks just keep this prod cycle's `generated/` tree navigable in the standard layout.
- Wire the call into `onstart:` in `workflow/Snakefile` so it runs once per workflow invocation.

## Configuration

Override one or more paths in your `simflow-config.yaml` exactly as before:

```yaml
paths:
  tier:
    hit: /scratch/other-prod/generated/tier/hit
    opt: /scratch/other-prod/generated/tier/opt
  pars: /scratch/other-prod/generated/pars
```

After the workflow starts you'll find:

```text
generated/tier/hit -> ../../../scratch/other-prod/generated/tier/hit
generated/tier/opt -> ../../../scratch/other-prod/generated/tier/opt
generated/pars     -> ../../scratch/other-prod/generated/pars
```

## Behaviour

Supported leaves: every `tier.<name>`, `pars`, `macros`, `geom`, `dtmaps`.

- For each leaf, if `config.paths.<key>` resolves to the canonical default (computed from the simflow's `templates/default.yaml` with `$_` → cwd), no symlink is created and any pre-existing one is removed (revert-to-local).
- Otherwise a relative symlink is created (or refreshed) at the default location pointing to the override.
- Real directories at the default location are never touched.
- `geom` / `dtmaps` defaults fall back to `<pars>/geom` and `<pars>/hpge/dtmaps`, mirroring `apply_path_defaults`.

Warnings are logged when:
- a real directory at the default shadows the override (override silently ignored);
- the override target doesn't exist (a broken symlink will be created);
- the override target is a non-directory.

The Snakefile passes the snakemake `logger`, so warnings are routed through the standard workflow logging channel.

## Test plan

- [x] `pixi run test-python` — full Python suite passes; 8 new tests in `tests/test_utils.py` cover override creation, no-op when at default, real-dir protection, idempotency, wrong-symlink replacement, stale-symlink removal, geom/dtmaps fallback, and intermediate-dir creation.
- [x] `pre-commit run --all-files` — clean.