### PR TITLE
feat: extend HPGe pulse shape library at grid edges like the drift time map

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -523,26 +523,27 @@ detector_groups:
 Metadata is organized in this directory by experimental configuration (first
 level) and detector type (second level), mirroring the `tier/` structure.
 
-### Drift time map settings
+### Pulse shape simulation settings
 
 A single shared YAML file (applies to all detectors and voltages) that overrides
-simulation control parameters for the
-[`build_hpge_drift_time_map`](../api/snakemake_rules.md) rule. When absent, the
-script uses built-in production defaults.
+`SolidStateDetectors.jl` simulation control parameters for the
+[`build_hpge_drift_time_map`](../api/snakemake_rules.md) and
+[`build_hpge_pulse_shape_library`](../api/snakemake_rules.md) rules. When
+absent, the scripts use built-in production defaults.
 
 ```{code-block} yaml
-:caption: simprod/config/pars/{experiment}/geds/dtmap/settings.yaml
+:caption: simprod/config/pars/{experiment}/geds/ssd/settings.yaml
 
 grid_size_in_mm: 0.5
 ssd_refinement_limits: [0.2, 0.1, 0.05, 0.02]
 padding: 3
 ```
 
-| Key                     | Type          | Default                  | Description                                                                                                                                                                                                                         |
-| ----------------------- | ------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `grid_size_in_mm`       | float         | `0.5`                    | Drift time map grid spacing in mm. Execution time scales quadratically with `1/grid_size_in_mm`.                                                                                                                                    |
-| `ssd_refinement_limits` | list of float | `[0.2, 0.1, 0.05, 0.02]` | SSD adaptive-mesh refinement thresholds. Each entry drives one refinement pass; smaller values give a more accurate electric field at higher cost. **Overly coarse values can prevent full detector depletion — change with care.** |
-| `padding`               | int           | `3`                      | Number of pixel layers padded around the drift time map boundary to avoid grid edge effects.                                                                                                                                        |
+| Key                     | Type          | Default                  | Description                                                                                                                                                                                                                                  |
+| ----------------------- | ------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grid_size_in_mm`       | float         | `0.5`                    | Simulation grid spacing in mm. Execution time scales quadratically with `1/grid_size_in_mm`. The built-in default differs per rule (0.5 mm for the drift time map, 5 mm for the pulse shape library); an explicit value here overrides both. |
+| `ssd_refinement_limits` | list of float | `[0.2, 0.1, 0.05, 0.02]` | SSD adaptive-mesh refinement thresholds. Each entry drives one refinement pass; smaller values give a more accurate electric field at higher cost. **Overly coarse values can prevent full detector depletion — change with care.**          |
+| `padding`               | int           | `3`                      | Number of pixel layers padded around the simulated map (drift time map and pulse shape library) boundary to avoid grid edge effects.                                                                                                         |
 
 :::{tip}
 

--- a/workflow/src/LegendSimflow.jl/src/LegendSimflow.jl
+++ b/workflow/src/LegendSimflow.jl/src/LegendSimflow.jl
@@ -11,5 +11,6 @@ export compute_ideal_pulse_shape_lib
 export setup_hpge_simulation
 export extract_drift_time_from_waveform
 export extend_drift_time_map
+export extend_pulse_shape_lib
 
 end # module legendsimflow

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -266,11 +266,9 @@ neighboring present waveforms (8-connectivity). The grid is internally enlarged
 by `layers` on applicable sides to ensure the extended cube is not clipped.
 Note: The column axis (typically radius r) is not extended into negative values.
 
-This is the waveform-cube analogue of [`extend_drift_time_map`](@ref): instead of
-a 2D matrix of scalar drift times, it operates on a 3D cube whose first axis is
 the waveform time samples and whose remaining two axes are the spatial (row, col)
-grid. A pixel is considered missing if any of its waveform samples is NaN.
-
+grid. A pixel is considered missing if its waveform is all-NaN (in practice checked
+via the first sample).
 # Arguments
 - `wf_cube::AbstractArray{<:Real,3}`: 3D array `[time, rows, cols]` where pixels
   outside the valid region hold NaN waveforms.

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -271,11 +271,8 @@ grid. A pixel is considered missing if its waveform is all-NaN (in practice chec
 via the first sample).
 # Arguments
 - `wf_cube::AbstractArray{<:Real,3}`: 3D array `[time, rows, cols]` where pixels
-  outside the valid region hold NaN waveforms.
-- `row_axis::AbstractVector`: Axis values corresponding to rows (e.g. z height).
-- `col_axis::AbstractVector`: Axis values corresponding to columns (e.g. r radius,
-  must be non-negative).
-- `layers::Int`: Number of pixel layers to add (default: 1).
+- `col_axis::AbstractVector`: Axis values corresponding to columns (e.g. r radius).
+  Note: this routine does not extend the column axis further into negative values.
 
 # Returns
 - `NamedTuple`: Contains extended `:waveform`, `:row_axis`, and `:col_axis`.

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -122,6 +122,57 @@ end
 
 
 """
+    extend_grid_axes(row_axis, col_axis, row_layers_low, row_layers_high, col_layers_low, col_layers_high)
+
+Extend the (row, col) grid axes by the given number of pixel layers on each side,
+preserving the original step size and physical units.
+
+Shared by the map padding routines [`extend_drift_time_map`](@ref) and
+[`extend_pulse_shape_lib`](@ref). A layer count of `0` leaves that side untouched
+(e.g. the column/radius axis is typically not extended into negative values).
+
+# Arguments
+- `row_axis::AbstractVector`: Axis values corresponding to rows (e.g. z height).
+- `col_axis::AbstractVector`: Axis values corresponding to columns (e.g. r radius).
+- `row_layers_low::Int`, `row_layers_high::Int`: Layers to add below/above the row axis.
+- `col_layers_low::Int`, `col_layers_high::Int`: Layers to add below/above the col axis.
+
+# Returns
+- `NamedTuple`: Contains the extended `:row_axis` and `:col_axis` (unit-carrying).
+"""
+function extend_grid_axes(
+    row_axis::AbstractVector,
+    col_axis::AbstractVector,
+    row_layers_low::Int,
+    row_layers_high::Int,
+    col_layers_low::Int,
+    col_layers_high::Int
+)::NamedTuple
+    row_vals = ustrip.(row_axis)
+    col_vals = ustrip.(col_axis)
+
+    row_step = maximum(abs.(diff(row_vals)))
+    col_step = maximum(abs.(diff(col_vals)))
+
+    extended_row_vals = vcat(
+        [row_vals[1] - row_step * i for i in row_layers_low:-1:1],
+        row_vals,
+        [row_vals[end] + row_step * i for i in 1:row_layers_high]
+    )
+    extended_col_vals = vcat(
+        [col_vals[1] - col_step * i for i in col_layers_low:-1:1],
+        col_vals,
+        [col_vals[end] + col_step * i for i in 1:col_layers_high]
+    )
+
+    return (;
+        row_axis = extended_row_vals * unit(eltype(row_axis)),
+        col_axis = extended_col_vals * unit(eltype(col_axis))
+    )
+end
+
+
+"""
     extend_drift_time_map(drift_map, row_axis, col_axis; layers=1)
 
 Extend a drift time map by adding pixel layers around the valid (non-NaN) region.
@@ -194,29 +245,112 @@ function extend_drift_time_map(
     end
 
     # Extend axes to match the enlarged grid
-    row_vals = ustrip.(row_axis)
-    col_vals = ustrip.(col_axis)
-
-    row_step = maximum(abs.(diff(row_vals)))
-    col_step = maximum(abs.(diff(col_vals)))
-
-    # Extend row axis on both sides
-    extended_row_vals = vcat(
-        [row_vals[1] - row_step * i for i in row_layers_low:-1:1],
-        row_vals,
-        [row_vals[end] + row_step * i for i in 1:row_layers_high]
-    )
-
-    # Extend col axis only on high side (no negative r values)
-    extended_col_vals = vcat(
-        col_vals,
-        [col_vals[end] + col_step * i for i in 1:col_layers_high]
+    axes = extend_grid_axes(
+        row_axis, col_axis, row_layers_low, row_layers_high, col_layers_low, col_layers_high
     )
 
     return (;
         drift_map = work_map,
-        row_axis = extended_row_vals * unit(eltype(row_axis)),
-        col_axis = extended_col_vals * unit(eltype(col_axis))
+        row_axis = axes.row_axis,
+        col_axis = axes.col_axis
+    )
+end
+
+
+"""
+    extend_pulse_shape_lib(wf_cube, row_axis, col_axis; layers=1)
+
+Extend a pulse shape library by adding pixel layers around the valid (non-NaN)
+region. Each new pixel waveform is set to the element-wise average of the
+neighboring present waveforms (8-connectivity). The grid is internally enlarged
+by `layers` on applicable sides to ensure the extended cube is not clipped.
+Note: The column axis (typically radius r) is not extended into negative values.
+
+This is the waveform-cube analogue of [`extend_drift_time_map`](@ref): instead of
+a 2D matrix of scalar drift times, it operates on a 3D cube whose first axis is
+the waveform time samples and whose remaining two axes are the spatial (row, col)
+grid. A pixel is considered missing if any of its waveform samples is NaN.
+
+# Arguments
+- `wf_cube::AbstractArray{<:Real,3}`: 3D array `[time, rows, cols]` where pixels
+  outside the valid region hold NaN waveforms.
+- `row_axis::AbstractVector`: Axis values corresponding to rows (e.g. z height).
+- `col_axis::AbstractVector`: Axis values corresponding to columns (e.g. r radius,
+  must be non-negative).
+- `layers::Int`: Number of pixel layers to add (default: 1).
+
+# Returns
+- `NamedTuple`: Contains extended `:waveform`, `:row_axis`, and `:col_axis`.
+"""
+function extend_pulse_shape_lib(
+    wf_cube::AbstractArray{<:Real,3},
+    row_axis::AbstractVector,
+    col_axis::AbstractVector;
+    layers::Int = 1
+)::NamedTuple
+    T = eltype(wf_cube)
+    n_time, orig_nrows, orig_ncols = size(wf_cube)
+
+    # Determine extension on each side
+    # Row axis (z): extend on both sides
+    # Col axis (r): only extend on high side (don't go negative)
+    row_layers_low = layers
+    row_layers_high = layers
+    col_layers_low = 0  # Don't extend r into negative values
+    col_layers_high = layers
+
+    # Create enlarged grid
+    new_nrows = orig_nrows + row_layers_low + row_layers_high
+    new_ncols = orig_ncols + col_layers_low + col_layers_high
+    work = fill(T(NaN), n_time, new_nrows, new_ncols)
+
+    # Copy original data into the grid (offset by the low-side layers)
+    work[:, (row_layers_low + 1):(row_layers_low + orig_nrows), (col_layers_low + 1):(col_layers_low + orig_ncols)] =
+        wf_cube
+
+    # A pixel is missing if its waveform is NaN. Pixels are written as whole
+    # waveforms (all-NaN outside the detector, all-finite inside), so the first
+    # sample is decisive and we avoid scanning the full time axis.
+    is_missing(row, col) = isnan(work[1, row, col])
+
+    # Extend the present region layer by layer
+    for _ in 1:layers
+        cur_nrows, cur_ncols = size(work, 2), size(work, 3)
+        boundary_pixels = Tuple{Int,Int}[]
+        boundary_wfs = Vector{Vector{T}}()
+
+        for row in 1:cur_nrows, col in 1:cur_ncols
+            if is_missing(row, col)
+                neighbor_wfs = Vector{Vector{T}}()
+                for (dr, dc) in NEIGHBOR_OFFSETS_8CONN
+                    nr, nc = row + dr, col + dc
+                    if 1 <= nr <= cur_nrows && 1 <= nc <= cur_ncols && !is_missing(nr, nc)
+                        push!(neighbor_wfs, work[:, nr, nc])
+                    end
+                end
+
+                if !isempty(neighbor_wfs)
+                    push!(boundary_pixels, (row, col))
+                    push!(boundary_wfs, sum(neighbor_wfs) ./ length(neighbor_wfs))
+                end
+            end
+        end
+
+        # Apply new values after scanning to avoid affecting current layer
+        for (idx, (row, col)) in enumerate(boundary_pixels)
+            work[:, row, col] = boundary_wfs[idx]
+        end
+    end
+
+    # Extend axes to match the enlarged grid
+    axes = extend_grid_axes(
+        row_axis, col_axis, row_layers_low, row_layers_high, col_layers_low, col_layers_high
+    )
+
+    return (;
+        waveform = work,
+        row_axis = axes.row_axis,
+        col_axis = axes.col_axis
     )
 end
 
@@ -401,13 +535,15 @@ end
 
 
 """
-    compute_ideal_pulse_shape_lib(sim, meta, T, angle_deg, only_holes, grid_size)
+    compute_ideal_pulse_shape_lib(sim, meta, T, angle_deg, only_holes, grid_size, padding)
 
 Compute a 2D pulse_shape_library (r, z ideal_waveform) at a specified azimuthal angle.
 
 Simulates charge carrier drift for a grid of positions in cylindrical coordinates,
 generating waveforms that represent the detector response. The grid is constructed
-in the (r, z) plane and then rotated to the specified angle.
+in the (r, z) plane and then rotated to the specified angle. The resulting map is
+padded with `padding` extra pixel layers around the valid region to avoid grid
+edge effects (see `extend_pulse_shape_lib()`).
 
 # Arguments
 - `sim`: SolidStateDetectors Simulation object
@@ -416,6 +552,8 @@ in the (r, z) plane and then rotated to the specified angle.
 - `angle_deg`: Azimuthal angle in degrees for the r-z plane rotation
 - `only_holes`: If true, extract only hole contribution; if false, use full waveform
 - `grid_size`: Grid spacing in meters
+- `padding`: Number of pixel layers used to pad the map and avoid grid edge
+  effects (see `extend_pulse_shape_lib()`)
 
 # Returns
 - `NamedTuple`: Contains `:r`, `:z`, `:dt` axes and `:waveform_XXX_deg` 3D array
@@ -427,7 +565,8 @@ function compute_ideal_pulse_shape_lib(
     T::Type{<:AbstractFloat},
     angle_deg::Real,
     only_holes::Bool,
-    grid_size::Real
+    grid_size::Real,
+    padding::Int
 )::NamedTuple
     @info "Computing waveform map at angle $angle_deg deg..."
 
@@ -494,12 +633,21 @@ function compute_ideal_pulse_shape_lib(
         wf_padded[:, idx[2], idx[1]] = signal
     end
 
+    # Pad the map with extra pixel layers around the valid region to avoid grid
+    # edge effects. The cube is already laid out as [time, z, r] = [time, row,
+    # col], so no transpose is needed (unlike the drift time map).
+    z_axis_with_units = collect(z_axis) * u"m"
+    r_axis_with_units = collect(r_axis) * u"m"
+    extended = extend_pulse_shape_lib(
+        wf_padded, z_axis_with_units, r_axis_with_units, layers = padding
+    )
+
     ang_str = lpad(string(Int(angle_deg)), 3, '0')
     return (;
-        :r => collect(r_axis) * u"m",
-        :z => collect(z_axis) * u"m",
+        :r => extended.col_axis,  # column axis of extended cube (r)
+        :z => extended.row_axis,  # row axis of extended cube (z)
         :dt => time_step,
-        Symbol("waveform_$(ang_str)_deg") => wf_padded * NoUnits
+        Symbol("waveform_$(ang_str)_deg") => extended.waveform * NoUnits
     )
 end
 

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -316,17 +316,19 @@ function extend_pulse_shape_lib(
 
         for row in 1:cur_nrows, col in 1:cur_ncols
             if is_missing(row, col)
-                neighbor_wfs = Vector{Vector{T}}()
+                wf_sum = zeros(T, n_time)
+                n_neighbors = 0
                 for (dr, dc) in NEIGHBOR_OFFSETS_8CONN
                     nr, nc = row + dr, col + dc
                     if 1 <= nr <= cur_nrows && 1 <= nc <= cur_ncols && !is_missing(nr, nc)
-                        push!(neighbor_wfs, work[:, nr, nc])
+                        @views wf_sum .+= work[:, nr, nc]
+                        n_neighbors += 1
                     end
                 end
 
-                if !isempty(neighbor_wfs)
+                if n_neighbors > 0
                     push!(boundary_pixels, (row, col))
-                    push!(boundary_wfs, sum(neighbor_wfs) ./ length(neighbor_wfs))
+                    push!(boundary_wfs, wf_sum ./ n_neighbors)
                 end
             end
         end

--- a/workflow/src/LegendSimflow.jl/test/test_lib.jl
+++ b/workflow/src/LegendSimflow.jl/test/test_lib.jl
@@ -98,7 +98,7 @@ end
 
     @test size(dt_map.drift_time_000_deg) == (length(dt_map.z), length(dt_map.r))
 
-    wf_map = compute_ideal_pulse_shape_lib(sim, meta, T, 0.0, false, 10/1000.0)
+    wf_map = compute_ideal_pulse_shape_lib(sim, meta, T, 0.0, false, 10/1000.0, 0)
 
     @test hasproperty(wf_map, :waveform_000_deg)
     @test hasproperty(wf_map, :r)
@@ -159,4 +159,43 @@ end
 
     # NaN corner at original [1,1] (work_map[2,1]) has non-NaN neighbours and is filled in
     @test !isnan(result.drift_map[2, 1])
+end
+
+@testset "extend_pulse_shape_lib" begin
+    # 3×3 spatial grid (same NaN pattern as the drift time map test) with a
+    # 2-sample constant waveform per pixel; missing pixels hold NaN waveforms
+    wf_cube = fill(NaN, 2, 3, 3)
+    present = Dict(
+        (1, 2) => 2.0,
+        (2, 1) => 1.0, (2, 2) => 3.0, (2, 3) => 4.0,
+        (3, 2) => 5.0
+    )
+    for ((row, col), val) in present
+        wf_cube[:, row, col] .= val
+    end
+
+    row_axis = [0.0, 1.0, 2.0] * u"m"
+    col_axis = [0.0, 1.0, 2.0] * u"m"
+
+    result = extend_pulse_shape_lib(wf_cube, row_axis, col_axis; layers = 1)
+
+    # Return value is a NamedTuple with the expected fields
+    @test result isa NamedTuple
+    @test hasproperty(result, :waveform)
+    @test hasproperty(result, :row_axis)
+    @test hasproperty(result, :col_axis)
+
+    # With layers=1: rows extended on both sides (+2), cols on high side only
+    # (+1); the time axis is unchanged
+    @test size(result.waveform) == (2, 5, 4)
+    @test length(result.row_axis) == 5
+    @test length(result.col_axis) == 4
+
+    # Original centre waveform is preserved (original data placed at rows 2:4, cols 1:3)
+    @test result.waveform[:, 3, 2] ≈ [3.0, 3.0]  # original centre value
+
+    # NaN corner at original [1,1] (waveform[:, 2, 1]) has present neighbours
+    # (1.0, 2.0, 3.0) and is filled with their element-wise mean
+    @test !any(isnan, result.waveform[:, 2, 1])
+    @test result.waveform[:, 2, 1] ≈ [2.0, 2.0]
 end

--- a/workflow/src/legendsimflow/scripts/make_hpge_ideal_pulse_shape_lib.jl
+++ b/workflow/src/legendsimflow/scripts/make_hpge_ideal_pulse_shape_lib.jl
@@ -23,6 +23,8 @@ const CRYSTAL_AXIS_ANGLES = [0, 45]
 # SSD adaptive-mesh refinement thresholds as fractions of the crystal radius
 # matches current SSD behaviour
 const DEFAULT_REFINEMENT_LIMITS = [0.2, 0.1, 0.05, 0.02]
+# nr of pixels for padding around the map to avoid grid edge effects (default; can be overridden via metadata settings file)
+const DEFAULT_PADDING = 3
 
 using LegendHDF5IO
 using ArgParse
@@ -84,12 +86,13 @@ function main()
     sim_cfg = (!isnothing(ssd_settings) && isfile(ssd_settings)) ? readprops(ssd_settings) : PropDict()
     grid_size = get(sim_cfg, :grid_size_in_mm, DEFAULT_GRID_SIZE * 1000) / 1000
     ref_limits = get(sim_cfg, :ssd_refinement_limits, DEFAULT_REFINEMENT_LIMITS)
+    padding = get(sim_cfg, :padding, DEFAULT_PADDING)
 
     @info "using ref limits $ref_limits"
     sim = setup_hpge_simulation(meta_path, meta, xtal, opv_val, T, ref_limits)
     output = nothing
     for a in CRYSTAL_AXIS_ANGLES
-        result = compute_ideal_pulse_shape_lib(sim, meta, T, a, false, grid_size)
+        result = compute_ideal_pulse_shape_lib(sim, meta, T, a, false, grid_size, padding)
 
         key = Symbol("waveform_$(lpad(string(a), 3, '0'))_deg")
         if output === nothing


### PR DESCRIPTION
## Summary

Pad the ideal HPGe pulse shape library (PSL) with extra pixel layers around the
valid region, so simulated waveforms near the crystal boundary are no longer
left as NaN. This mirrors the existing handling of the HPGe drift time map.

- `compute_ideal_pulse_shape_lib` gains a `padding` argument and pads the
  waveform cube via the new `extend_pulse_shape_lib`, the 3D (waveform-cube)
  analogue of `extend_drift_time_map`.
- `padding` is read from the `padding` key of the shared `geds/ssd/settings.yaml`
  SSD settings file (the key already existed; previously only the drift-time-map
  script read it). `DEFAULT_PADDING = 3`.
- The identical, payload-agnostic axis-extension logic is factored out of both
  routines into a shared `extend_grid_axes` helper.

No downstream changes are needed: the realistic-PSL builder (`psl.py`) derives
its invalid-pixel mask dynamically from the ideal cube, so the newly filled edge
pixels become valid automatically (the same way the drift time map extension is
consumed).

## Docs

Broadened the "Pulse shape simulation settings" section in `manual/meta.md` to
cover both the drift-time-map and pulse-shape-library rules, and corrected the
settings-file path (`geds/dtmap/settings.yaml` -> the actual
`geds/ssd/settings.yaml`).

## Testing

- Added an `extend_pulse_shape_lib` test set in `test_lib.jl` and threaded
  `padding` through the existing `compute_ideal_pulse_shape_lib` test.
- Validated `extend_pulse_shape_lib` and the refactored `extend_drift_time_map`
  standalone (axis extension, neighbour-mean fill, `Float32` preservation, no
  negative-r extension).
- `pre-commit run --all-files` passes (incl. JuliaFormatter).
- The full `pixi run test-julia` suite (SSD-backed `map_generation`) and the PSL
  script tests run in CI.

## AI assistance disclosure

This change was developed with AI assistance (Claude Code) and reviewed before
submission, per the repository's `AI_POLICY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)