### PR TITLE
fix: rerun rules with dynamic l200data inputs when the path changes

### DIFF
--- a/workflow/rules/evt.smk
+++ b/workflow/rules/evt.smk
@@ -74,6 +74,15 @@ rule build_tier_evt:
         spms_energy_thr_pe=_tier_setting("evt", "spms_energy_thr_pe"),
         skip_opt=_skip_opt,
         skip_hit=_skip_hit,
+        # with add_random_coincidences, this rule reads forced-trigger evt
+        # files discovered dynamically from l200data and not listed as inputs;
+        # track the path so it reruns on change (None otherwise to avoid
+        # spurious reruns)
+        _l200data=(
+            config.paths.get("l200data", None)
+            if _evt_settings.get("add_random_coincidences", False)
+            else None
+        ),
     output:
         patterns.output_simjob_filename(config, tier="evt"),
     log:

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -343,6 +343,10 @@ rule extract_current_pulse_model:
     # dynamically generated, and that would slow down the DAG generation
     # input:
     #     unpack(smk_extract_current_pulse_model_inputs),
+    params:
+        # track l200data so the rule reruns when it changes: inputs are
+        # discovered dynamically and not listed above
+        _l200data=config.paths.get("l200data", None),
     output:
         pars_file=temp(patterns.output_currmod_filename(config)),
         plot_file=patterns.plot_currmod_filename(config),
@@ -394,6 +398,9 @@ rule build_superpulses_from_data:
         "Building data superpulses for detector {wildcards.hpge_detector}"
     params:
         runids=sorted(aggregate.gen_list_of_all_runids(config)),
+        # track l200data so the rule reruns when it changes: raw data files are
+        # discovered dynamically and not listed as inputs
+        _l200data=config.paths.get("l200data", None),
     output:
         superpulses=patterns.output_superpulses_filename(config),
         plots=patterns.plot_superpulses_filename(config),
@@ -488,6 +495,10 @@ rule extract_hpge_observables_models:
         "Extracting HPGe observables models for {wildcards.runid}"
     # NOTE: we don't list the file dependencies here because they are
     # dynamically generated, and that would slow down the DAG generation
+    params:
+        # track l200data so the rule reruns when it changes: the parameter
+        # database is discovered dynamically and not listed above
+        _l200data=config.paths.get("l200data", None),
     output:
         eresmod_file=patterns.output_eresmod_filename(config),
         aoeresmod_file=patterns.output_aoeresmod_filename(config),


### PR DESCRIPTION
## Summary

Closes #250.

Several rules read files directly from `l200data` that are **not** listed as rule inputs, because they are dynamically discovered to keep DAG generation fast. As a consequence Snakemake had no way to notice when the configured `l200data` path changed (e.g. pointing to a new data production version) and would not rerun those rules.

This adds an `_l200data` param to the affected rules so the `params` rerun-trigger (enabled by default, no profile overrides it) forces a rerun when the path changes.

## Affected rules

- `extract_current_pulse_model` (par)
- `build_superpulses_from_data` (par)
- `extract_hpge_observables_models` (par)
- `build_tier_evt` (evt) — only when `add_random_coincidences` is enabled, since that is the only code path consuming `l200data` there; kept `None` otherwise to avoid spurious reruns of these expensive per-job rules.

## Rules left untouched

`build_tier_hit`, `extract_electronics_model_pars`, and `convolve_hpge_ideal_pulse_shape_lib` reach `l200data` only through file inputs produced by the rules above, so they rerun via the input chain and need no param. In `tier/hit.py`, `l200data` is only an unreached fallback (pars always come from input files).

## Testing

- `pre-commit run --all-files` passes.
- `test_dag` and `test_dag_simlist` pass (workflow parses and the DAG builds).