### PR TITLE
docs: automate rulegraph generation including post-checkpoint PSL rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ workflow/src/legendsimflow/_version.py
 tests/dummyprod/generated
 tests/dummyprod/generated-l200
 tests/dummyprod/generated-l1000
+tests/dummyprod/generated-rulegraph
 tests/dummyprod/inputs/simprod/l200cfg01-optmap-dummy.lh5
 tests/l200data/*/generated/tier/*
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,6 +22,10 @@ apidoc: clean-apidoc
       ../workflow/src/legendsimflow/scripts
 	python tools/generate_rule_docs.py
 
+rulegraph:
+	touch ../tests/dummyprod/inputs/simprod/l200cfg01-optmap-dummy.lh5
+	python tools/make_rulegraph.py 2>/dev/null > "$(SOURCEDIR)/img/rulegraph.mmd"
+
 clean-apidoc:
 	rm -rf "$(SOURCEDIR)/api"
 

--- a/docs/source/img/rulegraph.mmd
+++ b/docs/source/img/rulegraph.mmd
@@ -2,85 +2,121 @@
 title: DAG
 ---
 flowchart TB
-	id0[all]
-	id1[plot_tier_stp_vertices]
-	id2[build_tier_stp]
-	id3[build_geom_gdml]
-	id4[gen_geom_config]
+	id0[plot_tier_stp_vertices]
+	id1[build_tier_stp]
+	id2[build_geom_gdml]
+	id3[gen_geom_config]
+	id4[gen_remage_macro]
 	id5[build_tier_vtx]
-	id6[build_tier_opt]
-	id7[make_simstat_partition_file]
-	id8[cache_detector_usabilities]
-	id9[plot_tier_opt_observables]
-	id10[build_tier_hit]
-	id11[merge_hpge_drift_time_maps]
-	id12[build_hpge_drift_time_map]
-	id13[_init_julia_env]
-	id14[merge_current_pulse_model_pars]
-	id15[extract_current_pulse_model]
-	id16[extract_hpge_observables_models]
-	id17[plot_tier_hit_observables]
-	id18[plot_hpge_drift_time_maps]
-	id19[build_tier_evt]
-	id20[build_tier_cvt]
-	id21[plot_tier_cvt_observables]
-	style id0 fill:#D96957,stroke-width:2px,color:#333333
-	style id1 fill:#578DD9,stroke-width:2px,color:#333333
-	style id2 fill:#CBD957,stroke-width:2px,color:#333333
-	style id3 fill:#D97B57,stroke-width:2px,color:#333333
-	style id4 fill:#57D995,stroke-width:2px,color:#333333
-	style id5 fill:#B9D957,stroke-width:2px,color:#333333
-	style id6 fill:#D9D457,stroke-width:2px,color:#333333
-	style id7 fill:#57D9A7,stroke-width:2px,color:#333333
-	style id8 fill:#A7D957,stroke-width:2px,color:#333333
-	style id9 fill:#579ED9,stroke-width:2px,color:#333333
-	style id10 fill:#D9C257,stroke-width:2px,color:#333333
-	style id11 fill:#57D9CB,stroke-width:2px,color:#333333
-	style id12 fill:#D98D57,stroke-width:2px,color:#333333
-	style id13 fill:#D95757,stroke-width:2px,color:#333333
-	style id14 fill:#57D9B9,stroke-width:2px,color:#333333
-	style id15 fill:#95D957,stroke-width:2px,color:#333333
-	style id16 fill:#84D957,stroke-width:2px,color:#333333
-	style id17 fill:#57B0D9,stroke-width:2px,color:#333333
-	style id18 fill:#57D4D9,stroke-width:2px,color:#333333
-	style id19 fill:#D9B057,stroke-width:2px,color:#333333
-	style id20 fill:#D99E57,stroke-width:2px,color:#333333
-	style id21 fill:#57C2D9,stroke-width:2px,color:#333333
-	id19 --> id0
-	id10 --> id0
-	id21 --> id0
-	id15 --> id0
-	id6 --> id0
-	id2 --> id0
-	id17 --> id0
-	id9 --> id0
-	id18 --> id0
-	id20 --> id0
+	id6[cache_modelable_hpges]
+	id7[cache_detector_usabilities]
+	id8[make_simstat_partition_file]
+	id9[extract_hpge_observables_models]
+	id10[plot_hpge_drift_time_maps]
+	id11[build_hpge_drift_time_map]
+	id12[_init_julia_env]
+	id13[build_tier_opt]
+	id14[plot_tier_opt_observables]
+	id15[build_tier_hit]
+	id16[plot_tier_hit_observables]
+	id17[build_tier_evt]
+	id18[build_tier_cvt]
+	id19[plot_tier_cvt_observables]
+	id20[build_tier_pdf]
+	id21[merge_hpge_drift_time_maps]
+	id22[merge_current_pulse_model_pars]
+	id23[extract_current_pulse_model]
+	id24[merge_hpge_realistic_psls]
+	id25[convolve_hpge_ideal_pulse_shape_lib]
+	id26[build_hpge_pulse_shape_library]
+	id27[merge_electronics_model_pars]
+	id28[extract_electronics_model_pars]
+	id29[build_superpulses_from_data]
+	id30[all]
+	style id0 fill:#577CD9,stroke-width:2px,color:#333333
+	style id1 fill:#BAD957,stroke-width:2px,color:#333333
+	style id2 fill:#D98857,stroke-width:2px,color:#333333
+	style id3 fill:#57D9AD,stroke-width:2px,color:#333333
+	style id4 fill:#57D9BA,stroke-width:2px,color:#333333
+	style id5 fill:#ADD957,stroke-width:2px,color:#333333
+	style id6 fill:#95D957,stroke-width:2px,color:#333333
+	style id7 fill:#A1D957,stroke-width:2px,color:#333333
+	style id8 fill:#57D9C6,stroke-width:2px,color:#333333
+	style id9 fill:#63D957,stroke-width:2px,color:#333333
+	style id10 fill:#57ADD9,stroke-width:2px,color:#333333
+	style id11 fill:#D99557,stroke-width:2px,color:#333333
+	style id12 fill:#D95757,stroke-width:2px,color:#333333
+	style id13 fill:#D3D957,stroke-width:2px,color:#333333
+	style id14 fill:#5788D9,stroke-width:2px,color:#333333
+	style id15 fill:#D9D357,stroke-width:2px,color:#333333
+	style id16 fill:#5795D9,stroke-width:2px,color:#333333
+	style id17 fill:#D9C657,stroke-width:2px,color:#333333
+	style id18 fill:#D9BA57,stroke-width:2px,color:#333333
+	style id19 fill:#57A1D9,stroke-width:2px,color:#333333
+	style id20 fill:#C6D957,stroke-width:2px,color:#333333
+	style id21 fill:#57C6D9,stroke-width:2px,color:#333333
+	style id22 fill:#57D9D3,stroke-width:2px,color:#333333
+	style id23 fill:#7CD957,stroke-width:2px,color:#333333
+	style id24 fill:#57BAD9,stroke-width:2px,color:#333333
+	style id25 fill:#88D957,stroke-width:2px,color:#333333
+	style id26 fill:#D9A157,stroke-width:2px,color:#333333
+	style id27 fill:#57D3D9,stroke-width:2px,color:#333333
+	style id28 fill:#6FD957,stroke-width:2px,color:#333333
+	style id29 fill:#D9AD57,stroke-width:2px,color:#333333
+	style id30 fill:#D96357,stroke-width:2px,color:#333333
 	id1 --> id0
+	id5 --> id1
+	id4 --> id1
 	id2 --> id1
-	id5 --> id2
 	id3 --> id2
-	id4 --> id3
-	id3 --> id5
-	id8 --> id6
-	id2 --> id6
-	id7 --> id6
-	id3 --> id6
-	id2 --> id7
-	id6 --> id9
+	id2 --> id4
+	id2 --> id5
+	id1 --> id8
 	id11 --> id10
-	id2 --> id10
-	id14 --> id10
-	id16 --> id10
-	id3 --> id10
-	id7 --> id10
-	id8 --> id10
 	id12 --> id11
-	id13 --> id12
-	id15 --> id14
-	id10 --> id17
-	id12 --> id18
-	id10 --> id19
-	id6 --> id19
-	id19 --> id20
-	id20 --> id21
+	id1 --> id13
+	id8 --> id13
+	id2 --> id13
+	id7 --> id13
+	id13 --> id14
+	id7 --> id15
+	id8 --> id15
+	id22 --> id15
+	id24 --> id15
+	id2 --> id15
+	id21 --> id15
+	id1 --> id15
+	id9 --> id15
+	id15 --> id16
+	id13 --> id17
+	id7 --> id17
+	id8 --> id17
+	id15 --> id17
+	id1 --> id17
+	id17 --> id18
+	id18 --> id19
+	id18 --> id20
+	id11 --> id21
+	id23 --> id22
+	id25 --> id24
+	id26 --> id25
+	id27 --> id25
+	id12 --> id26
+	id28 --> id27
+	id26 --> id28
+	id29 --> id28
+	id13 --> id30
+	id10 --> id30
+	id7 --> id30
+	id8 --> id30
+	id9 --> id30
+	id16 --> id30
+	id17 --> id30
+	id14 --> id30
+	id15 --> id30
+	id6 --> id30
+	id20 --> id30
+	id1 --> id30
+	id0 --> id30
+	id18 --> id30
+	id19 --> id30

--- a/docs/tools/make_rulegraph.py
+++ b/docs/tools/make_rulegraph.py
@@ -1,0 +1,80 @@
+"""Generate a Snakemake rule graph for the Simflow.
+
+Runs in two phases:
+
+1. Pre-computes the modelable-HPGe cache (normally produced by the
+   ``cache_modelable_hpges`` checkpoint) so that post-checkpoint rules are
+   visible to Snakemake's DAG builder.
+2. Calls the Snakemake Python API to print the rule graph, with a monkey-patch
+   for a Snakemake 9 bug where ``execution_settings`` is ``None`` in rulegraph
+   mode after checkpoint resolution.
+
+Usage (from the project root)::
+
+    python docs/tools/make_rulegraph.py > docs/source/img/rulegraph.mmd
+
+Or via the Makefile target::
+
+    cd docs && make rulegraph
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# snakemake.api must be imported before snakemake.dag to avoid a circular import
+from snakemake import api as smkapi
+
+# isort: split
+import snakemake.dag as _smk_dag
+
+ROOT = Path(__file__).resolve().parents[2]
+DUMMYPROD = ROOT / "tests/dummyprod"
+CONFIG = DUMMYPROD / "rulegraph-config.yaml"
+SNAKEFILE = DUMMYPROD / "workflow/Snakefile"
+
+
+def _guard_none_execution_settings(orig):
+    def patched(self, job):
+        if self.workflow.execution_settings is None:
+            return False
+        return orig(self, job)
+
+    return patched
+
+
+# workaround for snakemake bug: execution_settings is None in
+# rulegraph mode after checkpoint resolution
+_smk_dag.DAG.is_edit_notebook_job = _guard_none_execution_settings(
+    _smk_dag.DAG.is_edit_notebook_job
+)
+_smk_dag.DAG.is_draft_notebook_job = _guard_none_execution_settings(
+    _smk_dag.DAG.is_draft_notebook_job
+)
+
+sys.path.insert(0, str(ROOT / "workflow/src"))
+from legendsimflow import aggregate  # noqa: E402
+from legendsimflow.utils import init_simflow_context  # noqa: E402
+
+
+def main() -> None:
+    config = init_simflow_context(CONFIG).config
+
+    yaml_path = config.paths.pars / "modelable_hpge_detectors.yaml"
+    yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    aggregate.gen_list_of_all_hpges_valid_for_modeling(config, write_to_file=yaml_path)
+
+    with smkapi.SnakemakeApi(smkapi.OutputSettings()) as api:
+        dag_api = api.workflow(
+            snakefile=SNAKEFILE,
+            workdir=DUMMYPROD,
+            config_settings=smkapi.ConfigSettings(configfiles=(CONFIG,)),
+            storage_settings=smkapi.StorageSettings(),
+            resource_settings=smkapi.ResourceSettings(cores=1),
+        ).dag(dag_settings=smkapi.DAGSettings(print_dag_as="mermaid-js"))  # type: ignore[arg-type]
+        dag_api.printrulegraph()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dummyprod/rulegraph-config.yaml
+++ b/tests/dummyprod/rulegraph-config.yaml
@@ -1,0 +1,47 @@
+experiment: legend
+
+runlist:
+  - l200-p02-r000-phy
+
+make_steps:
+  - vtx
+  - stp
+  - par
+  - opt
+  - hit
+  - evt
+  - cvt
+  - pdf
+
+benchmark:
+  enabled: false
+  n_primaries:
+    stp: 999
+
+paths:
+  generated: $_/generated-rulegraph
+  benchmarks: $_/generated-rulegraph/benchmarks
+  log: $_/generated-rulegraph/log
+
+  metadata: $_/inputs
+  config: $_/inputs/simprod/config
+  optical_maps:
+    lar: $_/inputs/simprod/l200cfg01-optmap-dummy.lh5
+    fiber: $_/inputs/simprod/l200cfg01-optmap-dummy.lh5
+    pen: $_/inputs/simprod/l200cfg01-optmap-dummy.lh5
+
+  pars: $_/generated-rulegraph/pars
+  macros: $_/generated-rulegraph/macros
+  tier:
+    vtx: $_/generated-rulegraph/tier/vtx
+    stp: $_/generated-rulegraph/tier/stp
+    opt: $_/generated-rulegraph/tier/opt
+    hit: $_/generated-rulegraph/tier/hit
+    evt: $_/generated-rulegraph/tier/evt
+    cvt: $_/generated-rulegraph/tier/cvt
+    pdf: $_/generated-rulegraph/tier/pdf
+  pdf_releases: $_/generated-rulegraph/releases
+
+nersc:
+  dvs_ro: false
+  scratch: false


### PR DESCRIPTION
## Summary

- Add `docs/tools/make_rulegraph.py`: pre-populates the `cache_modelable_hpges` checkpoint YAML before calling the Snakemake Python API, so post-checkpoint rules (PSL chain, electronics model) appear in the rulegraph. Also works around two Snakemake 9.19.0 bugs (reported upstream).
- Add `tests/dummyprod/rulegraph-config.yaml`: dedicated config using `experiment=legend` + p02 runs so all rules, including `build_tier_vtx` and the PSL chain, are visible.
- Update `docs/source/img/rulegraph.mmd`: now shows 31 rules (was 22), adding `gen_remage_macro`, `cache_modelable_hpges`, `build_hpge_pulse_shape_library`, `convolve_hpge_ideal_pulse_shape_lib`, `extract/merge_electronics_model_pars`, `build_superpulses_from_data`, `merge_hpge_realistic_psls`, `build_tier_pdf`.
- No DOT-to-Mermaid conversion script needed: Snakemake already supports `--rulegraph mermaid-js` natively.

## Snakemake bugs worked around

Both are filed upstream:

1. `is_edit_notebook_job`/`is_draft_notebook_job` crash with `AttributeError: 'NoneType' object has no attribute 'edit_notebook'` when `--rulegraph` is used on a workflow with a resolved checkpoint (`execution_settings` is `None` in rulegraph mode).
2. `rule_dot()` returns `None` via the Python API because `DAGSettings.print_dag_as` defaults to the `PrintDag.DOT` enum but the comparison uses `str(PrintDag.DOT)` — fixed by passing `print_dag_as="mermaid-js"` explicitly.

## Regenerating the rulegraph

```console
> cd docs && make rulegraph
```