### PR TITLE
PSL performance improvements

### DIFF
--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -57,9 +57,14 @@ def get_avg_aoe(waveforms: list[np.ndarray]) -> float:
     aoe = np.concatenate([np.max(waveform, axis=2).ravel() for waveform in waveforms])
     aoe = aoe[~np.isnan(aoe)]
 
-    hist_aoe = hist.new.Reg(
-        1000, np.min(aoe), np.max(aoe), name="A/E", label="A/E"
-    ).Double()
+    amin, amax = float(np.min(aoe)), float(np.max(aoe))
+    if amax <= amin:
+        # degenerate distribution (e.g. constant amplitudes): pad to a finite
+        # range so the histogram axis is valid
+        pad = abs(amin) * 1e-3 or 1.0
+        amin, amax = amin - pad, amax + pad
+
+    hist_aoe = hist.new.Reg(1000, amin, amax, name="A/E", label="A/E").Double()
 
     hist_aoe.fill(aoe)
     counts, bin_edges = hist_aoe.to_numpy()
@@ -495,7 +500,7 @@ def make_realistic_pulse_shape_lib(
         drift_indices = current_peak_indices - kernel_delay_idx
         drift_times_flat = drift_indices * dt
         drift_times_2d = drift_times_flat.reshape(original_shape[:-1]).astype(
-            np.float64
+            np.float32
         )
 
         # Restore NaN for invalid pixels in drift time
@@ -503,10 +508,11 @@ def make_realistic_pulse_shape_lib(
         dt_key = key.replace("waveform", "drift_time")
         realistic_pulse_shape_lib[dt_key] = Array(drift_times_2d, attrs={"units": "ns"})
 
-        # Reshape
+        # Reshape. float32 halves the on-disk library and the load footprint
+        # (more than enough for the ~1% A/E it feeds)
         new_length = curr_aligned.shape[-1]
         new_shape = (*original_shape[:-1], new_length)
-        wfs_out = curr_aligned.reshape(new_shape).astype(np.float64)
+        wfs_out = curr_aligned.reshape(new_shape).astype(np.float32)
 
         # Restore NaN for invalid pixels in waveforms
         wfs_out[nan_mask] = np.nan

--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -35,7 +35,7 @@ DT_DATA: float = 16.0
 MW_PARS: dict[str, int] = {"length": 48, "num_mw": 3, "mw_type": 0}
 
 
-def get_avg_aoe(waveforms: list[np.ndarray]) -> float:
+def get_avg_aoe(waveforms: list[np.ndarray]) -> tuple[hist.Hist, float]:
     """Estimate the average A/E from the PSL.
 
     Estimated as the mode of the distribution of

--- a/workflow/src/legendsimflow/reboost.py
+++ b/workflow/src/legendsimflow/reboost.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import awkward as ak
@@ -187,7 +187,10 @@ def get_senstables(
 
 
 def load_hpge_realistic_psl(
-    config: SimflowConfig, det_name: str, runid: str
+    config: SimflowConfig,
+    det_name: str,
+    runid: str,
+    waveform_angles: Sequence[str] = ("000",),
 ) -> (
     tuple[
         dict[str, reboost.hpge.utils.HPGeRZField],
@@ -208,6 +211,11 @@ def load_hpge_realistic_psl(
         HPGe detector name.
     runid
         Run identifier.
+    waveform_angles
+        Crystal-axis angles for which to load the (large) waveform
+        pulse-shape libraries. Defaults to the 000-degree axis only, which is
+        the single axis consumed by :func:`extract_detailed_psd_observables`.
+        The drift-time maps are always loaded for both axes regardless.
 
     Returns
     -------
@@ -230,17 +238,26 @@ def load_hpge_realistic_psl(
 
     if len(lh5.ls(psl_file, f"{det_name}/drift_time_*")) >= 2:
         log.debug("loading drift time maps from %s", psl_file)
-        dt_map = {}
-        waveform_map = {}
-        for angle in ("000", "045"):
-            dt_map[angle] = reboost.hpge.utils.get_hpge_rz_field(
+        # both axes needed: hpge_corrected_drift_time() blends them (and small)
+        dt_map = {
+            angle: reboost.hpge.utils.get_hpge_rz_field(
                 psl_file,
                 det_name,
                 f"drift_time_{angle}_deg",
                 bounds_error=False,
             )
-            waveform_map[angle] = reboost.hpge.utils.get_hpge_pulse_shape_library(
+            for angle in ("000", "045")
+        }
+        # waveforms dominate memory (PSL file is O(10 GB)); load only the axes
+        # used downstream (extract_detailed_psd_observables() is single-axis)
+        waveform_map = {}
+        for angle in waveform_angles:
+            lib = reboost.hpge.utils.get_hpge_pulse_shape_library(
                 psl_file, det_name, f"waveform_{angle}_deg", out_of_bounds_val=0
+            )
+            # float32 is enough for ~1% A/E; halves the templates if read as f64
+            waveform_map[angle] = lib._replace(
+                waveforms=np.asarray(lib.waveforms, dtype=np.float32)
             )
 
     else:

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -300,6 +300,9 @@ def main() -> None:
             )
 
             if simulate_psd_with_psl:
+                # free the previous detector's library before loading the next,
+                # so peak memory holds one detector's PSL rather than two
+                psl_dt_maps = realistic_psl = None
                 psl_dt_maps, realistic_psl = reboost_utils.load_hpge_realistic_psl(
                     config, det_name, runid
                 )


### PR DESCRIPTION
- **perf: load only the 000-degree waveform PSL and store it as float32**
- **perf: free the previous detector's PSL before loading the next in build_tier_hit**
- **perf: write realistic PSL waveforms and drift times as float32**
