### PR TITLE
fix: union detector_uids across evt files in cvt merge

### DIFF
--- a/tests/scripts/test_tier_cvt.py
+++ b/tests/scripts/test_tier_cvt.py
@@ -3,12 +3,57 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
-from lgdo import Table, lh5
+from lgdo import Scalar, Struct, Table, lh5
 
 from legendsimflow.scripts.tier import cvt
 
 dummyprod = Path(__file__).parent.parent / "dummyprod"
+
+
+def _write_detector_uids(path: Path, mapping: dict[str, int]) -> None:
+    s = Struct({name: Scalar(uid) for name, uid in mapping.items()})
+    lh5.write(s, "detector_uids", path, wo_mode="write_safe")
+
+
+def test_union_detector_uids_identical_mappings(tmp_path):
+    f1 = tmp_path / "a.lh5"
+    f2 = tmp_path / "b.lh5"
+    _write_detector_uids(f1, {"V01": 11, "V02": 12})
+    _write_detector_uids(f2, {"V01": 11, "V02": 12})
+
+    assert cvt.union_detector_uids([f1, f2]) == {"V01": 11, "V02": 12}
+
+
+def test_union_detector_uids_disjoint_subsets(tmp_path):
+    """A detector present in one job but missing in another (zero-hit) must union."""
+    f1 = tmp_path / "a.lh5"
+    f2 = tmp_path / "b.lh5"
+    _write_detector_uids(f1, {"V01": 11, "V02": 12})
+    _write_detector_uids(f2, {"V01": 11, "V03": 13})
+
+    assert cvt.union_detector_uids([f1, f2]) == {"V01": 11, "V02": 12, "V03": 13}
+
+
+def test_union_detector_uids_name_collision_raises(tmp_path):
+    f1 = tmp_path / "a.lh5"
+    f2 = tmp_path / "b.lh5"
+    _write_detector_uids(f1, {"V01": 11})
+    _write_detector_uids(f2, {"V01": 99})
+
+    with pytest.raises(ValueError, match="'V01' maps to 11"):
+        cvt.union_detector_uids([f1, f2])
+
+
+def test_union_detector_uids_uid_collision_raises(tmp_path):
+    f1 = tmp_path / "a.lh5"
+    f2 = tmp_path / "b.lh5"
+    _write_detector_uids(f1, {"V01": 11})
+    _write_detector_uids(f2, {"V02": 11})
+
+    with pytest.raises(ValueError, match="uid 11 maps to"):
+        cvt.union_detector_uids([f1, f2])
 
 
 def test_cvt_script_cli(tmp_path, monkeypatch):

--- a/workflow/src/legendsimflow/scripts/tier/cvt.py
+++ b/workflow/src/legendsimflow/scripts/tier/cvt.py
@@ -17,15 +17,50 @@
 
 import argparse
 import shutil
+from pathlib import Path
 
 import legenddataflowscripts as ldfs
 import legenddataflowscripts.utils
-from lgdo import lh5
+from lgdo import Scalar, Struct, lh5
 from snakemake_argparse_bridge import snakemake_compatible
 
 from legendsimflow import nersc, utils
 from legendsimflow.metadata import get_tier_settings
 from legendsimflow.scripts import log_script_invocation
+
+
+def union_detector_uids(evt_files: list[str | Path]) -> dict[str, int]:
+    """Build the union ``name -> uid`` mapping over a set of evt files.
+
+    Different jobs in the same simid can produce evt files with different
+    detector subsets when low-rate decays leave some detectors with zero hits.
+    Their ``detector_uids`` structs then disagree on which detector names are
+    present, even though the underlying ``name -> uid`` mapping is consistent.
+    This helper unions the entries; any genuine collision (a name mapped to
+    different uids, or a uid mapped to different names, across files) is
+    treated as a real inconsistency and raises.
+    """
+    union: dict[str, int] = {}
+    uid_to_name: dict[int, str] = {}
+    for f in evt_files:
+        per_file = lh5.read("detector_uids", f)
+        for name in per_file:
+            uid = int(per_file[name].value)
+            if name in union and union[name] != uid:
+                msg = (
+                    f"detector_uids inconsistency: '{name}' maps to {union[name]} "
+                    f"in earlier evt files but to {uid} in {f}"
+                )
+                raise ValueError(msg)
+            if uid in uid_to_name and uid_to_name[uid] != name:
+                msg = (
+                    f"detector_uids inconsistency: uid {uid} maps to "
+                    f"'{uid_to_name[uid]}' in earlier evt files but to '{name}' in {f}"
+                )
+                raise ValueError(msg)
+            union[name] = uid
+            uid_to_name[uid] = name
+    return union
 
 
 @snakemake_compatible(
@@ -68,21 +103,13 @@ def main() -> None:
     if len(evt_files) == 1:
         shutil.copy(evt_files[0], cvt_file)
     else:
-        # detector_uids must be identical across all evt inputs; merging would
-        # silently mask mismatches, so assert before copying.
-        ref = lh5.read("detector_uids", evt_files[0])
-        ref_map = {name: int(ref[name].value) for name in ref}
-        for f in evt_files[1:]:
-            other = lh5.read("detector_uids", f)
-            other_map = {name: int(other[name].value) for name in other}
-            if other_map != ref_map:
-                msg = (
-                    f"detector_uids in {f} disagrees with {evt_files[0]}; "
-                    "cvt merge requires all evt inputs to share the same "
-                    "name->rawid mapping"
-                )
-                raise ValueError(msg)
-        lh5.write(ref, "detector_uids", cvt_file, wo_mode="write_safe")
+        # detector_uids may differ across jobs because low-rate decays can leave
+        # some detectors with zero hits in some jobs (and thus absent from
+        # detector_uids). We union the mappings; a real (name, uid) collision is
+        # raised by union_detector_uids.
+        merged_uids = union_detector_uids(list(evt_files))
+        merged = Struct({name: Scalar(uid) for name, uid in merged_uids.items()})
+        lh5.write(merged, "detector_uids", cvt_file, wo_mode="write_safe")
 
         for table in lh5.ls(evt_files[0]):
             if table == "detector_uids":


### PR DESCRIPTION
## Summary

The cvt tier currently fails when two evt files in the same simid have different `detector_uids` structs:

```
ValueError: detector_uids in <job_0001>-tier_evt.lh5 disagrees with <job_0000>-tier_evt.lh5;
cvt merge requires all evt inputs to share the same name->rawid mapping
```

This happens in production when low-rate decays (e.g. `Pb214 → Po214` chains) leave some detectors with zero hits in some jobs — those detectors are then absent from `__by_uid__` and from evt's `detector_uids` struct, so two jobs that agree on every shared `name → uid` still fail the strict equality check.

## Changes

- New helper `union_detector_uids(evt_files)` in `workflow/src/legendsimflow/scripts/tier/cvt.py` that unions `name → uid` entries across all evt inputs and raises only on real collisions (one name mapped to different uids, or one uid mapped to different names).
- `cvt.main()` now writes the union as the cvt's `detector_uids` instead of asserting equality.
- 4 new unit tests in `tests/scripts/test_tier_cvt.py` covering: identical mappings, disjoint subsets (the production failure case), name-collision, uid-collision.

## Test plan

- [x] `pytest tests/scripts/test_tier_cvt.py -v` — all 5 tests pass
- [x] `pre-commit run --files <changed>` — clean
- [ ] CI green