### PR TITLE
feat: add A/E validation plot to the HPGe PSL map PDF

### DIFF
--- a/tests/scripts/test_make_realistic_hpge_psl.py
+++ b/tests/scripts/test_make_realistic_hpge_psl.py
@@ -14,7 +14,7 @@ dummyprod = Path(__file__).parent.parent / "dummyprod"
 
 
 def test_make_realistic_hpge_psl_cli(tmp_path, monkeypatch):
-    detector = "V03422A"
+    detector = "V05261B"
 
     config_path = tmp_path / "simflow-config.yaml"
     raw_cfg = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())

--- a/tests/test_psl.py
+++ b/tests/test_psl.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import matplotlib as mpl
+
+mpl.use("Agg")
+
 import awkward as ak
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from lgdo import Array, Scalar
+from matplotlib.figure import Figure
 
 from legendsimflow import psl
 
@@ -305,6 +311,47 @@ def test_make_realistic_pulse_shape_lib_3d():
 
     assert output["waveform_0"].view_as("np").shape == (n_r, n_z, n_samples)
     assert output["drift_time_0"].view_as("np").shape == (n_r, n_z)
+
+
+def test_plot_aoe_rz_map_single_angle():
+    n_r, n_z, n_samples = 3, 4, 50
+    rng = np.random.default_rng(0)
+    wfs = rng.random((n_r, n_z, n_samples))
+    # invalid pixels are all-NaN waveforms
+    wfs[0, 0, :] = np.nan
+    wfs[2, 3, :] = np.nan
+
+    lib = {
+        "r": Array(np.linspace(0.0, 30.0, n_r), attrs={"units": "mm"}),
+        "z": Array(np.linspace(-20.0, 20.0, n_z), attrs={"units": "mm"}),
+        "waveform_000_deg": Array(wfs),
+    }
+
+    fig = psl.plot_aoe_rz_map(lib, "V99000A", hpge_profile=None)
+    assert isinstance(fig, Figure)
+    # a single A/E panel, no ratio panel (only one angle available)
+    panels = [ax for ax in fig.axes if ax.get_images()]
+    assert len(panels) == 1
+    plt.close(fig)
+
+
+def test_plot_aoe_rz_map_two_angles():
+    n_r, n_z, n_samples = 3, 4, 50
+    rng = np.random.default_rng(1)
+
+    lib = {
+        "r": Array(np.linspace(0.0, 30.0, n_r), attrs={"units": "mm"}),
+        "z": Array(np.linspace(-20.0, 20.0, n_z), attrs={"units": "mm"}),
+        "waveform_000_deg": Array(rng.random((n_r, n_z, n_samples))),
+        "waveform_045_deg": Array(rng.random((n_r, n_z, n_samples))),
+    }
+
+    fig = psl.plot_aoe_rz_map(lib, "V99000A", hpge_profile=None)
+    assert isinstance(fig, Figure)
+    # two angle panels plus the <100>/<110> ratio panel
+    panels = [ax for ax in fig.axes if ax.get_images()]
+    assert len(panels) == 3
+    plt.close(fig)
 
 
 def test_process_ideal_waveforms():

--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Mapping
 
 import awkward as ak
