### PR TITLE
feat: add HEAD LDO regulator voltages to slow control crawler output

### DIFF
--- a/workflow/src/legendsimflow/scripts/crawl_legend_slow_control.py
+++ b/workflow/src/legendsimflow/scripts/crawl_legend_slow_control.py
@@ -29,6 +29,13 @@ def round_step_5(x):
     return int(5 * math.floor(x / 5 + 0.5))
 
 
+def round_step_05(x: float) -> float:
+    # round to the nearest 0.5, with halves going away from zero (built-in
+    # round() would use bankers' rounding, e.g. 1.25 -> 1.0). normalize -0.0 to
+    # 0.0 to avoid ugly YAML output for small negative readings
+    return math.copysign(math.floor(abs(x) * 2 + 0.5) / 2, x) + 0.0
+
+
 def dict_diff(d1: dict, d2: dict) -> dict:
     """Return entries of d1 that differ from d2."""
     return {k: v for k, v in d1.items() if k not in d2 or d2[k] != v}
@@ -88,6 +95,10 @@ for name in sorted(chmap):
     # use monitored voltage: I noticed that sometimes vset can be different
     # from vmon for a long time period (and vmon is always correct)
     voltages[name] = {"operational_voltage_in_V": round_step_5(status.vmon)}
+    if "cc4" in status:
+        voltages[name]["cc4_voltages"] = {
+            f"{rail}_in_V": round_step_05(v) for rail, v in status.cc4.items()
+        }
 
 # now we check what we need to write
 if args.opv_db is not None:


### PR DESCRIPTION
## Summary

- Add `round_step_05()` helper to round to the nearest 0.5 V.
- For each geds channel, `crawl_legend_slow_control.py` now queries the `head_ldo_snap` slow control table (via `LegendSlowControlDB.status()`) and writes all 8 LDO rail voltages (`VB`, `VB1`, `VB2`, `VCC`, `VCC1`, `VEE`, `VEE1`, `VFET`) into a `cc4_voltages` sub-dictionary, with keys suffixed `_in_V` and values rounded to 0.5 V.

Example output per channel:

```yaml
V02162B:
  operational_voltage_in_V: 3400
  cc4_voltages:
    vb_in_V: 0.0
    vb1_in_V: 2.0
    vb2_in_V: 2.0
    vcc_in_V: 9.0
    vcc1_in_V: 3.0
    vee_in_V: -3.0
    vee1_in_V: -9.0
    vfet_in_V: 12.0
```

0.5 V resolution was chosen after verifying across the full slow control history (`scdb`, `scdbL140`, `scdbL60`) that all real human-set operating points are well separated by at least 0.5 V, while measurement noise is only a few mV.

Requires `pylegendmeta` >= the version introducing `HeadLdoSnap` and the `cc4` output in `LegendSlowControlDB.status()` (see legend-exp/pylegendmeta#138).

## AI assistance disclosure

Per the project AI policy, this contribution was drafted with AI assistance (Claude Code) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)