### PR TITLE
Restore per-detector currmod building rules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,9 @@ intersphinx_mapping = {
     # legend
     "dspeed": ("https://dspeed.readthedocs.io/en/stable", None),
     "daq2lh5": ("https://legend-daq2lh5.readthedocs.io/en/stable", None),
-    "lgdo": ("https://legend-pydataobj.readthedocs.io/en/stable", None),
+    # pinned to v1.x: legend-pydataobj v2 removed lgdo.lh5 (moved to legend-lh5io),
+    # which would break intersphinx references to lgdo.lh5.* still used in this project
+    "lgdo": ("https://legend-pydataobj.readthedocs.io/en/v1.17.4", None),
     "dbetto": ("https://dbetto.readthedocs.io/en/stable", None),
     "pylegendmeta": ("https://pylegendmeta.readthedocs.io/en/stable", None),
     # remage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "h5py",
     "hist",
     "legend-dataflow-scripts >=0.3.0a5",
-    "legend-pydataobj >=1.17.1",
+    "legend-pydataobj >=1.17.1,<2",
     "legend-pygeom-l200 >=0.8",
     "legend-pygeom-tools >=0.2",
     "legend-pygeom-hpges >=0.9",
@@ -115,7 +115,7 @@ legend-simflow = { path = ".", editable = true }
 awkward = "*"
 dbetto = ">=1.3.2,<1.4"
 # legend-dataflow-scripts = "..."  # not on conda-forge
-legend-pydataobj = ">=1.17.1"
+legend-pydataobj = ">=1.17.1,<2"
 legend-pygeom-l200 = ">=0.8,<0.9"
 legend-pygeom-tools = ">=0.2,<0.3"
 dspeed = ">=2.1,<2.2"

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -147,30 +147,40 @@ def legend_currmod_paths(tmp_path_factory):
     """Run ``extract_hpge_current_pulse_model`` for both l1000dsg01 runids.
 
     The l1000dsg01 metadata has a ``default`` key so no l200data is required.
-    Returns a dict mapping each runid to its output YAML path.
+    For each runid, runs the per-detector extraction script over all modelable
+    HPGes and merges the outputs into a single ``{runid}-model.yaml`` keyed by
+    detector name (mirroring the ``merge_current_pulse_model_pars`` rule).
+    Returns a dict mapping each runid to its merged YAML path.
     """
     out_dir = tmp_path_factory.mktemp("legend_currmod")
     config_path = _l1000_config(out_dir)
+    config = utils.init_simflow_context(str(config_path), workflow=None).config
 
     paths = {}
     for runid in _RUNIDS_L1000:
-        pars_file = out_dir / f"{runid}-model.yaml"
-        plot_file = out_dir / f"{runid}-fit-results.pdf"
+        merged_file = out_dir / f"{runid}-model.yaml"
+        merged: dict = {}
+        for hpge in aggregate.gen_list_of_hpges_valid_for_modeling(config, runid):
+            pars_file = out_dir / f"{runid}-{hpge}-model.yaml"
+            plot_file = out_dir / f"{runid}-{hpge}-fit-result.pdf"
+            with _override_argv(
+                "extract-hpge-currmod",
+                "--runid",
+                runid,
+                "--hpge-detector",
+                hpge,
+                "--pars-file",
+                str(pars_file),
+                "--plot-file",
+                str(plot_file),
+                "--simflow-config",
+                str(config_path),
+            ):
+                extract_hpge_current_pulse_model.main()
+            merged[hpge] = dbetto.utils.load_dict(pars_file)
 
-        with _override_argv(
-            "extract-hpge-currmod",
-            "--runid",
-            runid,
-            "--pars-file",
-            str(pars_file),
-            "--plot-file",
-            str(plot_file),
-            "--simflow-config",
-            str(config_path),
-        ):
-            extract_hpge_current_pulse_model.main()
-
-        paths[runid] = pars_file
+        dbetto.utils.write_dict(merged, merged_file)
+        paths[runid] = merged_file
 
     return paths
 

--- a/tests/scripts/test_extract_hpge_current_pulse_model.py
+++ b/tests/scripts/test_extract_hpge_current_pulse_model.py
@@ -15,13 +15,13 @@ RUNID_P03 = "l200-p03-r000-phy"
 # p02 runid: currmod validity.yaml maps 20220102 → p02 file (no "default", only V02160A override)
 RUNID_P02 = "l200-p02-r000-phy"
 
-# ON detector that receives the metadata default values
-DET_DEFAULT = "V05261B"
+# any ON detector that is NOT V02160A — receives the metadata default values
+DET_DEFAULT = "V05261A"
 # has a per-detector override in the p03 metadata
 DET_OVERRIDE = "V02160A"
 
 
-def _build_argv(tmp_path: Path, runid: str) -> list[str]:
+def _build_argv(tmp_path: Path, runid: str, hpge_detector: str) -> list[str]:
     """Return sys.argv for the currmod script under test.
 
     Copies the dummyprod simflow-config.yaml to tmp_path, points metadata at
@@ -33,18 +33,12 @@ def _build_argv(tmp_path: Path, runid: str) -> list[str]:
     raw["paths"].pop("l200data", None)
     config_path.write_text(yaml.safe_dump(raw))
 
-    # minimal cache file with the two dummyprod ON detectors
-    cache_path = tmp_path / "modelable_hpge_detectors.yaml"
-    cache_path.write_text(
-        yaml.safe_dump({runid: {DET_DEFAULT: 4200, DET_OVERRIDE: 4200}})
-    )
-
     return [
         "extract-hpge-currmod",
         "--runid",
         runid,
-        "--modelable-hpges-file",
-        str(cache_path),
+        "--hpge-detector",
+        hpge_detector,
         "--pars-file",
         str(tmp_path / "pars.yaml"),
         "--plot-file",
@@ -54,8 +48,9 @@ def _build_argv(tmp_path: Path, runid: str) -> list[str]:
     ]
 
 
-def test_metadata_all_detectors(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "argv", _build_argv(tmp_path, RUNID_P03))
+def test_metadata_default_written_for_detector(tmp_path, monkeypatch):
+    """p03 + a detector without its own override must get the metadata default."""
+    monkeypatch.setattr(sys, "argv", _build_argv(tmp_path, RUNID_P03, DET_DEFAULT))
 
     extract_hpge_current_pulse_model.main()
 
@@ -68,20 +63,31 @@ def test_metadata_all_detectors(tmp_path, monkeypatch):
     with pars_file.open() as f:
         result = yaml.safe_load(f)
 
-    # DET_DEFAULT (V05261B) gets the metadata default values
-    assert DET_DEFAULT in result
-    assert result[DET_DEFAULT]["current_pulse_pars"]["sigma"] == pytest.approx(45.0)
-    assert result[DET_DEFAULT]["mean_aoe"] == pytest.approx(0.72)
-    assert result[DET_DEFAULT]["current_reso"] == pytest.approx(4.1)
+    assert "current_pulse_pars" in result
+    assert result["current_pulse_pars"]["sigma"] == pytest.approx(45.0)
+    assert result["mean_aoe"] == pytest.approx(0.72)
+    assert result["current_reso"] == pytest.approx(4.1)
 
-    # DET_OVERRIDE (V02160A) gets the per-detector override
-    assert DET_OVERRIDE in result
-    assert result[DET_OVERRIDE]["current_pulse_pars"]["sigma"] == pytest.approx(48.0)
-    assert result[DET_OVERRIDE]["current_reso"] == pytest.approx(5.3)
+
+def test_metadata_override_wins_for_v02160a(tmp_path, monkeypatch):
+    """p03 + V02160A must get the per-detector override, not the default."""
+    monkeypatch.setattr(sys, "argv", _build_argv(tmp_path, RUNID_P03, DET_OVERRIDE))
+
+    extract_hpge_current_pulse_model.main()
+
+    pars_file = tmp_path / "pars.yaml"
+    assert pars_file.exists(), "pars output file was not created"
+
+    with pars_file.open() as f:
+        result = yaml.safe_load(f)
+
+    assert result["current_pulse_pars"]["sigma"] == pytest.approx(48.0)
+    assert result["current_reso"] == pytest.approx(5.3)
 
 
 def test_raises_without_default_and_no_l200data(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "argv", _build_argv(tmp_path, RUNID_P02))
+    """p02 has no 'default' key and no l200data is configured → RuntimeError."""
+    monkeypatch.setattr(sys, "argv", _build_argv(tmp_path, RUNID_P02, DET_DEFAULT))
 
     with pytest.raises(RuntimeError, match=r"l200data|currmod"):
         extract_hpge_current_pulse_model.main()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -233,21 +233,6 @@ def test_skip_list_removes_detector(config, caplog):
     assert "V99000A" not in hpges
 
 
-def test_skip_list_warns_for_valid_detector(config, caplog):
-    """Skip-listing a detector that would otherwise be valid produces a WARNING.
-
-    The message must include the detector name, the runid, and the reason string
-    from the skip-file value.
-    """
-    runid = "l200-p02-r003-phy"
-    with caplog.at_level(logging.WARNING, logger="legendsimflow.aggregate"):
-        agg.gen_list_of_hpges_valid_for_modeling(config, runid)
-    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
-    assert any(
-        "V99000A" in msg and runid in msg and "SSD crashes" in msg for msg in warnings
-    )
-
-
 def test_skip_list_time_validity_boundary(config):
     """A detector in the skip file for r003+ is included for r000-r002 but not r003+."""
     # r000-r002: validity points to the empty skip file

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -164,8 +164,10 @@ def test_hpge_voltage_functions(config):
 
 
 def test_currmod_stuff(config):
+    runid = "l200-p02-r000-phy"
     simid = "stp.pen_plates_Ra224_to_Pb208"
 
+    assert len(agg.gen_list_of_currmods(config, runid)) == 1
     assert len(agg.gen_list_of_merged_currmods(config, simid)) == 1
     assert len(agg.gen_list_of_currmod_plots_outputs(config, simid)) == 1
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -214,19 +214,32 @@ def test_dtmap_filenames(config):
 
 
 def test_currmod_filenames(config):
+    result = p.input_currmod_evt_idx_file(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
+
+    result = p.output_currmod_filename(config, runid=RUNID, hpge_detector=DET)
+    assert isinstance(result, Path)
+    assert RUNID in str(result)
+    assert DET in str(result)
+    assert result.suffix == ".yaml"
+
     result = p.output_currmod_merged_filename(config, runid=RUNID)
     assert isinstance(result, Path)
     assert RUNID in str(result)
     assert result.suffix == ".yaml"
 
-    result = p.log_currmod_filename(config, runid=RUNID)
+    result = p.log_currmod_filename(config, runid=RUNID, hpge_detector=DET)
     assert isinstance(result, Path)
     assert RUNID in str(result)
+    assert DET in str(result)
     assert result.suffix == ".log"
 
-    result = p.plot_currmod_filename(config, runid=RUNID)
+    result = p.plot_currmod_filename(config, runid=RUNID, hpge_detector=DET)
     assert isinstance(result, Path)
     assert RUNID in str(result)
+    assert DET in str(result)
     assert result.suffix == ".pdf"
     assert result.parent.name == "plots"
 

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -189,35 +189,91 @@ rule plot_hpge_drift_time_maps:
         "../src/legendsimflow/scripts/plots/hpge_drift_time_maps.py"
 
 
-rule extract_hpge_current_pulse_model:
-    """Extract the HPGe current signal model for all detectors in a run.
+def smk_extract_current_pulse_model_inputs(wildcards):
+    """Prepare inputs for the HPGe current model extraction rule."""
+    raw_file, wf_idx, dsp_cfg_file = hpge_pars.find_current_pulse_model_inputs(
+        config,
+        wildcards.runid,
+        wildcards.hpge_detector,
+        hit_tier_name="hit",
+        use_hpge_name="true",
+    )
 
-    For each HPGe detector valid for modeling in the given run, either reads
-    parameters from ``simprod/config/pars/geds/currmod/`` metadata (fast path,
-    no l200data required) or fits current pulse waveforms from LEGEND-200 data.
-    Results are written to a single YAML file keyed by detector name, and all
-    fit validation plots are collected into one PDF.
+    evt_idx_file = patterns.input_currmod_evt_idx_file(
+        config, runid=wildcards.runid, hpge_detector=wildcards.hpge_detector
+    )
 
-    Uses wildcard ``runid``.
+    with evt_idx_file.open("w") as f:
+        f.write(wf_idx)
 
-    Warning:
-        when the script falls back to LEGEND-200 data, it discovers the
-        underlying ``l200data`` input files dynamically at runtime. These files
-        are therefore not tracked by Snakemake as rule inputs, so changes to
-        them will not automatically trigger a rerun unless this rule is forced
-        or those inputs are declared explicitly.
+    return {
+        "raw_file": raw_file,
+        "raw_wf_idx_file": evt_idx_file,
+        "dsp_cfg_file": dsp_cfg_file,
+    }
+
+
+rule extract_current_pulse_model:
+    """Extract the HPGe current signal model.
+
+    Perform a fit of current signals recorded in LEGEND-200 and stores the
+    best-fit model parameters in a YAML file.
+
+    :::{warning}
+    This rule does not have the relevant LEGEND-200 data files as input, since
+    they are dynamically discovered and this would therefore slow down the DAG
+    generation. Therefore, remember to force-rerun if the input data is
+    updated!
+    :::
+
+    Uses wildcards `runid` and `hpge_detector`.
     """
     message:
-        "Extracting current pulse model for all detectors in {wildcards.runid}"
-    input:
-        modelable_hpges=rules.cache_modelable_hpges.output[0],
+        "Extracting current model for detector {wildcards.hpge_detector} in {wildcards.runid}"
+    # NOTE: we don't list the file dependencies here because they are
+    # dynamically generated, and that would slow down the DAG generation
+    # input:
+    #     unpack(smk_extract_current_pulse_model_inputs),
     output:
-        pars_file=patterns.output_currmod_merged_filename(config),
+        pars_file=temp(patterns.output_currmod_filename(config)),
         plot_file=patterns.plot_currmod_filename(config),
     log:
         patterns.log_currmod_filename(config),
     script:
         "../src/legendsimflow/scripts/extract_hpge_current_pulse_model.py"
+
+
+rule merge_current_pulse_model_pars:
+    """Merge the HPGe current signal model parameters in a single file per `runid`.
+
+    Collect the individual best-fit parameter files (one per detector) and
+    write them into a single YAML file keyed by detector name.
+
+    Uses wildcard `runid`.
+    """
+    message:
+        "Merging current model parameters in {wildcards.runid}"
+    input:
+        lambda wc: aggregate.gen_list_of_currmods(
+            config, wc.runid, cache=smk_load_hpge_cache()
+        ),
+    params:
+        # materialize the HPGe list here so the run: block can map file
+        # indices back to detector names without calling back into the cache
+        hpges=lambda wc: list(smk_load_hpge_cache()[wc.runid]),
+    output:
+        patterns.output_currmod_merged_filename(config),
+    run:
+        import dbetto
+
+        # NOTE: this is guaranteed to be sorted as in the input file list
+        hpges = params.hpges
+
+        out_dict = {}
+        for i, f in enumerate(input):
+            out_dict[hpges[i]] = dbetto.utils.load_dict(f)
+
+        dbetto.utils.write_dict(out_dict, output[0])
 
 
 rule extract_hpge_observables_models:

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -404,7 +404,7 @@ def gen_list_of_dtmap_plots_outputs(
 
 def gen_list_of_currmods(
     config: SimflowConfig, runid: str, cache: dict[str, dict[str, int]] | None = None
-) -> list[str]:
+) -> list[Path]:
     """Generate the list of HPGe current model parameter files for a `runid`."""
     hpges = (
         gen_list_of_hpges_valid_for_modeling(config, runid)
@@ -428,7 +428,7 @@ def gen_list_of_merged_currmods(config: SimflowConfig, simid: str) -> list[Path]
 def gen_list_of_currmod_plots_outputs(
     config: SimflowConfig, simid: str, cache: dict[str, dict[str, int]] | None = None
 ) -> list[Path]:
-    """Generate the list of HPGe drift time map plot outputs."""
+    """Generate the list of HPGe current pulse model plot outputs."""
     files = []
     for runid in get_runlist(config, simid):
         hpges = (

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -77,7 +77,7 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str, **kw
         return [
             patterns.plot_tier_hit_observables_filename(config, simid=simid),
             *gen_list_of_dtmap_plots_outputs(config, simid, **kwargs),
-            *gen_list_of_currmod_plots_outputs(config, simid),
+            *gen_list_of_currmod_plots_outputs(config, simid, **kwargs),
         ]
     if tier == "opt":
         return [
@@ -88,7 +88,7 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str, **kw
     if tier == "par":
         return [
             *gen_list_of_dtmap_plots_outputs(config, simid, **kwargs),
-            *gen_list_of_currmod_plots_outputs(config, simid),
+            *gen_list_of_currmod_plots_outputs(config, simid, **kwargs),
         ]
     return []
 
@@ -402,6 +402,21 @@ def gen_list_of_dtmap_plots_outputs(
     return list(files)
 
 
+def gen_list_of_currmods(
+    config: SimflowConfig, runid: str, cache: dict[str, dict[str, int]] | None = None
+) -> list[str]:
+    """Generate the list of HPGe current model parameter files for a `runid`."""
+    hpges = (
+        gen_list_of_hpges_valid_for_modeling(config, runid)
+        if cache is None
+        else cache[runid].keys()
+    )
+    return [
+        patterns.output_currmod_filename(config, hpge_detector=hpge, runid=runid)
+        for hpge in hpges
+    ]
+
+
 def gen_list_of_merged_currmods(config: SimflowConfig, simid: str) -> list[Path]:
     r"""Generate the list of (merged) HPGe current model parameter files for all requested `runid`\ s."""
     return [
@@ -410,12 +425,23 @@ def gen_list_of_merged_currmods(config: SimflowConfig, simid: str) -> list[Path]
     ]
 
 
-def gen_list_of_currmod_plots_outputs(config: SimflowConfig, simid: str) -> list[Path]:
-    r"""Generate the list of HPGe current pulse model plot files for all requested `runid`\ s."""
-    return [
-        patterns.plot_currmod_filename(config, runid=runid)
-        for runid in get_runlist(config, simid)
-    ]
+def gen_list_of_currmod_plots_outputs(
+    config: SimflowConfig, simid: str, cache: dict[str, dict[str, int]] | None = None
+) -> list[Path]:
+    """Generate the list of HPGe drift time map plot outputs."""
+    files = []
+    for runid in get_runlist(config, simid):
+        hpges = (
+            gen_list_of_hpges_valid_for_modeling(config, runid)
+            if cache is None
+            else cache[runid].keys()
+        )
+        for hpge in hpges:
+            files.append(
+                patterns.plot_currmod_filename(config, hpge_detector=hpge, runid=runid)
+            )
+
+    return files
 
 
 def gen_list_of_eresmods(config: SimflowConfig, simid: str) -> list[Path]:

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -292,6 +292,20 @@ def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 # hpge current model
 
 
+def input_currmod_evt_idx_file(config: SimflowConfig, **kwargs) -> Path:
+    """The path to the event index file used to extract current pulse waveforms."""
+    pat = config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-best-evt-idx.txt"
+    return _expand(pat, **kwargs)
+
+
+def output_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
+    """The path to the per-detector HPGe current pulse model parameter file."""
+    return _expand(
+        config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-model.yaml",
+        **kwargs,
+    )
+
+
 def output_currmod_merged_filename(config: SimflowConfig, **kwargs) -> Path:
     """The path to the merged HPGe current pulse model parameter file for a `runid`."""
     return _expand(
@@ -301,14 +315,16 @@ def output_currmod_merged_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def log_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The log file path for current pulse model extraction for a `runid`."""
-    pat = log_dirname(config) / "hpge/currmod/{runid}-model.log"
+    """The log file path for current pulse model extraction for a detector and `runid`."""
+    pat = log_dirname(config) / "hpge/currmod/{runid}-{hpge_detector}-model.log"
     return _expand(pat, **kwargs)
 
 
 def plot_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the current pulse model fit validation plots for a `runid`."""
-    pat = config.paths.pars / "hpge/currmod/plots/{runid}-fit-results.pdf"
+    """The path to the current pulse model fit validation plot for a detector and `runid`."""
+    pat = (
+        config.paths.pars / "hpge/currmod/plots/{runid}-{hpge_detector}-fit-result.pdf"
+    )
     return _expand(pat, **kwargs)
 
 

--- a/workflow/src/legendsimflow/scripts/extract_hpge_current_pulse_model.py
+++ b/workflow/src/legendsimflow/scripts/extract_hpge_current_pulse_model.py
@@ -26,14 +26,14 @@ from matplotlib.backends.backend_pdf import PdfPages
 from reboost.hpge.psd import _current_pulse_model as current_pulse_model
 from snakemake_argparse_bridge import snakemake_compatible
 
-from legendsimflow import aggregate, hpge_pars, utils
+from legendsimflow import hpge_pars, utils
 from legendsimflow import metadata as mutils
 from legendsimflow.plot import decorate
 from legendsimflow.scripts import log_script_invocation
 
 
 def _plot_currmod_from_metadata(
-    entry: dict, hpge: str, runid: str, pdf: PdfPages
+    entry: dict, hpge: str, runid: str, plot_file: str
 ) -> None:
     pars = entry["current_pulse_pars"]
     t = np.linspace(-500, 1500, 2000)
@@ -44,14 +44,15 @@ def _plot_currmod_from_metadata(
     ax.set_xlabel("time [ns]")
     ax.set_ylabel("current [a.u.]")
     ax.set_title(f"{hpge} in {runid}: current pulse model (from metadata)")
-    pdf.savefig(fig)
+    with PdfPages(plot_file) as pdf:
+        pdf.savefig(fig)
     plt.close(fig)
 
 
 @snakemake_compatible(
     mapping={
         "runid": "wildcards.runid",
-        "modelable_hpges_file": "input.modelable_hpges",
+        "hpge_detector": "wildcards.hpge_detector",
         "pars_file": "output.pars_file",
         "plot_file": "output.plot_file",
         "log_file": "log[0]",
@@ -68,6 +69,12 @@ def main() -> None:
         help="LEGEND run identifier (e.g. l200-p03-r000-phy)",
     )
     parser.add_argument(
+        "--hpge-detector",
+        required=True,
+        dest="hpge_detector",
+        help="HPGe detector name",
+    )
+    parser.add_argument(
         "--pars-file",
         required=True,
         help="output YAML file for the current pulse model parameters",
@@ -78,13 +85,6 @@ def main() -> None:
         help="output PDF plot file",
     )
     parser.add_argument("--log-file", default=None, help="log file")
-    parser.add_argument(
-        "--modelable-hpges-file",
-        default=None,
-        dest="modelable_hpges_file",
-        help="path to the modelable_hpge_detectors.yaml cache file; "
-        "if omitted the HPGe list is derived from the metadata directly",
-    )
     parser.add_argument(
         "--simflow-config",
         "--config",
@@ -101,19 +101,12 @@ def main() -> None:
     log_script_invocation(log, "extract-hpge-currmod", parser, args)
 
     runid = args.runid
+    hpge = args.hpge_detector
     pars_file = args.pars_file
     plot_file = args.plot_file
 
     # use just a single waveform
     single_waveform = True
-
-    # read HPGe list from the pre-built cache when available (avoids repeating
-    # the expensive channelmap + metadata scan), otherwise derive it directly
-    if args.modelable_hpges_file is not None:
-        hpge_cache = dbetto.utils.load_dict(args.modelable_hpges_file)
-        hpges = sorted(hpge_cache.get(runid, {}).keys())
-    else:
-        hpges = aggregate.gen_list_of_hpges_valid_for_modeling(config, runid)
 
     # check for metadata-driven defaults first; if present, bypass the
     # waveform fitting entirely (enables LEGEND-1000 simulations without
@@ -126,14 +119,10 @@ def main() -> None:
     )
 
     if currmod_default is not None:
-        log.info("... using currmod metadata defaults in %s", runid)
-        result = {}
-        with PdfPages(plot_file) as pdf:
-            for hpge in hpges:
-                entry = raw_currmod.get(hpge, currmod_default).to_dict()
-                result[hpge] = entry
-                _plot_currmod_from_metadata(entry, hpge, runid, pdf)
-        dbetto.utils.write_dict(result, pars_file)
+        log.info("... using currmod metadata defaults for %s in %s", hpge, runid)
+        entry = raw_currmod.get(hpge, currmod_default)
+        dbetto.utils.write_dict(entry.to_dict(), pars_file)
+        _plot_currmod_from_metadata(entry.to_dict(), hpge, runid, plot_file)
         return
 
     l200data = getattr(config.paths, "l200data", None)
@@ -148,119 +137,118 @@ def main() -> None:
 
     msg = f"... determined hit tier name is {hit_tier_name}"
     log.info(msg)
+    log.info("... looking up the fit inputs")
 
     msg = f"... using a single waveform? {single_waveform}"
     log.info(msg)
 
-    result = {}
+    raw_wf_pairs, dsp_cfg_file, all_dts, selected_dts = (
+        hpge_pars.lookup_currmod_fit_inputs(
+            l200data,
+            metadata,
+            runid,
+            hpge,
+            hit_tier_name,
+            max_waveforms=1 if single_waveform else 100,
+        )
+    )
+
+    lh5_group = mutils._get_lh5_table(
+        metadata,
+        raw_wf_pairs[0][0],
+        hpge,
+        "raw",
+        runid,
+    )
+
+    log.info("... fetching %d current pulse(s)", len(raw_wf_pairs))
+    times_list, current_list = hpge_pars.get_current_pulses(
+        raw_wf_pairs, lh5_group, str(dsp_cfg_file)
+    )
+
+    log.info("... fitting the current pulse(s) to extract the model")
+    popt, x, y = hpge_pars.fit_currmod(times_list, current_list)
+
+    # now plot
+    log.info("... plotting the fit result")
+
     with PdfPages(plot_file) as pdf:
-        for hpge in hpges:
-            log.info("... looking up the fit inputs for %s", hpge)
+        log.info("... plotting drift-time selection")
 
-            raw_wf_pairs, dsp_cfg_file, all_dts, selected_dts = (
-                hpge_pars.lookup_currmod_fit_inputs(
-                    l200data,
-                    metadata,
-                    runid,
-                    hpge,
-                    hit_tier_name,
-                    max_waveforms=1 if single_waveform else 100,
-                )
-            )
+        fig, _ = hpge_pars.plot_dt_selection(all_dts, selected_dts)
+        fig.suptitle(f"{hpge} in {runid}: drift-time selection for current-pulse fit")
+        decorate(fig)
+        pdf.savefig()
+        plt.close(fig)
+        del all_dts, selected_dts
 
-            lh5_group = mutils._get_lh5_table(
-                metadata,
-                raw_wf_pairs[0][0],
-                hpge,
-                "raw",
-                runid,
-            )
+        fig, ax = hpge_pars.plot_currmod_fit_result(times_list, current_list, x, y)
 
-            log.info("... fetching %d current pulse(s)", len(raw_wf_pairs))
-            times_list, current_list = hpge_pars.get_current_pulses(
-                raw_wf_pairs, lh5_group, str(dsp_cfg_file)
-            )
+        ax.set_xlim(-1200, 1200)
+        fig.suptitle(f"{hpge} in {runid}: current waveform fit result")
+        decorate(fig)
+        pdf.savefig()
 
-            log.info("... fitting the current pulse(s) to extract the model")
-            popt, x, y = hpge_pars.fit_currmod(times_list, current_list)
+        # also save with a narrower range
+        ax.set_xlim(-400, 300)
+        pdf.savefig()
+        plt.close(fig)
+        del times_list, current_list
 
-            log.info("... plotting the fit result for %s", hpge)
-            log.info("... plotting drift-time selection")
+        log.info("... adding the mean aoe")
 
-            fig, _ = hpge_pars.plot_dt_selection(all_dts, selected_dts)
-            fig.suptitle(
-                f"{hpge} in {runid}: drift-time selection for current-pulse fit"
-            )
-            decorate(fig)
-            pdf.savefig()
-            plt.close(fig)
-            del all_dts, selected_dts
+        popt_dict = utils._curve_fit_popt_to_dict(popt)
+        mean_aoe = hpge_pars.estimate_mean_aoe(popt)
 
-            fig, ax = hpge_pars.plot_currmod_fit_result(times_list, current_list, x, y)
+        log.info("... estimating effect of noise")
 
-            ax.set_xlim(-1200, 1200)
-            fig.suptitle(f"{hpge} in {runid}: current waveform fit result")
-            decorate(fig)
-            pdf.savefig()
+        files = hpge_pars.lookup_file_paths(
+            l200data, runid, hit_tier_name=hit_tier_name
+        )
 
-            # also save with a narrower range
-            ax.set_xlim(-400, 300)
-            pdf.savefig()
-            plt.close(fig)
-            del times_list, current_list
+        temp = current_pulse_model(np.linspace(-500, 1000, 1501), *popt)
 
-            log.info("... adding the mean aoe")
+        noise_sample, a_max = hpge_pars.get_noise_maxima_and_sample(
+            files.raw,
+            files.hit,
+            lh5_group,
+            str(dsp_cfg_file),
+            "curr_av",
+            temp,
+            norm=mean_aoe * 2000,
+            sample_size=100,
+            maximum_number=100000,
+        )
 
-            popt_dict = utils._curve_fit_popt_to_dict(popt)
-            mean_aoe = hpge_pars.estimate_mean_aoe(popt)
+        log.info("... plot noise waveforms")
+        fig, ax = hpge_pars.plot_noise_waveforms(
+            noise_sample, temp, norm=mean_aoe * 2000
+        )
+        fig.suptitle(f"{hpge} in {runid}: noise waveforms")
+        decorate(fig)
+        pdf.savefig()
+        plt.close(fig)
+        del noise_sample, temp
 
-            log.info("... estimating effect of noise")
+        # now do the plot
+        fit_result = hpge_pars.fit_noise_gauss(a_max, bins=1000)
+        fig, ax = hpge_pars.plot_gauss_fit(
+            a_max, fit_result, nominal_val=mean_aoe * 2000
+        )
+        fig.suptitle(f"{hpge} in {runid}: noise waveforms fit result")
+        decorate(fig)
+        pdf.savefig()
+        plt.close(fig)
 
-            files = hpge_pars.lookup_file_paths(
-                l200data, runid, hit_tier_name=hit_tier_name
-            )
-
-            temp = current_pulse_model(np.linspace(-500, 1000, 1501), *popt)
-
-            noise_sample, a_max = hpge_pars.get_noise_maxima_and_sample(
-                files.raw,
-                files.hit,
-                lh5_group,
-                str(dsp_cfg_file),
-                "curr_av",
-                temp,
-                norm=mean_aoe * 2000,
-                sample_size=100,
-                maximum_number=100000,
-            )
-
-            log.info("... plot noise waveforms")
-            fig, ax = hpge_pars.plot_noise_waveforms(
-                noise_sample, temp, norm=mean_aoe * 2000
-            )
-            fig.suptitle(f"{hpge} in {runid}: noise waveforms")
-            decorate(fig)
-            pdf.savefig()
-            plt.close(fig)
-            del noise_sample, temp
-
-            fit_result = hpge_pars.fit_noise_gauss(a_max, bins=1000)
-            fig, ax = hpge_pars.plot_gauss_fit(
-                a_max, fit_result, nominal_val=mean_aoe * 2000
-            )
-            fig.suptitle(f"{hpge} in {runid}: noise waveforms fit result")
-            decorate(fig)
-            pdf.savefig()
-            plt.close(fig)
-
-            result[hpge] = {
+        log.info("... saving outputs")
+        dbetto.utils.write_dict(
+            {
                 "current_pulse_pars": popt_dict,
                 "mean_aoe": mean_aoe,
                 "current_reso": fit_result.values["sigma"],
-            }
-
-    log.info("... saving outputs")
-    dbetto.utils.write_dict(result, pars_file)
+            },
+            pars_file,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reverts 7310c59 (`refactor: collapse currmod per-detector rules into a single runid-level rule`), restoring the two-rule pattern (`extract_current_pulse_model` per detector + `merge_current_pulse_model_pars`) and the per-detector pattern/aggregate helpers.
- Preserves later fixes that landed on top of 7310c59 in the affected files: `ax.set_xlim(-500, 1500)` from 36a057d, the `simpars(..., config.experiment, ...)` signature from 9e67956, and the realistic dummy parameter values used in the unit tests.
- Drops the `test_skip_list_warns_for_valid_detector` assertion (a87295d) that became dead after 2ed6450 removed the corresponding warning.

## Test plan
- [x] `pixi run test-python` — 233 passed
- [x] `pixi run test-julia` — 42/42 passed
- [x] `pre-commit run` on touched files — clean