@@ -615,3 +616,137 @@ def plot_rz_scan(
     cbar.set_label(label)
 
     return fig, ax
+
+
+def symmetrize(a: np.ndarray) -> np.ndarray:
+    """Mirror a half ``[n_r, n_z]`` R/Z map about ``r = 0`` into a full image."""
+    a = a.T
+    return np.concatenate((np.fliplr(a), a), axis=1)
+
+
+def plot_aoe_rz_map(
+    pulse_shape_lib: Mapping[str, Array | Scalar],
+    detector_id: str,
+    *,
+    hpge_profile: object | None = None,
+) -> Figure:
+    """Plot the A/E R/Z map(s) of a pulse shape library.
+
+    For each azimuthal angle present in the library, computes the per-pixel A/E
+    as the maximum of the (energy-normalized) current waveform over the time
+    axis and renders it as a symmetrized R/Z heatmap, styled like the HPGe
+    drift-time-map validation plot. When both the ``<100>`` (0 deg) and
+    ``<110>`` (45 deg) angles are present, an additional ``<100>/<110>`` ratio
+    panel is appended.
+
+    Parameters
+    ----------
+    pulse_shape_lib
+        Mapping containing the pulse shape library, as returned by
+        :func:`make_realistic_pulse_shape_lib`. Must contain ``r``, ``z`` (in
+        mm) and at least one ``waveform_<angle>_deg`` key.
+    detector_id
+        Detector name, e.g. ``"V03422A"``, used in the panel titles.
+    hpge_profile
+        Optional detector geometry object (as returned by
+        ``pygeomhpges.make_hpge``). When given, its profile is overlaid on every
+        panel.
+
+    Returns
+    -------
+    fig : Figure
+    """
+    import pygeomhpges.draw  # noqa: PLC0415
+
+    axis_labels = {0: "<100>", 45: "<110>"}
+
+    angles = sorted(int(k.split("_")[1]) for k in pulse_shape_lib if "waveform" in k)
+    if not angles:
+        msg = "no 'waveform_<angle>_deg' keys found in pulse shape library"
+        raise KeyError(msg)
+
+    r = pulse_shape_lib["r"].nda  # already in mm
+    z = pulse_shape_lib["z"].nda
+
+    # per-angle A/E maps (max current amplitude over the time axis)
+    images = {}
+    for angle in angles:
+        wfs = pulse_shape_lib[f"waveform_{angle:03d}_deg"].nda
+        with warnings.catch_warnings():
+            # invalid pixels are all-NaN waveforms; keep them NaN (rendered blank)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            aoe = np.nanmax(wfs, axis=-1)
+        images[angle] = symmetrize(aoe)
+
+    has_ratio = {0, 45}.issubset(angles)
+    n_panels = len(angles) + (1 if has_ratio else 0)
+
+    extent = (-r.max(), r.max(), z.min(), z.max())
+    stacked = list(images.values())
+    vmin, vmax = np.nanmin(stacked), np.nanmax(stacked)
+
+    fig, axes = plt.subplots(
+        ncols=n_panels,
+        figsize=(4 * n_panels, 4),
+        sharey=True,
+        squeeze=False,
+    )
+    axes = axes[0]
+
+    def plot(ax, img, title, *, cmap, vmin=None, vmax=None):
+        im = ax.imshow(
+            img,
+            origin="lower",
+            extent=extent,
+            aspect="equal",
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+        )
+        if hpge_profile is not None:
+            pygeomhpges.draw.plot_profile(
+                hpge_profile,
+                axes=ax,
+                marker=None,
+                linewidth=1,
+                color="black",
+            )
+
+        xmin, xmax, ymin, ymax = extent
+
+        f = 0.04
+        ax.set_xlim(xmin - f * (xmax - xmin), xmax + f * (xmax - xmin))
+        ax.set_ylim(ymin - f * (ymax - ymin), ymax + f * (ymax - ymin))
+
+        ax.set_xlabel("r (mm)")
+        ax.set_title(f"{detector_id} · {title}")
+
+        return im
+
+    im = None
+    for ax, angle in zip(axes[: len(angles)], angles, strict=True):
+        im = plot(
+            ax,
+            images[angle],
+            axis_labels.get(angle, f"{angle}°"),
+            cmap="viridis",
+            vmin=vmin,
+            vmax=vmax,
+        )
+
+    axes[0].set_ylabel("z (mm)")
+
+    # shared A/E colorbar across all angle panels
+    fig.colorbar(im, ax=axes[: len(angles)], label="A/E")
+
+    if has_ratio:
+        ratio = np.divide(
+            images[0],
+            images[45],
+            out=np.full_like(images[0], np.nan),
+            where=images[45] > 0,
+        )
+        im_ratio = plot(axes[-1], ratio, "<100> / <110>", cmap="coolwarm")
+        fig.colorbar(im_ratio, ax=axes[-1], label="ratio")
+
+    return fig

--- a/workflow/src/legendsimflow/scripts/make_hpge_realistic_pulse_shape_lib.py
+++ b/workflow/src/legendsimflow/scripts/make_hpge_realistic_pulse_shape_lib.py
@@ -22,6 +22,8 @@ import dbetto
 import legenddataflowscripts as ldfs
 import legenddataflowscripts.utils
 import lh5
+import pyg4ometry
+import pygeomhpges
 from lgdo import Array, Struct
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
@@ -189,6 +191,23 @@ def main():
                 label=f"mean A/E = {mean_aoe:.2f}",
             )
             ax.legend()
