### PR TITLE
docs: improve README with feature list and detector models

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,47 @@ background signatures in the LEGEND experiment and produce probability-density
 functions (pdfs). Configuration metadata (e.g. rules for generating simulation
 macros or post-processing settings) is stored at
 [legend-simflow-config](https://github.com/legend-exp/legend-simflow-config).
+
+## Features
+
+- Tier-based Snakemake workflow taking Geant4
+  ([_remage_](https://remage.readthedocs.io)) Monte Carlo events all the way to
+  analysis-ready pdfs.
+- Simulated statistics weighted by the livetime of a user-selected list of data
+  taking runs (run partitioning).
+- Fully metadata-driven: a production is configured by editing a single YAML
+  file, no code required. Runs locally or on HPC sites through ready-made
+  Snakemake profiles.
+
+### Detector response models
+
+Physics and detector models tuned to real LEGEND-200 data and applied during
+post-processing:
+
+- **HPGe energy**: per-detector energy scale and measured energy resolution
+  FWHM(E) used to smear the simulated energy.
+- **HPGe active volume**: dead-layer / active-volume model from detector
+  geometry and metadata.
+- **HPGe pulse shape and PSD**: drift-time maps and ideal pulse-shape libraries
+  computed with
+  [_SolidStateDetectors.jl_](https://juliaphysics.github.io/SolidStateDetectors.jl),
+  convolved with an electronics-response model fitted to data superpulses; A/E
+  response from current-signal templates and measured A/E resolution, with
+  data-driven PSD survival cuts.
+- **Liquid-argon scintillation and SiPMs**: scintillation photon generation,
+  photoelectron detection sampled from optical maps, per-photoelectron amplitude
+  resolution, and time clustering reproducing the SiPM time response.
+- **Detector status**: per-run usability and PSD-usability flags.
+- **Event building**: time-coincidence maps (TCM) across detectors to group hits
+  into physics events.
+
+## Documentation
+
+Full documentation is hosted at
+[legend-simflow.readthedocs.io](https://legend-simflow.readthedocs.io). Good
+entry points:
+
+- [Overview and key concepts](https://legend-simflow.readthedocs.io/en/latest/)
+- [Installation and configuration](https://legend-simflow.readthedocs.io/en/latest/manual/setup.html)
+- [Running a production](https://legend-simflow.readthedocs.io/en/latest/manual/prod.html)
+- [Configuration metadata and file naming](https://legend-simflow.readthedocs.io/en/latest/manual/meta.html)

--- a/README.md
+++ b/README.md
@@ -38,12 +38,9 @@ post-processing:
   FWHM(E) used to smear the simulated energy.
 - **HPGe active volume**: dead-layer / active-volume model from detector
   geometry and metadata.
-- **HPGe pulse shape and PSD**: drift-time maps and ideal pulse-shape libraries
-  computed with
-  [_SolidStateDetectors.jl_](https://juliaphysics.github.io/SolidStateDetectors.jl),
-  convolved with an electronics-response model fitted to data superpulses; A/E
-  response from current-signal templates and measured A/E resolution, with
-  data-driven PSD survival cuts.
+- **HPGe pulse shape and PSD**: Extraction of the A/E PSD observables based on drift-time maps and ideal pulse-shape libraries computed with
+  [_SolidStateDetectors.jl_](https://juliaphysics.github.io/SolidStateDetectors.jl). This is
+  combined with an electronics-response model's fitted to data waveforms.
 - **Liquid-argon scintillation and SiPMs**: scintillation photon generation,
   photoelectron detection sampled from optical maps, per-photoelectron amplitude
   resolution, and time clustering reproducing the SiPM time response.


### PR DESCRIPTION
## Summary

Closes #232.

The README was minimal. This expands it while deliberately *not* duplicating the documentation:

- A short **Features** list (tier-based remage→pdf workflow, run partitioning by livetime, metadata-driven config, local/HPC execution).
- A **Detector response models** subsection listing the physics/detector models actually applied during post-processing: HPGe energy scale and resolution smearing, active-volume / dead-layer model, pulse shape and PSD (drift-time maps and pulse-shape libraries via SolidStateDetectors.jl, electronics response fitted to data superpulses, A/E from current-signal templates, data-driven PSD cuts), LAr scintillation and SiPM response, detector status flags, and TCM-based event building.
- A **Documentation** section pointing to the relevant Read the Docs pages.

All external links were checked to resolve (HTTP 200).

## Testing

- `pre-commit run` passes on `README.md` (markdown-only change outside `docs/source/`, so the test suite and docs build do not apply).