### PR TITLE
feat: data-amplitude weighting for the HPGe electronics-response fit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dependencies = [
     "pylegendmeta >=1.4.4",
     "pyyaml",
     "reboost >=0.12.2,<0.13",
+    # particle 1.0 made charge() return a Fraction, which numba cannot type in reboost
+    "particle <1",
     "revertex >=0.1.2",
     "ruamel.yaml",
     "snakemake >=9.19,<9.20",
@@ -143,6 +145,8 @@ legend-pygeom-hpges = ">=0.9,<0.10"
 pyg4ometry = "*"
 pygama = ">=2.3.6,<2.4"
 reboost = ">=0.12.2,<0.13"
+# particle 1.0 made charge() return a Fraction, which numba cannot type in reboost
+particle = "<1"
 
 # tier stp
 remage = ">=0.19.5,<0.20"

--- a/tests/test_hpge_electronics_tuning.py
+++ b/tests/test_hpge_electronics_tuning.py
@@ -111,6 +111,49 @@ def test_compute_rms_no_overlap_raises():
         compute_rms_in_slice(np.ones(10), np.arange(100, 110, dtype=float), sp)
 
 
+def test_compute_rms_weight_zero_matches_unweighted():
+    sl = Slice(energy_range=(0, 1e6), drift_time_range=(900, 1100))
+    time = np.arange(100, dtype=float)
+    data_wf = np.sin(np.linspace(0, 2 * np.pi, 100)) + 2.0
+    sim_wf = data_wf + 0.3
+    sp = _make_superpulse(sl, data_wf, time)
+
+    # weight_power=0.0 is the default and must reproduce the plain RMS exactly
+    assert compute_rms_in_slice(sim_wf, time, sp, weight_power=0.0) == pytest.approx(
+        compute_rms_in_slice(sim_wf, time, sp)
+    )
+
+
+def test_compute_rms_weight_downweights_low_amplitude():
+    sl = Slice(energy_range=(0, 1e6), drift_time_range=(900, 1100))
+    time = np.arange(100, dtype=float)
+    # data is large on the "peak" half, ~0 on the "tail" half
+    data_wf = np.zeros(100)
+    data_wf[:50] = 10.0
+    # the simulation errs only where the data is near zero (the tail)
+    sim_wf = data_wf.copy()
+    sim_wf[50:] += 1.0
+    sp = _make_superpulse(sl, data_wf, time)
+
+    rms_plain = compute_rms_in_slice(sim_wf, time, sp)
+    rms_weighted = compute_rms_in_slice(sim_wf, time, sp, weight_power=2.0)
+
+    assert rms_plain > 0
+    # amplitude weighting suppresses the low-amplitude (tail) residual
+    assert rms_weighted < rms_plain
+    assert rms_weighted == pytest.approx(0.0, abs=1e-12)
+
+
+def test_compute_rms_weight_zero_data_raises():
+    sl = Slice(energy_range=(0, 1e6), drift_time_range=(900, 1100))
+    time = np.arange(100, dtype=float)
+    sp = _make_superpulse(sl, np.zeros(100), time)
+
+    # all-zero data gives zero weights everywhere -> undefined weighted RMS
+    with pytest.raises(ValueError, match="weights sum to zero"):
+        compute_rms_in_slice(np.ones(100), time, sp, weight_power=2.0)
+
+
 def test_build_cost_function_penalty():
     """Non-positive parameters must return the penalty value."""
     sl = Slice(energy_range=(0, 1e6), drift_time_range=(900, 1100))

--- a/workflow/src/legendsimflow/hpge_electronics_tuning.py
+++ b/workflow/src/legendsimflow/hpge_electronics_tuning.py
@@ -80,11 +80,18 @@ def compute_rms_in_slice(
     sim_time: NDArray,
     data_sp: Superpulse,
     comparison_window: tuple[float, float] | None = None,
+    weight_power: float = 0.0,
 ) -> float:
     """RMS residual between a simulated and a data current superpulse.
 
     The simulation is linearly interpolated onto the data time grid.
     Samples outside the sim time range are excluded from the comparison.
+
+    With ``weight_power > 0`` the squared residuals are weighted by the data
+    current amplitude, ``w = |data|**weight_power``, before the RMS, so the
+    high-amplitude samples around the current peak dominate the cost and the
+    near-zero tail is down-weighted (a data-amplitude-weighted RMS).
+    ``weight_power = 0`` (the default) reproduces the plain equal-weight RMS.
 
     Parameters
     ----------
@@ -98,11 +105,15 @@ def compute_rms_in_slice(
     comparison_window
         ``(t_min, t_max)`` in ns relative to the current peak.
         If ``None``, the full waveform overlap is used.
+    weight_power
+        Exponent ``p`` of the data-amplitude weight ``w = |data|**p`` applied
+        to the squared residuals. ``0`` (default) is the unweighted RMS;
+        larger values concentrate the fit on the current peak and its flanks.
 
     Returns
     -------
     rms
-        Root mean square of the residuals.
+        (Optionally data-amplitude-weighted) root mean square of the residuals.
 
     """
     data_time = data_sp.current_time_axis
@@ -127,7 +138,17 @@ def compute_rms_in_slice(
         msg = "no valid samples in comparison region"
         raise ValueError(msg)
 
-    return float(np.sqrt(np.mean((sim_on_data - data_wf) ** 2)))
+    sq_resid = (sim_on_data - data_wf) ** 2
+
+    if weight_power:
+        weights = np.abs(data_wf) ** weight_power
+        weight_sum = np.sum(weights)
+        if weight_sum == 0:
+            msg = "data-amplitude weights sum to zero in comparison region"
+            raise ValueError(msg)
+        return float(np.sqrt(np.sum(weights * sq_resid) / weight_sum))
+
+    return float(np.sqrt(np.mean(sq_resid)))
 
 
 def build_cost_function(
@@ -137,6 +158,7 @@ def build_cost_function(
     alignment_idx: int,
     nsamples_output: int,
     comparison_window: tuple[float, float] | None = None,
+    weight_power: float = 0.0,
 ) -> Callable:
     """Build the scalar cost function for the Minuit minimiser.
 
@@ -158,6 +180,9 @@ def build_cost_function(
         Length of the output waveforms.
     comparison_window
         ``(t_min, t_max)`` in ns. Passed through to :func:`compute_rms_in_slice`.
+    weight_power
+        Data-amplitude weight exponent ``p`` (``w = |data|**p``) passed through
+        to :func:`compute_rms_in_slice`. ``0`` (default) is the unweighted RMS.
 
     Returns
     -------
@@ -188,7 +213,11 @@ def build_cost_function(
             sim_avg = np.mean(processed, axis=0)
             sim_time = (np.arange(len(sim_avg)) - alignment_idx) * dt
             total += compute_rms_in_slice(
-                sim_avg, sim_time, data_superpulses[sl], comparison_window
+                sim_avg,
+                sim_time,
+                data_superpulses[sl],
+                comparison_window,
+                weight_power,
             )
         return total / len(ideal_wfs_slice)
 
@@ -276,6 +305,7 @@ def fit_electronics_parameters(
     sigma_limits: tuple[float, float],
     tau_limits: tuple[float, float],
     comparison_window: tuple[float, float] | None = None,
+    weight_power: float = 0.0,
     max_calls: int = 5000,
 ) -> dict:
     """Fit the electronics response parameters sigma and tau.
@@ -307,6 +337,10 @@ def fit_electronics_parameters(
     comparison_window
         ``(t_min, t_max)`` in ns relative to the current peak.
         If ``None``, the full waveform overlap is used.
+    weight_power
+        Data-amplitude weight exponent ``p`` for the cost (``w = |data|**p``);
+        ``0`` (default) is the plain equal-weight RMS, larger values bias the
+        fit toward the current peak. See :func:`compute_rms_in_slice`.
     max_calls
         Maximum number of Minuit function evaluations.
 
@@ -325,6 +359,7 @@ def fit_electronics_parameters(
         alignment_idx,
         nsamples_output,
         comparison_window,
+        weight_power,
     )
 
     history: list[tuple[tuple[float, float], float]] = []

--- a/workflow/src/legendsimflow/scripts/extract_hpge_elec_response_model.py
+++ b/workflow/src/legendsimflow/scripts/extract_hpge_elec_response_model.py
@@ -54,6 +54,10 @@ DEFAULT_SETTINGS = {
     "sigma_limits": (0.0, 200.0),
     "tau_limits": (0.0, 200.0),
     "comparison_window": (-500.0, 500.0),
+    # data-amplitude weight exponent p for the fit cost (w = |data|**p): biases
+    # the fit toward the current peak and its flanks; 0.0 reproduces the plain
+    # equal-weight RMS
+    "weight_power": 2.0,
     "max_calls": 1000,
     "dt_range_tuning": (600.0, 3000.0),
     "max_num_superpulses": 5,
@@ -237,6 +241,7 @@ def main() -> None:
         sigma_limits=tuple(settings.sigma_limits),
         tau_limits=tuple(settings.tau_limits),
         comparison_window=comparison_window,
+        weight_power=settings.get("weight_power", 0.0),
         max_calls=settings.max_calls,
     )
 


### PR DESCRIPTION
## Summary

The single-pole HPGe electronics-response fit (`extract_hpge_elec_response_model`) minimises an equal-weight RMS between the data and model current superpulses over the comparison window. Because the long, low-amplitude tail contributes many samples, it can dominate the cost and pull the fit away from the current peak, which is the A/E observable.

This adds an optional **data-amplitude weight** `w = |data|**weight_power` to the per-slice cost, so the current peak and its flanks dominate and the near-zero tail is down-weighted. `weight_power = 0` reproduces the previous equal-weight RMS exactly.

## Changes

- `compute_rms_in_slice`, `build_cost_function`, and `fit_electronics_parameters` gain a `weight_power` argument (default `0.0`, backward compatible), threaded through the cost chain.
- `extract_hpge_elec_response_model.py`: `weight_power` added to `DEFAULT_SETTINGS` and passed to the fit (read with a safe fallback for older settings files).
- Tests: `weight_power=0` matches the unweighted RMS; a low-amplitude (tail) residual is suppressed by the weighting; all-zero data raises.

## Behaviour change

`DEFAULT_SETTINGS["weight_power"] = 2.0`, so the production fit is now **peak-weighted by default**. Set it to `0.0` (globally, or via a per-run settings file) to recover the previous equal-weight behaviour.

## Validation

- `pre-commit run --files ...` on the changed files: all hooks pass.
- `pytest tests/test_hpge_electronics_tuning.py tests/test_psl.py`: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