+            decorate(fig)
+            pdf.savefig(fig)
+            plt.close(fig)
+
+            # A/E R/Z map, styled like the HPGe drift-time-map validation plot
+            reg = pyg4ometry.geant4.Registry()
+            natge = pygeomhpges.materials.make_natural_germanium(registry=reg)
+            hpge_profile = pygeomhpges.make_hpge(
+                metadata.hardware.detectors.germanium.diodes[args.detector],
+                registry=reg,
+                material=natge,
+                allow_cylindrical_asymmetry=False,
+            )
+
+            fig = psl.plot_aoe_rz_map(
+                realistic_dict, args.detector, hpge_profile=hpge_profile
+            )
             decorate(fig)
             pdf.savefig(fig)
             plt.close(fig)

--- a/workflow/src/legendsimflow/scripts/plots/hpge_drift_time_maps.py
+++ b/workflow/src/legendsimflow/scripts/plots/hpge_drift_time_maps.py
@@ -25,6 +25,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 from legendsimflow import nersc
 from legendsimflow.plot import decorate
+from legendsimflow.psl import symmetrize
 
 args = nersc.dvs_ro_snakemake(snakemake)  # noqa: F821
 
@@ -33,11 +34,6 @@ output_pdf = args.output[0]
 
 reg = pyg4ometry.geant4.Registry()
 natge = pygeomhpges.materials.make_natural_germanium(registry=reg)
-
-
-def symmetrize(a):
-    a = a.T
-    return np.concatenate((np.fliplr(a), a), axis=1)
 
 
 def save_page(pdf, make_fig):


### PR DESCRIPTION
## Summary

Adds a per-pixel **A/E** R/Z map page to the realistic pulse-shape-library (PSL) validation PDF, the analogue of the existing HPGe **drift-time-map** validation plot. A/E is the central single-site / multi-site discrimination observable, so its spatial behaviour across the crystal is a useful sanity check on the realistic PSL.

The A/E of each `(r, z)` pixel is `max(current_waveform)` over the time axis. Since the realistic waveforms are already normalized by the bulk A/E (`mean_aoe`) during the PSL build, this yields A/E in units where the single-site bulk sits at ~1. The result is a 2D `[n_r, n_z]` map, the same shape as a `drift_time_<NNN>_deg` map, so the drift-time-map panel styling is reused.

## What changed

- **`psl.py`**: new `plot_aoe_rz_map(pulse_shape_lib, detector_id, *, hpge_profile=None)` plus a shared `symmetrize()` helper. The renderer generalizes over the crystal-axis angles present in the library: one viridis R/Z panel per angle with a shared "A/E" colorbar, plus a coolwarm `<100>/<110>` ratio panel when both `0` and `45` are present. The realistic PSL currently carries a single angle (`waveform_000_deg`, `<100>`), so today this produces one panel; it will reproduce the full drift-time-map-style 3-panel layout automatically if a second angle is added.
- **`make_hpge_realistic_pulse_shape_lib.py`**: appends the A/E map page (after the existing A_max histogram) to the validation PDF, building the HPGe profile overlay from metadata. A/E is computed from the in-memory normalized waveforms, so no extra I/O.
- **`hpge_drift_time_maps.py`**: now imports `symmetrize` from `legendsimflow.psl` instead of defining its own copy (the helper is now canonical in `psl.py`).
- **Tests**: added `test_plot_aoe_rz_map_*` (single- and two-angle layouts) in `tests/test_psl.py`; the realistic-PSL CLI test now uses a real dummyprod detector (`V05261B`) so it exercises the profile overlay end to end.

No new Snakemake rules, patterns, aggregators, or rulegraph changes: the A/E map rides along with the existing realistic-PSL validation PDF (the `plot_file` side-output of `convolve_hpge_ideal_pulse_shape_lib`).

## Example

The new page renders like a drift-time-map panel (detector profile overlaid, symmetric R/Z extent, viridis + "A/E" colorbar, NaN regions blank).

## Testing

- `pytest tests/test_psl.py tests/scripts/test_make_realistic_hpge_psl.py` passes.
- `pre-commit run --all-files` clean.