### PR TITLE
docs: document the HPGe pulse-shape-library (PSL) workflow

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,18 +3,41 @@
 Sphinx-based. Build: `cd docs && make`. Config in `docs/source/conf.py`. See
 `Makefile` for other useful targets.
 
+## Structure
+
+- `meta.md`: description of the input metadata that configures the production,
+  format and meaning;
+- `output.md`: description of the outputs of the production, format and
+  contents, organized by step;
+- `pipeline.md`: description of the workflow steps and what they do. No details
+  about the output formats here, they go in `output.md`;
+- `prod.md`: Simflow execution modes and configuration;
+- `setup.md`: high level setup of the Simflow, installation and main
+  configuration file.
+- `sites.md`: Computing site execution tips.
+- `tips.md`: Collection of tips&tricks.
+
 ## Conventions
 
 - Source in `docs/source/`, user manual under `manual/`
 - A script in `tools/` generates the Snakemake rule reference from docstrings
 - Pages written in Markdown
+- Use admonitions when appropriate, to highlight important messages to end
+  users.
 - Colon fences (`:::`) for sphinx directives like admonitions. Always add an
   empty line after the open and before the close of a `:::` block, otherwise
   `prettier` will re-wrap and break rendering
 - Always enable code block highlighting. Use `console` for shell commands
   (prompt delimiter `>`)
+- Write LaTeX-formatted math when appropriate. MyST `dollarmath` is enabled so
+  you can use `$...$` and `$$...$$` for inline and block math, respectively.
+- Runids (including components) and tier names must be formatted as monospaced
+  text.
 - Document each function and Snakemake rule in its docstring; higher-level docs
   go in the user manual
+- Avoid duplication between docstrings and manual when possible and rather xref
+  docstrings (also from other packages through intersphinx). Keep details in the
+  docstrings.
 - All new pages must appear in a toctree — orphan pages cause build warnings
 - API reference is auto-generated; do not write it by hand
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -51,7 +51,11 @@ macros or post-processing settings) is stored at
 
 1. The LEGEND-200 data is queried to extract several runtime quantities of
    interest (HPGe energy resolution, electronic noise, hardware status, etc.).
-   These are typically referred to as the "pars".
+   When PSL-based pulse-shape simulation is enabled, calibration data are also
+   used to build per-detector data superpulses and fit an electronics-response
+   model, which are then combined with simulation-derived drift-time maps and
+   ideal pulse-shape libraries to produce the realistic pulse-shape library
+   (PSL) for each run. These outputs are collectively referred to as the "pars".
 
 1. Run the first (hit-oriented) step of simulation post-processing. Here, a
    "hit" represents a collection of Geant4 "step" in a single detector

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -433,10 +433,13 @@ psdcuts_default:
 - `aoeresmod_default` — A/E resolution model applied to detectors without a
   per-detector entry. See {ref}`build-tier-hit-hpge` for when this fallback is
   triggered.
-- `simulate_psd` a flag to perform the PSD simulations based on the single
-  template (default is `True`).
-- `simulate_psd_with_psl` a flag to perform the simulations based on the
-  pulse-shape-library (PSL), default: `False`,
+- `simulate_psd` (bool, default `True`): enable the single-template A/E PSD
+  simulation, written to the `geds/psd` subtable of the `hit` tier.
+- `simulate_psd_with_psl` (bool, default `False`): enable the
+  pulse-shape-library based PSD simulation (see {ref}`hpge-psl-overview`),
+  written to the `geds/psd_psl` subtable. The two flags are independent: enable
+  either, both, or neither. Setting both to `False` disables the HPGe PSD
+  simulation entirely.
 - `psdcuts_default` — PSD cut values applied to detectors without a per-detector
   entry. See {ref}`build-tier-hit-hpge` for when this fallback is triggered.
 
@@ -529,10 +532,13 @@ detector_groups:
 Metadata is organized in this directory by experimental configuration (first
 level) and detector type (second level), mirroring the `tier/` structure.
 
+(ssd-settings-meta)=
+
 ### Pulse shape simulation settings
 
 A single shared YAML file (applies to all detectors and voltages) that overrides
-`SolidStateDetectors.jl` simulation control parameters for the
+[`SolidStateDetectors.jl`](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/)
+simulation control parameters for the
 [`build_hpge_drift_time_map`](../api/snakemake_rules.md) and
 [`build_hpge_pulse_shape_library`](../api/snakemake_rules.md) rules. When
 absent, the scripts use built-in production defaults.
@@ -547,9 +553,9 @@ padding: 3
 
 | Key                     | Type          | Default                  | Description                                                                                                                                                                                                                                  |
 | ----------------------- | ------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `grid_size_in_mm`       | float         | `0.5`                    | Simulation grid spacing in mm. Execution time scales quadratically with `1/grid_size_in_mm`. The built-in default differs per rule (0.5 mm for the drift time map, 5 mm for the pulse shape library); an explicit value here overrides both. |
+| `grid_size_in_mm`       | float         | `0.5`                    | Simulation grid spacing in mm. Execution time scales quadratically with `1/grid_size_in_mm`. The built-in default differs per rule (0.5 mm for the drift-time map, 5 mm for the pulse-shape library); an explicit value here overrides both. |
 | `ssd_refinement_limits` | list of float | `[0.2, 0.1, 0.05, 0.02]` | SSD adaptive-mesh refinement thresholds. Each entry drives one refinement pass; smaller values give a more accurate electric field at higher cost. **Overly coarse values can prevent full detector depletion — change with care.**          |
-| `padding`               | int           | `3`                      | Number of pixel layers padded around the simulated map (drift time map and pulse shape library) boundary to avoid grid edge effects.                                                                                                         |
+| `padding`               | int           | `3`                      | Number of pixel layers padded around the simulated map (drift-time map and pulse-shape library) boundary to avoid grid edge effects.                                                                                                         |
 
 :::{tip}
 
@@ -605,8 +611,8 @@ at runtime.
 ### A/E resolution model defaults
 
 An optional validity-based metadata directory providing HPGe-specific A/E
-resolution parameters. Follows the same structure and four-case logic as
-{ref}`eresmod-metadata-dir`.
+resolution parameters. Follows the same structure as {ref}`eresmod-metadata-dir`
+and the same {ref}`source-resolution logic <par-collection-model>`.
 
 ```{code-block} yaml
 :caption: simprod/config/pars/{experiment}/geds/aoeresmod/l200-p03-r%-T%-all-aoeresmod.yaml
@@ -699,8 +705,8 @@ A/E mean of 1 (a warning is logged for `on` detectors).
 ### PSD cut defaults
 
 An optional validity-based metadata directory providing HPGe-specific PSD cut
-values. Follows the same structure and four-case logic as
-{ref}`eresmod-metadata-dir`.
+values. Follows the same structure as {ref}`eresmod-metadata-dir` and the same
+{ref}`source-resolution logic <par-collection-model>`.
 
 ```{code-block} yaml
 :caption: simprod/config/pars/{experiment}/geds/psdcuts/l200-p03-r%-T%-all-psdcuts.yaml
@@ -733,10 +739,20 @@ at runtime.
 
 ### Current pulse model defaults
 
+:::{note}
+
+The current-pulse model drives the single-template A/E PSD simulation, enabled
+with `simulate_psd: True` in {ref}`hit-tier-settings` (default `True`). Set it
+to `False` to disable the single-template PSD path. See
+{ref}`build-tier-hit-hpge`.
+
+:::
+
 An optional validity-based metadata directory providing HPGe-specific current
-pulse model parameters. Follows the same structure and four-case logic as
-{ref}`eresmod-metadata-dir`, but applied per-detector rather than per-run (one
-output file per `(runid, hpge_detector)` pair).
+pulse model parameters. Follows the same structure as
+{ref}`eresmod-metadata-dir` and the same
+{ref}`source-resolution logic <par-collection-model>`, but applied per-detector
+rather than per-run (one output file per `(runid, hpge_detector)` pair).
 
 ```{code-block} yaml
 :caption: simprod/config/pars/{experiment}/geds/currmod/l200-p03-r%-T%-all-currmod.yaml
@@ -767,14 +783,14 @@ V02160A:
   current_reso: 0.012
 ```
 
-- `default` _(optional)_ — current pulse model applied to all HPGe detectors not
+- `default` _(optional)_ — current-pulse model applied to all HPGe detectors not
   listed explicitly.
 - `<detector>` _(optional)_ — per-detector override.
 
 Each entry must contain:
 
 - `current_pulse_pars` — mapping of parameter names to their values for the
-  current pulse model (`amax`, `mu`, `sigma`, `tail_fraction`, `tau`,
+  current-pulse model (`amax`, `mu`, `sigma`, `tail_fraction`, `tau`,
   `high_tail_fraction`, `high_tau`; the last two default to `0` if omitted)
 - `mean_aoe` — mean A/E value
 - `current_reso` — current resolution (σ) from the noise-fit
@@ -782,12 +798,110 @@ Each entry must contain:
 See {ref}`hpge-currmod-extraction` for a description of how these files are used
 at runtime.
 
+(superpulses-settings-meta)=
+
+### Superpulse settings
+
+:::{note}
+
+These settings apply only when the pulse-shape-library (PSL) PSD simulation is
+enabled with `simulate_psd_with_psl: True` in {ref}`hit-tier-settings` (default
+`False`). See {ref}`hpge-psl-overview`.
+
+:::
+
+A static YAML settings file that controls the superpulse building step
+(`build_superpulses_from_data`). When absent, the script uses built-in
+production defaults. Settings are read via
+`get_par_settings(config, "superpulses")` from
+`simprod/config/pars/{experiment}/geds/superpulses/`.
+
+```{code-block} yaml
+:caption: simprod/config/pars/{experiment}/geds/superpulses/settings.yaml
+
+build_per_runid: false
+min_number_wfs: 10
+target_wfs: 100
+chi2_threshold: 3
+t0_field: spms/event_t0
+end_time_field: geds/psd/low_aoe/time
+drift_time_slices: "1000:200:2000"
+evt_tier_name: pet
+max_files: null
+charge_output: wf_pz_win
+curr_output: curr_av
+energy_output: cuspEmax
+```
+
+| Key                 | Type        | Default                 | Description                                                                                                                                                                                  |
+| ------------------- | ----------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build_per_runid`   | bool        | `false`                 | When `true`, produce one superpulse LH5 file per `(runid, detector)` instead of one file per detector accumulating all runs. See {ref}`hpge-superpulses-extraction`.                         |
+| `min_number_wfs`    | int         | `10`                    | Minimum waveforms required to form a superpulse for a slice; slices with fewer events are skipped.                                                                                           |
+| `target_wfs`        | int         | `100`                   | Target number of waveforms to collect per slice before stopping accumulation.                                                                                                                |
+| `chi2_threshold`    | float       | `3`                     | Reduced chi2 threshold for the self-similarity cut; waveforms above this value are rejected before computing the final superpulse.                                                           |
+| `t0_field`          | str         | `spms/event_t0`         | Event-level field used as the start time for drift-time calculation. Events where this field is NaN are discarded; for `spms/event_t0` this removes events without a coincident SiPM signal. |
+| `end_time_field`    | str         | `geds/psd/low_aoe/time` | Event-level field used as the end time for drift-time calculation.                                                                                                                           |
+| `drift_time_slices` | str         | `"1000:200:2000"`       | Drift-time bins as `start:step:stop` in ns; the default creates 200 ns-wide bins from 1000 to 2000 ns.                                                                                       |
+| `evt_tier_name`     | str         | `pet`                   | Name of the evt tier to read from the data production (e.g. `pet` or `evt`).                                                                                                                 |
+| `max_files`         | int or null | `null`                  | If set, limits the number of raw and evt files processed per run (useful for testing).                                                                                                       |
+| `charge_output`     | str         | `wf_pz_win`             | DSP processing chain output name for the charge waveform.                                                                                                                                    |
+| `curr_output`       | str         | `curr_av`               | DSP processing chain output name for the current waveform.                                                                                                                                   |
+| `energy_output`     | str         | `cuspEmax`              | DSP processing chain output name for the energy estimator used in waveform normalisation.                                                                                                    |
+
+(elecmod-metadata-dir)=
+
+### Electronics-response model defaults
+
+:::{note}
+
+These settings apply only when the pulse-shape-library (PSL) PSD simulation is
+enabled with `simulate_psd_with_psl: True` in {ref}`hit-tier-settings` (default
+`False`). See {ref}`hpge-psl-overview`.
+
+:::
+
+An optional validity-based metadata directory providing HPGe-specific
+electronics-response model parameters. When a `default` key is present, the
+data-driven fit in `extract_electronics_model_pars` is bypassed entirely and the
+metadata values are written directly to the output YAML. This makes PSL-based
+simulations possible without access to LEGEND-200 data (e.g. for LEGEND-1000
+studies). The structure follows the same validity-based format as
+{ref}`eresmod-metadata-dir`.
+
+```{code-block} yaml
+:caption: simprod/config/pars/{experiment}/geds/elecmod/l200-p03-r%-T%-all-elecmod.yaml
+
+default:
+  sigma: 10.0
+  tau: 50.0
+
+# optional per-detector override
+V02160A:
+  sigma: 12.0
+  tau: 45.0
+```
+
+- `default` _(optional)_ — electronics-response model parameters applied to all
+  HPGe detectors not listed explicitly. When present, also removes the
+  requirement for `build_superpulses_from_data` as an input to
+  `extract_electronics_model_pars`.
+- `<detector>` _(optional)_ — per-detector override; key is the detector name as
+  it appears in the channel map (e.g. `V02160A`).
+
+Each entry must contain:
+
+- `sigma` — Gaussian sigma of the digitizer bandwidth in ns.
+- `tau` — exponential decay constant of the preamplifier response in ns.
+
+See {ref}`hpge-elecmod-extraction` for a description of how these files are used
+at runtime.
+
 (skip-metadata-dir)=
 
 ### Manual HPGe skip-list
 
 An optional validity-based metadata directory listing HPGe detectors that should
-be excluded from drift-time map and current pulse model generation, regardless
+be excluded from drift-time map and current-pulse model generation, regardless
 of their status in the channel map.
 
 ```{code-block} yaml
@@ -802,12 +916,12 @@ Each entry is a mapping of detector name (as it appears in the channel map, e.g.
 The reason is written to the workflow log as a WARNING when the skip is applied.
 
 Detectors listed here are removed from the "modelable" HPGe list for the
-matching runs. They will not get a drift-time map nor a current pulse model
+matching runs. They will not get a drift-time map nor a current-pulse model
 produced. The validity rules are the same as those of the other `geds/`
 parameter directories (see {ref}`eresmod-metadata-dir`).
 
 A detector that is manually skipped is treated identically to one that lacks a
-drift-time map or current pulse model for any other reason: PSD output columns
+drift-time map or current-pulse model for any other reason: PSD output columns
 are filled with NaN and the fallback A/E resolution and PSD cuts
 (`aoeresmod_default` / `psdcuts_default`) are used. No hard error is raised. See
 {ref}`build-tier-hit-hpge` for the full fallback policy.

--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -4,6 +4,28 @@ This page documents the fields (columns) produced by each post-processing tier
 of the Simflow. All output files use the
 [LEGEND HDF5 (LH5) format](https://legend-exp.github.io/legend-data-format-specs/dev/hdf5/).
 
+(par-output-files)=
+
+## `par` tier — HPGe PSD parameter files
+
+The drift-time-map and pulse-shape-library rules of the `par` tier write the
+per-detector / per-run parameter files consumed by `build_tier_hit` for PSD
+simulation. See [](pipeline.md) for how each is produced, and the rule reference
+linked there for the internal field structure. Their on-disk locations are:
+
+| Output                              | Location                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| Drift-time map (merged per run)     | `{config.paths.dtmaps}/{runid}-hpge-drift-time-maps.lh5`                                    |
+| Ideal PSL (per detector/voltage)    | `{config.paths.pars}/hpge/psl/ideal/singles/{detector}-{voltage}V-hpge-pulse-shape-lib.lh5` |
+| Data superpulses                    | `{config.paths.pars}/hpge/superpulses/{detector}-superpulses.lh5`                           |
+| Electronics-response model (merged) | `{config.paths.pars}/hpge/elecmod/{runid}-model.yaml`                                       |
+| Realistic PSL (merged per run)      | `{config.paths.pars}/hpge/psl/realistic/{runid}-hpge-pulse-shape-lib.lh5`                   |
+
+The data-superpulse layout switches to one file per `(runid, detector)` pair
+(`{runid}-{detector}-superpulses.lh5`) when `build_per_runid` is set (see
+{ref}`superpulses-settings-meta`). The drift-time map and realistic PSL also
+have per-detector `singles/` files that the merge step combines.
+
 ## `hit` tier — HPGe detector post-processing
 
 The `hit` tier applies detector response models (energy resolution, pulse-shape
@@ -34,19 +56,33 @@ These fields are carried over from the
 | `usability`     | `Array` | —     | Encoded detector usability status for this run (e.g. `on`, `off`, `ac`). Decode with {func}`legendsimflow.metadata.decode_usability`. See the detector status flags in `legend-metadata/datasets/statuses`. |
 | `psd_usability` | `Array` | —     | Encoded PSD usability flag (e.g. `valid`). Indicates whether PSD parameters are valid in LEGEND-200 data for this detector and run. Decode with {func}`legendsimflow.metadata.decode_psd_usability`.        |
 
-In addition, several PSD based fields can be added, these are in either the
-subtable `psd`, for the single template based A/E simulation (present if
-`simulate_psd` is `True` in the hit tier setting file), or `psd_psl` for the
-pulse shape library based one (present if `simulate_psd_with_psl` is `True` in
-the hit tier settings file). Each subtable contains the following fields:
+The `hit` tier can add HPGe pulse-shape-discrimination (PSD) fields in two
+optional subtables, selected by the metadata settings in
+{ref}`hit-tier-settings`:
 
-| Field             | Type    | Units | Description                                                                                                                                                                                                                                                                                            |
-| ----------------- | ------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `drift_time_amax` | `Array` | ns    | Drift time at the maximum-current (A) position of the simulated current pulse. Set to `NaN` when no drift-time map or current-pulse model is available for the detector.                                                                                                                               |
-| `aoe_raw`         | `Array` | —     | Raw A/E value: maximum current amplitude divided by energy. The maximum current (A) is obtained from the simulated current pulse, constructed from individual hit drift times and a current-pulse model, and includes electronic noise effects.                                                        |
-| `aoe_corr`        | `Array` | —     | Energy-corrected A/E value, obtained by correcting `aoe_raw` for the observed energy dependence.                                                                                                                                                                                                       |
-| `aoe`             | `Array` | —     | A/E classifier value: `(aoe_corr - 1) / aoe_resolution`. Used for pulse-shape discrimination (PSD). Set to `NaN` when PSD simulation is not available (i.e., when the drift-time map or current-pulse model is missing). This is distinct from the usability flags that track LEGEND-200 data quality. |
-| `is_single_site`  | `Array` | —     | Boolean PSD flag. `True` if `aoe` falls within the single-site acceptance window defined by cut values extracted from LEGEND-200 data (`psdcuts.aoe.low_side` to `psdcuts.aoe.high_side`).                                                                                                             |
+- `psd` — single-template A/E simulation, present only when `simulate_psd: True`
+  (the default).
+- `psd_psl` — pulse-shape-library (PSL) based simulation, present only when
+  `simulate_psd_with_psl: True` (see {ref}`hpge-psl-overview`).
+
+:::{note}
+
+The two subtables hold the same-named A/E fields, but their **meaning differs**:
+the `psd` values come from a single per-detector current-pulse template, while
+the `psd_psl` values come from the per-pixel pulse-shape library (see
+{ref}`hpge-psl-overview`).
+
+:::
+
+| Field             | Type    | Units | Subtable         | Description                                                                                                                                                                                                                                                                                            |
+| ----------------- | ------- | ----- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `drift_time_amax` | `Array` | ns    | `psd`, `psd_psl` | Drift time at the maximum-current (A) position of the simulated current pulse. Set to `NaN` when no drift-time map or current-pulse model is available for the detector.                                                                                                                               |
+| `aoe_raw`         | `Array` |       | `psd`, `psd_psl` | Raw A/E value: maximum current amplitude divided by energy. The maximum current (A) is obtained from the simulated current pulse and includes electronic noise effects.                                                                                                                                |
+| `aoe_corr`        | `Array` |       | `psd`, `psd_psl` | Energy-corrected A/E value, obtained by correcting `aoe_raw` for the observed energy dependence.                                                                                                                                                                                                       |
+| `aoe`             | `Array` |       | `psd`, `psd_psl` | A/E classifier value: `(aoe_corr - 1) / aoe_resolution`. Used for pulse-shape discrimination (PSD). Set to `NaN` when PSD simulation is not available (i.e., when the drift-time map or current-pulse model is missing). This is distinct from the usability flags that track LEGEND-200 data quality. |
+| `is_single_site`  | `Array` |       | `psd`, `psd_psl` | Boolean PSD flag. `True` when the A/E classifier `aoe` exceeds the lower single-site cut `psdcuts.aoe.low_side` (extracted from LEGEND-200 data).                                                                                                                                                      |
+| `is_bb_like`      | `Array` |       | `psd_psl`        | Boolean PSD flag. `True` for $0\nu\beta\beta$-like single-site events: `aoe` above `psdcuts.aoe.low_side` and not above the upper cut `psdcuts.aoe.high_side`.                                                                                                                                         |
+| `is_high_aoe`     | `Array` |       | `psd_psl`        | Boolean PSD flag. `True` when `aoe` exceeds the upper cut `psdcuts.aoe.high_side` (high-A/E events, e.g. surface or $\alpha$).                                                                                                                                                                         |
 
 ## `opt` tier — optical (SiPM) post-processing
 
@@ -123,15 +159,24 @@ and are from non-OFF detectors.
 
 #### `geds/psd/` and `geds/psd_psl` — PSD fields
 
-| Field            | Type              | Units | Description                                                                                       |
-| ---------------- | ----------------- | ----- | ------------------------------------------------------------------------------------------------- |
-| `is_good`        | `VectorOfVectors` | —     | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data. Variable-length per event. |
-| `aoe`            | `VectorOfVectors` | —     | A/E classifier values forwarded from the `hit` tier. Variable-length per event.                   |
-| `has_aoe`        | `VectorOfVectors` | —     | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed). Variable-length per event. |
-| `is_single_site` | `VectorOfVectors` | —     | Boolean PSD flag forwarded from the `hit` tier. Variable-length per event.                        |
+These two subtables are optional and gated by the `hit`-tier settings
+({ref}`hit-tier-settings`): `geds/psd` is present when `simulate_psd: True` and
+`geds/psd_psl` when `simulate_psd_with_psl: True`. Each carries the same-named
+fields forwarded from the corresponding `hit`-tier subtable (`psd` is
+single-template, `psd_psl` is PSL based; see {ref}`hpge-psl-overview`), so a
+field's meaning depends on which subtable it is in. All fields are
+`VectorOfVectors` (variable-length per event).
 
-The table `geds/psd` contains the single template based PSD simulation, while
-`psd_psl` contains the pulse-shape-library based simulation.
+| Field             | Units | Subtable         | Description                                                                      |
+| ----------------- | ----- | ---------------- | -------------------------------------------------------------------------------- |
+| `is_good`         |       | `psd`            | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data.           |
+| `aoe`             |       | `psd`, `psd_psl` | A/E classifier values forwarded from the `hit` tier.                             |
+| `aoe_corr`        |       | `psd`, `psd_psl` | Energy-corrected A/E values forwarded from the `hit` tier.                       |
+| `drift_time_amax` | ns    | `psd`, `psd_psl` | Drift time at the maximum-current position, forwarded from the `hit` tier.       |
+| `has_aoe`         |       | `psd`, `psd_psl` | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed).           |
+| `is_single_site`  |       | `psd`, `psd_psl` | Boolean single-site PSD flag forwarded from the `hit` tier.                      |
+| `is_bb_like`      |       | `psd_psl`        | Boolean flag for $0\nu\beta\beta$-like single-site events, forwarded from `hit`. |
+| `is_high_aoe`     |       | `psd_psl`        | Boolean high-A/E flag forwarded from the `hit` tier.                             |
 
 ### `spms/` — SiPM (LAr scintillation) array
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -24,26 +24,25 @@ Document the remage simulation step.
 The `par` step extracts per-detector observable models for each data taking run
 before the `hit` tier is built. The results are written to per-run YAML files on
 disk so that `build_tier_hit` does not need to load the (potentially large) data
-production parameter database at processing time.
+production parameter database at processing time. The on-disk locations of the
+files produced by this step are listed in {ref}`par-output-files`.
 
-(hpge-eresmod-extraction)=
+(par-collection-model)=
 
-### HPGe energy resolution (`extract_hpge_observables_models`)
+### Parameter source resolution
 
-The `extract_hpge_observables_models` rule produces a per-detector YAML file
-mapping each HPGe detector to its energy resolution model. It is a _collection_
-step: it gathers what it can from the available sources and writes the result to
-disk. Completeness is validated downstream in `build_tier_hit` (see
-{ref}`build-tier-hit-hpge`).
-
-The exact sources used depend on what is configured:
+Several `par`-tier rules build their per-detector output by combining two
+possible sources: the LEGEND-200 data production (`l200data`) and an optional
+HPGe-specific metadata override directory (a validity-based directory, one per
+observable). Each such rule is a _collection_ step, and which source is used
+depends on what is configured:
 
 1. **`l200data` only, no HPGe-specific overrides** — everything available in
    `l200data` is collected, independent of detector status.
 
-2. **`l200data` + HPGe-specific overrides in {ref}`eresmod-metadata-dir`, no
-   `default` key** — everything available in `l200data` is collected as in case
-   1; the explicitly listed detectors are then overridden.
+2. **`l200data` + HPGe-specific overrides without a `default` key** — everything
+   available in `l200data` is collected as in case 1; the explicitly listed
+   detectors are then overridden.
 
 3. **`l200data` + HPGe-specific overrides with a `default` key** — the metadata
    takes over entirely: every HPGe detector in the channel map is expanded from
@@ -53,33 +52,46 @@ The exact sources used depend on what is configured:
 4. **HPGe-specific overrides with a `default` key, no `l200data`** — same as
    case 3. `l200data` is not required.
 
+Completeness is validated downstream in `build_tier_hit` (see
+{ref}`build-tier-hit-hpge`). Cases 3 and 4 cover every detector, so the
+`build_tier_hit` fallback defaults are never triggered.
+
+(hpge-eresmod-extraction)=
+
+### HPGe energy resolution
+
+The `extract_hpge_observables_models` rule produces a per-detector YAML file
+mapping each HPGe detector to its energy resolution model, following the
+{ref}`source-resolution logic <par-collection-model>`. Its HPGe-specific
+metadata override directory is described in {ref}`eresmod-metadata-dir`.
+
 (hpge-aoeresmod-extraction)=
 
-### HPGe A/E resolution (`extract_hpge_observables_models`)
+### HPGe A/E resolution
 
 The same rule produces a per-detector YAML file for the A/E resolution model,
-following the same four-case logic as {ref}`hpge-eresmod-extraction`. The
+following the {ref}`source-resolution logic <par-collection-model>`. The
 metadata directory is described in {ref}`aoeresmod-metadata-dir`.
 
 (hpge-psdcuts-extraction)=
 
-### HPGe PSD cuts (`extract_hpge_observables_models`)
+### HPGe PSD cuts
 
 The same rule produces a per-detector YAML file for the PSD cut values,
-following the same four-case logic as {ref}`hpge-eresmod-extraction`. The
+following the {ref}`source-resolution logic <par-collection-model>`. The
 metadata directory is described in {ref}`psdcuts-metadata-dir`.
 
 (hpge-currmod-extraction)=
 
-### HPGe current pulse model (`extract_current_pulse_model`)
+### HPGe current-pulse model
 
 The `extract_current_pulse_model` rule produces one YAML file per
-`(runid, hpge_detector)` pair holding the current pulse model parameters for
-that detector in that run. Unlike the eresmod/aoeresmod/psdcuts extractions
-(which are per-run), this step has per-detector granularity. It follows the same
-four-case logic as {ref}`hpge-eresmod-extraction`, but cases 3 and 4 bypass
-waveform fitting entirely and do not need `l200data`. The metadata directory is
-described in {ref}`currmod-metadata-dir`.
+`(runid, hpge_detector)` pair holding the current-pulse model parameters for
+that detector in that run. It follows the
+{ref}`source-resolution logic <par-collection-model>`, with two differences: it
+has per-detector rather than per-run granularity, and cases 3 and 4 bypass the
+waveform fitting entirely (so they do not need `l200data`). The metadata
+directory is described in {ref}`currmod-metadata-dir`.
 
 ### Manual HPGe skip-list
 
@@ -89,6 +101,204 @@ required), individual detectors can be removed from the modelable HPGe list for
 a given set of runs via the {ref}`skip-metadata-dir` directory. A WARNING is
 emitted for each skipped detector, including the reason string and the run
 identifier.
+
+(hpge-psl-overview)=
+
+### Pulse-shape library (PSL) chain
+
+:::{note}
+
+This chain is built only when `simulate_psd_with_psl: True` is set in
+{ref}`hit-tier-settings` (default `False`). With the flag disabled the realistic
+PSL is not requested by `build_tier_hit` and none of the `par`-tier rules in
+this chain run.
+
+:::
+
+The PSL chain produces the realistic per-detector waveform library consumed by
+`build_tier_hit` for PSL-based pulse-shape discrimination. It proceeds through
+four stages, each a separate `par`-tier rule:
+
+1. Compute the ideal pulse-shape libraries with
+   [`SolidStateDetectors.jl`](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/)
+   (simulation-derived, no real data needed).
+2. Build data superpulses (average charge and current waveforms per drift-time
+   slice) from LEGEND-200 data.
+3. Fit the electronics transfer function (Gaussian digitizer bandwidth $\sigma$
+   and preamplifier decay $\tau$) by comparing processed ideal PSL waveforms to
+   the data superpulses.
+4. Convolve the ideal PSL with the fitted transfer function to produce the
+   realistic PSL, which also carries the per-pixel drift-time map used for
+   PSL-based PSD.
+
+The realistic PSL is then consumed by `build_tier_hit` as the
+pulse-shape-library input to reboost's HPGe PSD routines
+({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
+
+(hpge-dtmap-extraction)=
+
+### HPGe drift-time maps
+
+:::{note}
+
+The standalone drift-time map feeds the **single-template** PSD path
+(`simulate_psd`); the PSL path derives its per-pixel drift times from the
+realistic PSL instead. It is documented here because it is, like the ideal PSL,
+an `SolidStateDetectors.jl` simulation sharing the same
+{ref}`ssd-settings-meta`.
+
+:::
+
+`build_hpge_drift_time_map` runs a Julia script backed by
+`SolidStateDetectors.jl` for each `(hpge_detector, hpge_voltage)` pair. The
+script reads crystal geometry from `legend-metadata` (diode and crystal YAML
+files), solves the electric field, and records the drift time from each $(r, z)$
+grid point to the readout contact. The output is one LH5 file per
+`(detector, voltage)` pair, in the $(r, z)$-field format consumed by reboost
+({func}`reboost.hpge.psd.drift_time`). See the
+[`build_hpge_drift_time_map`](../api/snakemake_rules.md) rule reference for the
+output fields.
+
+`merge_hpge_drift_time_maps` copies the top-level LH5 objects from all
+per-detector files that apply to a given `runid` into a single merged LH5 file
+keyed by detector name. If no drift-time maps exist for a run, an empty HDF5
+file is created.
+
+`plot_hpge_drift_time_maps` produces a validation PDF for each
+`(detector, voltage)` pair from the single-detector output.
+
+The `SolidStateDetectors.jl` (SSD) simulation parameters (grid size, refinement
+thresholds, padding) are controlled by {ref}`ssd-settings-meta`.
+
+(hpge-ideal-psl-extraction)=
+
+### Ideal HPGe pulse-shape library
+
+`build_hpge_pulse_shape_library` runs a Julia script backed by
+`SolidStateDetectors.jl` for each `(hpge_detector, hpge_voltage)` pair, using
+the same crystal geometry as the drift-time map. It simulates the full
+charge-collection transient at every $(r, z, \text{angle})$ grid point. These
+are un-convolved charge waveforms; the electronics transfer function is applied
+in the realistic PSL step. See the
+[`build_hpge_pulse_shape_library`](../api/snakemake_rules.md) rule reference for
+the output fields.
+
+The SSD simulation parameters are shared with the drift-time map and controlled
+by {ref}`ssd-settings-meta`.
+
+(hpge-superpulses-extraction)=
+
+### Data superpulses
+
+`build_superpulses_from_data` builds average ("super") charge and current
+waveforms per drift-time slice from LEGEND-200 data for each HPGe detector.
+These represent the measured pulse shape at known drift times and are used to
+constrain the electronics-response model fit.
+
+**Input data.** For each configured `runid`, the data source is resolved as
+follows:
+
+- **Physics runs (`phy`)**: the reference calibration run is looked up and its
+  `raw`, `evt` (or `pet`), and channel-map data are used in place of the
+  physics-run data. If several physics runs resolve to the same reference
+  calibration run, the input files are de-duplicated so that no event is counted
+  twice.
+- **Non-physics runs** (calibration `cal`, SSC `ssc`, ...): the run's own `raw`
+  and `evt` tier files are used directly.
+
+In both cases the script reads `raw`-tier LH5 waveforms and applies the
+production DSP configuration.
+
+**Analysis.** Events in a fixed energy range are read from the configured event
+tier (`evt_tier_name`, e.g. `evt` or `pet`), passed through standard quality
+cuts, and binned by drift time. The drift time is
+$t_\text{drift} = t_\text{end} - t_0$, where $t_\text{end}$ and $t_0$ are the
+`end_time_field` and `t0_field` configured in {ref}`superpulses-settings-meta`
+and events with an undefined $t_0$ are discarded. Within each drift-time slice
+(field `drift_time_slices`) the surviving waveforms are averaged into a
+preliminary superpulse, a self-similarity $\chi^2$ cut (`chi2_threshold`)
+removes outliers, and the final superpulse is the mean of the remaining
+waveforms. Slices with fewer than `min_number_wfs` surviving waveforms are
+skipped.
+
+See the [`build_superpulses_from_data`](../api/snakemake_rules.md) rule
+reference for the per-slice fields. The `build_per_runid` flag (see
+{ref}`superpulses-settings-meta`) selects whether superpulses are accumulated
+per detector (default) or split per run; the consumer rule
+`extract_electronics_model_pars` adjusts its input accordingly.
+
+(hpge-elecmod-extraction)=
+
+### HPGe electronics-response model
+
+`extract_electronics_model_pars` fits the electronics transfer function for each
+`(runid, hpge_detector)` pair. The response kernel is the convolution of a
+Gaussian (digitizer bandwidth $\sigma$) and a causal exponential decay
+(preamplifier response, decay constant $\tau$),
+
+$$
+h = h_\text{digi} * h_\text{preamp}, \qquad
+h_\text{digi}(t) \propto \exp\!\left[-\frac{1}{2}\left(\frac{t}{\sigma}\right)^2\right], \qquad
+h_\text{preamp}(t) \propto e^{-t/\tau}\,\Theta(t),
+$$
+
+with $\sigma$ and $\tau$ in ns, $\Theta$ the Heaviside step, and each factor
+normalised to unit sum. Convolving an ideal PSL charge waveform with $h$ and
+differentiating yields a simulated current waveform. The fit minimises the mean
+data-amplitude-weighted RMS between these simulated waveforms and the measured
+data superpulses across drift-time slices, using Minuit (MIGRAD).
+
+For each candidate `(sigma, tau)`, ideal PSL waveforms whose drift time falls in
+a matching slice are convolved with the electronics kernel, differentiated, and
+moving-window-averaged to produce simulated current waveforms. Only slices whose
+drift-time centre falls within `dt_range_tuning` are used (defaults to 600-3000
+ns), and at most `max_num_superpulses` slices (default `5`, sorted by decreasing
+drift time) are selected.
+
+If a `default` key is present in the `elecmod` validity metadata (see
+{ref}`elecmod-metadata-dir`), the fitting step is bypassed entirely and the
+metadata values are written directly to the output YAML. This is the analogue of
+cases 3 and 4 of the {ref}`source-resolution logic <par-collection-model>`; the
+difference is that the non-`default` path here is a data-driven fit rather than
+a collection from `l200data`.
+
+The fitted parameters (`sigma`, `tau`, and fit diagnostics) are written to a
+temporary per-detector YAML; see the
+[`extract_electronics_model_pars`](../api/snakemake_rules.md) rule reference for
+the full list of keys.
+
+`merge_electronics_model_pars` collects the per-detector YAML files and writes a
+single YAML keyed by detector name for each `runid`. This merged file is the
+direct input for the realistic PSL convolution step; `sigma` and `tau` are the
+only keys required by the consumer.
+
+(hpge-realistic-psl-extraction)=
+
+### Realistic HPGe pulse-shape library
+
+`convolve_hpge_ideal_pulse_shape_lib` selects the ideal PSL for the detector's
+operational voltage in that run, reads the fitted `sigma` and `tau` from the
+merged electronics model file, and applies the following processing chain:
+
+1. Convolve the ideal charge waveforms with the electronics response kernel
+   (Gaussian bandwidth combined with preamplifier decay).
+2. Differentiate to obtain current waveforms, then apply a three-stage
+   moving-window average.
+3. Align waveforms by shifting the current peak to a fixed sample index.
+4. Compute the drift time for each (r, z) pixel from the current peak position.
+5. Normalise the current amplitudes by the mode of the A/E distribution.
+
+The output for a single `(runid, detector)` pair is in the pulse-shape-library
+format consumed by reboost
+({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`). See the
+[`convolve_hpge_ideal_pulse_shape_lib`](../api/snakemake_rules.md) rule
+reference for the output fields. Validation plots (R and Z waveform scans and an
+A/E R/Z heatmap) are produced alongside.
+
+`merge_hpge_realistic_psls` copies the per-detector realistic PSL objects into a
+single merged LH5 file keyed by detector name for each `runid`. This merged file
+is the final output consumed by `build_tier_hit` when `simulate_psd_with_psl` is
+enabled.
 
 ## `opt` — optical hit building
 
@@ -102,11 +312,24 @@ Document the optical hit building step.
 
 (build-tier-hit-hpge)=
 
-### HPGe observable validation (`build_tier_hit`)
+### HPGe observable validation
+
+:::{note}
+
+HPGe PSD simulation runs in two independent, optional modes selected in
+{ref}`hit-tier-settings`: set `simulate_psd: True` (default) for the
+single-template A/E estimate (`geds/psd` output) and
+`simulate_psd_with_psl: True` for the pulse-shape-library based estimate
+(`geds/psd_psl` output, see {ref}`hpge-psl-overview`). Either, both, or neither
+can be enabled; with both `False` no PSD columns are written.
+
+:::
 
 `build_tier_hit` reads the per-detector YAML files produced in the `par` step
-and validates that every simulated detector has the parameters it needs. The
-hard-error vs. fallback policy differs slightly per observable:
+and validates that every simulated detector has the parameters it needs.
+
+The hard-error vs. fallback policy below applies whenever PSD is simulated and
+differs slightly per observable:
 
 | Observable        | Hard error                                                                                             | Fallback (+ warning) | Fallback key        |
 | ----------------- | ------------------------------------------------------------------------------------------------------ | -------------------- | ------------------- |
@@ -116,19 +339,19 @@ hard-error vs. fallback policy differs slightly per observable:
 
 The fallback keys are read from {ref}`hit-tier-settings`. They are never
 triggered when a `default` key is present in the corresponding metadata (cases 3
-and 4 of the extraction steps above), because all detectors are already covered
-in that case.
+and 4 of the {ref}`source-resolution logic <par-collection-model>`), because all
+detectors are already covered in that case.
 
 :::{note}
 
 An ON detector with `psd_usability = "missing"` explicitly signals that PSD data
 are unavailable for that detector (e.g. a known hardware issue). Similarly, a
-detector missing a drift-time map or current pulse model cannot have its PSD
+detector missing a drift-time map or current-pulse model cannot have its PSD
 response simulated at all — the PSD output columns are filled with NaN in that
 case. Both situations fall back to the default A/E resolution and PSD cuts
 rather than raising a hard error. A detector listed in the
 {ref}`skip-metadata-dir` directory is treated identically: it has no drift-time
-map or current pulse model and therefore follows the same NaN PSD output /
+map or current-pulse model and therefore follows the same NaN PSD output /
 fallback A/E resolution and PSD cuts path, with no hard error.
 
 :::

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -73,11 +73,11 @@ Here's a basic description of its fields:
     - `lar`: the liquid argon optical map file.
   - `pars` (output): root folder for all generated parameter files (e.g. YAML
     files storing parameters extracted from the LEGEND-200 data, geometry files,
-    drift time maps).
+    drift-time maps).
   - `macros` (output): generated _remage_ macro files
   - `geom` (optional output): generated simulation geometry files. Defaults to
     `{paths.pars}/geom` if not set.
-  - `dtmaps` (optional output): generated HPGe drift time maps. Defaults to
+  - `dtmaps` (optional output): generated HPGe drift-time maps. Defaults to
     `{paths.pars}/hpge/dtmaps` if not set.
   - `tier` (dict, output): generated outputs for each tier, keyed by tier name
     (e.g. `tier.stp`, `tier.hit`, ...). Validation plots for each tier are

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -123,8 +123,8 @@ def smk_load_hpge_cache() -> dict:
 checkpoint cache_modelable_hpges:
     """Cache the list of HPGe detectors valid for modeling.
 
-    Computing the list of HPGe detectors that are suitable for drift time map
-    and current pulse model generation requires querying `legend-metadata` for
+    Computing the list of HPGe detectors that are suitable for drift-time map
+    and current-pulse model generation requires querying `legend-metadata` for
     every run in the Simflow. This can be slow, so the result is cached on disk
     as a YAML file mapping ``runid -> {hpge: voltage}``. Downstream rules that
     need this information (e.g. `merge_hpge_drift_time_maps`) depend on this

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -97,16 +97,31 @@ def smk_hpge_psd_simulation_inputs(wildcards):
 
 
 rule build_hpge_drift_time_map:
-    """Produce an HPGe drift time map.
+    """Produce an HPGe drift-time map.
 
-    Run a Julia script based on a pulse shape simulation performed with the
-    `SolidStateDetectors.jl` package, using crystal geometry information from
-    `legend-metadata`.
+    Run a Julia script based on a pulse-shape simulation performed with the
+    [`SolidStateDetectors.jl`](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/)
+    package, using crystal geometry information from `legend-metadata`. The drift time recorded at each grid point is the time at
+    which the simulated hole charge-collection signal reaches its maximum current
+    (the argmax of the charge-signal derivative); one map is produced per
+    crystal-axis angle.
+
+    The output is one LH5 file per `(detector, voltage)` pair with a single
+    top-level group named after the detector, holding the gridded map in the
+    `(r, z)`-field format read back by
+    {func}`reboost.hpge.utils.get_hpge_rz_field` and consumed by
+    {func}`reboost.hpge.psd.drift_time` when the `hit` tier is built:
+
+    | Field                    | Type         | Units | Description                                                                                                       |
+    | ------------------------ | ------------ | ----- | --------------------------------------------------------------------------------------------------------------- |
+    | `r`                      | `Array`      | m     | Radial coordinates of the rectangular `(r, z)` grid.                                                             |
+    | `z`                      | `Array`      | m     | Axial coordinates of the grid. The origin `(r, z) = (0, 0)` is the centre of the p+ contact.                     |
+    | `drift_time_<angle>_deg` | `Array` (2D) | ns    | Drift time over the `(r, z)` grid at crystal-axis azimuth `<angle>`. Pixels outside the detector profile hold NaN. |
 
     Uses wildcards `hpge_detector` and `hpge_voltage`.
     """
     message:
-        "Generating drift time map for HPGe detector {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
+        "Generating drift-time map for HPGe detector {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
     input:
         unpack(smk_hpge_psd_simulation_inputs),
     params:
@@ -130,15 +145,15 @@ rule build_hpge_drift_time_map:
 
 
 rule merge_hpge_drift_time_maps:
-    """Merge HPGe drift time maps in a single file.
+    """Merge HPGe drift-time maps in a single file.
 
-    Copy the top-level LH5 objects from each individual detector drift time map
+    Copy the top-level LH5 objects from each individual detector drift-time map
     file into a single merged file using `h5copy`.
 
     Uses wildcard `runid`.
     """
     message:
-        "Merging HPGe drift time map files for {wildcards.runid}"
+        "Merging HPGe drift-time map files for {wildcards.runid}"
     input:
         lambda wc: aggregate.gen_list_of_dtmaps(
             config, wc.runid, cache=smk_load_hpge_cache()
@@ -173,15 +188,15 @@ rule merge_hpge_drift_time_maps:
 
 
 rule plot_hpge_drift_time_maps:
-    """Produce a validation plot of an HPGe drift time map.
+    """Produce a validation plot of an HPGe drift-time map.
 
-    Generates diagnostic plots of the computed drift time map for a single
+    Generates diagnostic plots of the computed drift-time map for a single
     detector at the specified operational voltage.
 
     Uses wildcards `hpge_detector` and `hpge_voltage`.
     """
     message:
-        "Plotting drift time map for HPGe {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
+        "Plotting drift-time map for HPGe {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
     input:
         rules.build_hpge_drift_time_map.output,
     output:
@@ -191,16 +206,31 @@ rule plot_hpge_drift_time_maps:
 
 
 rule build_hpge_pulse_shape_library:
-    """Produce an HPGe pulse shape library.
+    """Produce an (ideal) HPGe pulse-shape library.
 
-    Run a Julia script based on a pulse shape simulation performed with the
-    `SolidStateDetectors.jl` package, using crystal geometry information from
-    `legend-metadata`.
+    Run a Julia script based on a pulse-shape simulation performed with the
+    [`SolidStateDetectors.jl`](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/)
+    package, using crystal geometry information from `legend-metadata`. It simulates the full charge-collection transient at every
+    `(r, z, angle)` grid point. These are un-convolved (ideal) charge waveforms;
+    the electronics transfer function is applied later, in
+    `convolve_hpge_ideal_pulse_shape_lib`.
+
+    The output is one LH5 file per `(detector, voltage)` pair with a single
+    top-level group named after the detector:
+
+    | Field                  | Type         | Units | Description                                                                  |
+    | ---------------------- | ------------ | ----- | --------------------------------------------------------------------------- |
+    | `r`                    | `Array`      | m     | Radial coordinates of the simulation grid.                                  |
+    | `z`                    | `Array`      | m     | Axial coordinates of the simulation grid.                                   |
+    | `dt`                   | `Scalar`     | ns    | Time step between waveform samples.                                         |
+    | `waveform_<angle>_deg` | `Array` (3D) |       | Ideal charge waveforms at azimuth `<angle>`, shape `(n_z, n_r, n_samples)`. |
+
+    The sample times of a waveform are `t_i = i * dt` (no `t0` offset is stored).
 
     Uses wildcards `hpge_detector` and `hpge_voltage`.
     """
     message:
-        "Generating pulse shape library for HPGe detector {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
+        "Generating pulse-shape library for HPGe detector {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
     input:
         unpack(smk_hpge_psd_simulation_inputs),
     params:
@@ -224,17 +254,34 @@ rule build_hpge_pulse_shape_library:
 
 
 rule convolve_hpge_ideal_pulse_shape_lib:
-    """Convolve ideal HPGe pulse shape libraries with electronics response.
+    """Convolve ideal HPGe pulse-shape libraries with electronics response.
 
-    Produces one realistic pulse shape library per detector and run by selecting
+    Produce one realistic pulse-shape library per detector and run by selecting
     the ideal library for the detector operational voltage in that run and
-    convolving it with electronics parameters from a merged electronics-model
-    YAML file.
+    convolving it with the electronics parameters (`sigma`, `tau`) from a merged
+    electronics-model YAML file, then differentiating, moving-window-averaging,
+    aligning, and normalising to obtain current waveforms.
+
+    The output is one LH5 file per `(runid, detector)` pair with a top-level
+    group named after the detector, in the pulse-shape-library format read back
+    by {func}`reboost.hpge.utils.get_hpge_pulse_shape_library` when the `hit`
+    tier is built:
+
+    | Field                    | Type         | Units | Description                                                                                            |
+    | ------------------------ | ------------ | ----- | ----------------------------------------------------------------------------------------------------- |
+    | `r`                      | `Array`      | mm    | Radial coordinates of the simulation grid (converted from metres).                                    |
+    | `z`                      | `Array`      | mm    | Axial coordinates of the simulation grid (converted from metres).                                     |
+    | `dt`                     | `Scalar`     | ns    | Sampling time step of the realistic current waveforms.                                                |
+    | `t0`                     | `Scalar`     | ns    | Global time offset: time of the alignment index relative to the current peak.                         |
+    | `waveform_<angle>_deg`   | `Array` (3D) |       | Processed, normalised current waveforms at azimuth `<angle>`, shape `(n_r, n_z, n_samples)`; NaN outside the detector. |
+    | `drift_time_<angle>_deg` | `Array` (2D) | ns    | Drift time per `(r, z)` pixel at azimuth `<angle>`, shape `(n_r, n_z)`; NaN outside the detector.       |
+
+    The current-waveform sample times are `t_i = t0 + i * dt`.
 
     Uses wildcards `runid` and `hpge_detector`.
     """
     message:
-        "Convolving ideal pulse shape library for detector {wildcards.hpge_detector} in {wildcards.runid}"
+        "Convolving ideal pulse-shape library for detector {wildcards.hpge_detector} in {wildcards.runid}"
     input:
         ideal_psl=lambda wc: patterns.output_ideal_psl_filename(
             config,
@@ -258,7 +305,7 @@ rule convolve_hpge_ideal_pulse_shape_lib:
 rule merge_hpge_realistic_psls:
     """Merge HPGe realistic PSL in a single file.
 
-    Copy the top-level LH5 objects from each individual detector drift time map
+    Copy the top-level LH5 objects from each individual detector realistic-PSL
     file into a single merged file using `h5copy`.
 
     Uses wildcard `runid`.
@@ -323,7 +370,7 @@ def smk_extract_current_pulse_model_inputs(wildcards):
 
 
 rule extract_current_pulse_model:
-    """Extract the HPGe current signal model.
+    """Extract the HPGe current-pulse model.
 
     Perform a fit of current signals recorded in LEGEND-200 and stores the
     best-fit model parameters in a YAML file.
@@ -357,7 +404,7 @@ rule extract_current_pulse_model:
 
 
 rule merge_current_pulse_model_pars:
-    """Merge the HPGe current signal model parameters in a single file per `runid`.
+    """Merge the HPGe current-pulse model parameters in a single file per `runid`.
 
     Collect the individual best-fit parameter files (one per detector) and
     write them into a single YAML file keyed by detector name.
@@ -396,9 +443,32 @@ _build_per_runid = get_par_settings(config, "superpulses").get("build_per_runid"
 
 
 rule build_superpulses_from_data:
-    """Build HPGe superpulses by accumulating all runs in the configured runlists.
+    """Build HPGe data superpulses (average waveforms per drift-time slice).
 
-    Uses wildcard `hpge_detector` and `runid` if per run superpulses are requested.
+    Accumulate waveforms from LEGEND-200 data per detector (across all configured
+    runs, or per run when `build_per_runid` is set) and average them within
+    drift-time slices to form "super" pulses, after a self-similarity chi2 cut.
+
+    The output LH5 file contains one group per drift-time slice, named
+    `{detector}/dt_{lo}_{hi}_ns/`, each holding:
+
+    | Field                  | Type     | Units             | Description                                                     |
+    | ---------------------- | -------- | ----------------- | --------------------------------------------------------------- |
+    | `charge_wf`            | `Array`  | ADC/cuspEmax      | Average normalised charge waveform.                             |
+    | `current_wf`           | `Array`  | (ADC/cuspEmax)/ns | Average current waveform.                                       |
+    | `charge_time_axis`     | `Array`  | ns                | Time axis for the charge waveform, aligned to `tp_aoe_max = 0`. |
+    | `current_time_axis`    | `Array`  | ns                | Time axis for the current waveform.                             |
+    | `drift_time_center`    | `Scalar` | ns                | Centre of the drift-time bin.                                   |
+    | `drift_time_lo`        | `Scalar` | ns                | Lower bound of the drift-time bin.                              |
+    | `drift_time_hi`        | `Scalar` | ns                | Upper bound of the drift-time bin.                              |
+    | `energy_lo`            | `Scalar` | keV               | Lower bound of the energy selection.                            |
+    | `energy_hi`            | `Scalar` | keV               | Upper bound of the energy selection.                            |
+    | `detector`             | `Scalar` |                   | Detector name string.                                           |
+    | `n_events_preliminary` | `Scalar` |                   | Waveforms before the chi2 cut.                                  |
+    | `n_events_final`       | `Scalar` |                   | Waveforms after the chi2 cut.                                   |
+
+    Uses wildcard `hpge_detector`, and `runid` if per-run superpulses are
+    requested (`build_per_runid`).
     """
     message:
         "Building data superpulses for detector {wildcards.hpge_detector}"
@@ -425,8 +495,29 @@ rule build_superpulses_from_data:
 
 
 rule extract_electronics_model_pars:
-    """Extract the HPGe electronics signal model.
+    """Extract the HPGe electronics-response model.
 
+    Fit the electronics transfer function (a Gaussian digitizer bandwidth `sigma`
+    convolved with a causal exponential preamplifier decay `tau`) by comparing
+    processed ideal PSL waveforms to the measured data superpulses. When a
+    `default` key is present in the `elecmod` validity metadata the fit is
+    bypassed and the metadata values are written directly.
+
+    The (temporary, per-detector) output YAML, consumed by
+    `merge_electronics_model_pars`, contains:
+
+    | Key        | Type             | Description                                                                                                  |
+    | ---------- | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+    | `detector` | str              | Detector name.                                                                                              |
+    | `sigma`    | float            | Fitted Gaussian sigma of the digitizer bandwidth, in ns.                                                    |
+    | `tau`      | float            | Fitted preamplifier decay constant, in ns.                                                                  |
+    | `rms`      | float            | Best-fit mean RMS across slices.                                                                            |
+    | `angle`    | str              | Crystal-axis angle tag used for PSL waveform selection (e.g. `"000"`).                                       |
+    | `aoe_data` | float (optional) | Max current amplitude of the data superpulse in the highest drift-time slice; present with diagnostic plots. |
+    | `aoe_mc`   | float (optional) | Max current amplitude of the simulation superpulse in the highest drift-time slice; present with plots.      |
+
+    Only `sigma` and `tau` are required by the consumer
+    (`convolve_hpge_ideal_pulse_shape_lib`).
 
     Uses wildcards `runid` and `hpge_detector`.
     """
@@ -459,7 +550,7 @@ rule extract_electronics_model_pars:
 
 
 rule merge_electronics_model_pars:
-    """Merge the HPGe electronics signal model parameters in a single file per `runid`.
+    """Merge the HPGe electronics-response model parameters in a single file per `runid`.
 
     Collect the individual best-fit parameter files (one per detector) and
     write them into a single YAML file keyed by detector name.

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -91,7 +91,7 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str):
     if tier == "stp":
         return [patterns.plot_tier_stp_vertices_filename(config, simid=simid)]
     if tier == "par":
-        # HPGe drift time map plots, a byproduct of the par step; only produced
+        # HPGe drift-time map plots, a byproduct of the par step; only produced
         # when PSD is simulated in the hit tier
         if not get_tier_settings(config, "hit").get("simulate_psd", True):
             return []
@@ -168,7 +168,7 @@ def gen_list_of_hpges_valid_for_modeling(
 
     It generates the list of deployed detectors in `runid` via the LEGEND
     channelmap, then checks if in the crystal metadata there's all the
-    information required to generate a drift time map etc.
+    information required to generate a drift-time map etc.
 
     Detectors listed in the validity-based metadata directory
     ``simprod/config/pars/{experiment}/geds/skip/`` for the given `runid` are
@@ -212,7 +212,7 @@ def gen_list_of_hpges_valid_for_modeling(
                 hpges.append(hpge.name)
 
     if len(hpges) == 0:
-        msg = f"the list of HPGes valid for drift time map generation in {runid} is empty!"
+        msg = f"the list of HPGes valid for drift-time map generation in {runid} is empty!"
         log.warning(msg)
 
     return sorted(hpges)
@@ -343,7 +343,7 @@ def get_hpge_voltage(config: SimflowConfig, hpge: str, runid: str) -> int:
 def gen_list_of_dtmaps(
     config: SimflowConfig, runid: str, cache: dict[str, dict[str, int]] | None = None
 ) -> list[Path]:
-    """Generate the list of HPGe drift time map files for a `runid`."""
+    """Generate the list of HPGe drift-time map files for a `runid`."""
     if cache is None:
         hpges = gen_list_of_hpges_valid_for_modeling(config, runid)
         return [
@@ -369,7 +369,7 @@ def gen_list_of_dtmaps(
 def gen_list_of_merged_dtmaps(
     config: SimflowConfig, simid: str, has_psd=True
 ) -> list[Path]:
-    r"""Generate the list of (merged) HPGe drift time map files for all requested `runid`\ s."""
+    r"""Generate the list of (merged) HPGe drift-time map files for all requested `runid`\ s."""
     if not has_psd:
         return []
 
@@ -382,7 +382,7 @@ def gen_list_of_merged_dtmaps(
 def gen_list_of_ideal_psls(
     config: SimflowConfig, runid: str, cache: dict[str, dict[str, int]] | None = None
 ) -> list[Path]:
-    """Generate the list of ideal HPGe pulse shape library files for a `runid`.
+    """Generate the list of ideal HPGe pulse-shape library files for a `runid`.
 
     If ``cache`` is provided, it must be the modelable-HPGe cache mapping
     ``runid -> {hpge: voltage}`` and avoids repeated metadata lookups.
@@ -415,7 +415,7 @@ def gen_list_of_realistic_psls(
     cache: dict[str, dict[str, int]] | None = None,
     has_detailed_psd: bool = True,
 ) -> list[Path]:
-    """Generate the list of realistic HPGe pulse shape library files for a `runid`.
+    """Generate the list of realistic HPGe pulse-shape library files for a `runid`.
 
     If ``cache`` is provided, it must be the modelable-HPGe cache mapping
     ``runid -> {hpge: voltage}`` and avoids repeated metadata lookups.
@@ -455,7 +455,7 @@ def gen_list_of_merged_realistic_psls(
 def gen_list_of_dtmap_plots_outputs(
     config: SimflowConfig, simid: str, cache: dict[str, dict[str, int]] | None = None
 ) -> list[Path]:
-    """Generate the list of HPGe drift time map plot outputs."""
+    """Generate the list of HPGe drift-time map plot outputs."""
     files = set()
     for runid in get_runlist(config, simid):
         if cache is None:
@@ -535,7 +535,7 @@ def gen_list_of_merged_elecmods(config: SimflowConfig, simid: str) -> list[Path]
 def gen_list_of_currmod_plots_outputs(
     config: SimflowConfig, simid: str, cache: dict[str, dict[str, int]] | None = None
 ) -> list[Path]:
-    """Generate the list of HPGe current pulse model plot outputs."""
+    """Generate the list of HPGe current-pulse model plot outputs."""
     files = []
     for runid in get_runlist(config, simid):
         hpges = (

--- a/workflow/src/legendsimflow/hpge_electronics_tuning.py
+++ b/workflow/src/legendsimflow/hpge_electronics_tuning.py
@@ -231,7 +231,7 @@ def get_ideal_wfs_all_slices(
 ) -> dict:
     """Select ideal waveforms per drift-time slice.
 
-    Reads the ideal pulse shape library, flattens the (r, z) grid,
+    Reads the ideal pulse-shape library, flattens the (r, z) grid,
     and selects waveforms whose drift time falls in each data
     superpulse slice.
 

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -245,11 +245,11 @@ def plot_tier_cvt_observables_filename(config: SimflowConfig, **kwargs) -> Path:
     )
 
 
-# drift time maps
+# drift-time maps
 
 
 def output_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the HPGe drift time map file for a detector and voltage."""
+    """The path to the HPGe drift-time map file for a detector and voltage."""
     return _expand(
         config.paths.dtmaps
         / "singles/{hpge_detector}-{hpge_voltage}V-hpge-drift-time-map.lh5",
@@ -258,12 +258,12 @@ def output_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def output_dtmap_merged_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the merged HPGe drift time map file for a `runid`."""
+    """The path to the merged HPGe drift-time map file for a `runid`."""
     return _expand(config.paths.dtmaps / "{runid}-hpge-drift-time-maps.lh5", **kwargs)
 
 
 def log_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The log file path for drift time map generation for a detector and voltage."""
+    """The log file path for drift-time map generation for a detector and voltage."""
     pat = (
         log_dirname(config)
         / "hpge/dtmaps/{hpge_detector}-{hpge_voltage}V-drift-time-map.log"
@@ -272,7 +272,7 @@ def log_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def plot_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the drift time map validation plot for a detector and voltage."""
+    """The path to the drift-time map validation plot for a detector and voltage."""
     pat = (
         config.paths.dtmaps
         / "singles/plots/{hpge_detector}-{hpge_voltage}V-drift-time-map.pdf"
@@ -281,7 +281,7 @@ def plot_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The benchmark file path for drift time map generation for a detector and voltage."""
+    """The benchmark file path for drift-time map generation for a detector and voltage."""
     pat = (
         config.paths.benchmarks
         / "hpge/dtmaps/{hpge_detector}-{hpge_voltage}V-drift-time-map.tsv"
@@ -289,11 +289,11 @@ def benchmark_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(pat, **kwargs)
 
 
-# hpge pulse shape libraries
+# hpge pulse-shape libraries
 
 
 def output_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the ideal HPGe pulse shape library for a detector and voltage."""
+    """The path to the ideal HPGe pulse-shape library for a detector and voltage."""
     pat = (
         config.paths.pars
         / "hpge/psl/ideal/singles/{hpge_detector}-{hpge_voltage}V-hpge-pulse-shape-lib.lh5"
@@ -302,7 +302,7 @@ def output_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def log_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The log file path for ideal pulse shape library generation for a detector and voltage."""
+    """The log file path for ideal pulse-shape library generation for a detector and voltage."""
     pat = (
         log_dirname(config)
         / "hpge/psl/ideal/{hpge_detector}-{hpge_voltage}V-hpge-pulse-shape-lib.log"
@@ -311,7 +311,7 @@ def log_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def benchmark_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The benchmark file path for ideal pulse shape library generation for a detector and voltage."""
+    """The benchmark file path for ideal pulse-shape library generation for a detector and voltage."""
     pat = (
         config.paths.benchmarks
         / "hpge/psl/ideal/{hpge_detector}-{hpge_voltage}V-hpge-pulse-shape-lib.tsv"
@@ -320,7 +320,7 @@ def benchmark_ideal_psl_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def output_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the realistic HPGe pulse shape library for a detector and run."""
+    """The path to the realistic HPGe pulse-shape library for a detector and run."""
     pat = (
         config.paths.pars
         / "hpge/psl/realistic/singles/{runid}-{hpge_detector}-hpge-pulse-shape-lib.lh5"
@@ -329,7 +329,7 @@ def output_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def plot_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the realistic HPGe pulse shape library plots for a detector and run."""
+    """The path to the realistic HPGe pulse-shape library plots for a detector and run."""
     pat = (
         config.paths.pars
         / "hpge/psl/realistic/singles/plots/{runid}-{hpge_detector}-hpge-pulse-shape-lib.pdf"
@@ -346,7 +346,7 @@ def output_realistic_psl_merged_filename(config: SimflowConfig, **kwargs) -> Pat
 
 
 def log_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The log file path for realistic pulse shape library generation for a detector and run."""
+    """The log file path for realistic pulse-shape library generation for a detector and run."""
     pat = (
         log_dirname(config)
         / "hpge/psl/realistic/{runid}-{hpge_detector}-hpge-pulse-shape-lib.log"
@@ -355,7 +355,7 @@ def log_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def benchmark_realistic_psl_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The benchmark file path for realistic pulse shape library generation for a detector and run."""
+    """The benchmark file path for realistic pulse-shape library generation for a detector and run."""
     pat = (
         config.paths.benchmarks
         / "hpge/psl/realistic/{runid}-{hpge_detector}-hpge-pulse-shape-lib.tsv"
@@ -373,7 +373,7 @@ def input_currmod_evt_idx_file(config: SimflowConfig, **kwargs) -> Path:
 
 
 def output_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the per-detector HPGe current pulse model parameter file."""
+    """The path to the per-detector HPGe current-pulse model parameter file."""
     return _expand(
         config.paths.pars / "hpge/currmod/{runid}-{hpge_detector}-model.yaml",
         **kwargs,
@@ -381,7 +381,7 @@ def output_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def output_currmod_merged_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the merged HPGe current pulse model parameter file for a `runid`."""
+    """The path to the merged HPGe current-pulse model parameter file for a `runid`."""
     return _expand(
         config.paths.pars / "hpge/currmod/{runid}-model.yaml",
         **kwargs,
@@ -482,13 +482,13 @@ def plot_elecmod_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def log_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The log file path for current pulse model extraction for a detector and `runid`."""
+    """The log file path for current-pulse model extraction for a detector and `runid`."""
     pat = log_dirname(config) / "hpge/currmod/{runid}-{hpge_detector}-model.log"
     return _expand(pat, **kwargs)
 
 
 def plot_currmod_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the current pulse model fit validation plot for a detector and `runid`."""
+    """The path to the current-pulse model fit validation plot for a detector and `runid`."""
     pat = (
         config.paths.pars / "hpge/currmod/plots/{runid}-{hpge_detector}-fit-result.pdf"
     )

--- a/workflow/src/legendsimflow/psl.py
+++ b/workflow/src/legendsimflow/psl.py
@@ -533,7 +533,7 @@ def plot_rz_scan(
     step: int = 1,
     xlim: tuple[float, float] | None = None,
 ) -> tuple[Figure, plt.Axes]:
-    """Plot an R or Z scan of waveforms from a pulse shape library.
+    """Plot an R or Z scan of waveforms from a pulse-shape library.
 
     For a given azimuthal angle, produces one figure scanning over
     radial or axial positions at a fixed index on the other axis.
@@ -542,7 +542,7 @@ def plot_rz_scan(
     Parameters
     ----------
     pulse_shape_lib
-        Mapping containing the pulse shape library (ideal or realistic),
+        Mapping containing the pulse-shape library (ideal or realistic),
         as returned by :func:`make_realistic_pulse_shape_lib` or read from
         the ideal LH5 file.  Must contain ``r``, ``z``, ``dt`` keys and at
         least one ``waveform_<angle>_deg`` key.
@@ -574,7 +574,7 @@ def plot_rz_scan(
 
     wf_key = f"waveform_{str(angle_deg).zfill(3)}_deg"
     if wf_key not in pulse_shape_lib:
-        msg = f"Key '{wf_key}' not found in pulse shape library"
+        msg = f"Key '{wf_key}' not found in pulse-shape library"
         raise KeyError(msg)
 
     wfs = pulse_shape_lib[wf_key].nda
@@ -636,7 +636,7 @@ def plot_aoe_rz_map(
     *,
     hpge_profile: object | None = None,
 ) -> Figure:
-    """Plot the A/E R/Z map(s) of a pulse shape library.
+    """Plot the A/E R/Z map(s) of a pulse-shape library.
 
     For each azimuthal angle present in the library, computes the per-pixel A/E
     as the maximum of the (energy-normalized) current waveform over the time
@@ -648,7 +648,7 @@ def plot_aoe_rz_map(
     Parameters
     ----------
     pulse_shape_lib
-        Mapping containing the pulse shape library, as returned by
+        Mapping containing the pulse-shape library, as returned by
         :func:`make_realistic_pulse_shape_lib`. Must contain ``r``, ``z`` (in
         mm) and at least one ``waveform_<angle>_deg`` key.
     detector_id
@@ -668,7 +668,7 @@ def plot_aoe_rz_map(
 
     angles = sorted(int(k.split("_")[1]) for k in pulse_shape_lib if "waveform" in k)
     if not angles:
-        msg = "no 'waveform_<angle>_deg' keys found in pulse shape library"
+        msg = "no 'waveform_<angle>_deg' keys found in pulse-shape library"
         raise KeyError(msg)
 
     r = pulse_shape_lib["r"].nda  # already in mm

--- a/workflow/src/legendsimflow/reboost.py
+++ b/workflow/src/legendsimflow/reboost.py
@@ -200,7 +200,7 @@ def load_hpge_realistic_psl(
 ):
     """Load HPGe PSL from disk.
 
-    Loads the waveforms as well as drift time maps for
+    Loads the waveforms as well as drift-time maps for
     both coordinates.
 
     Parameters
@@ -219,8 +219,8 @@ def load_hpge_realistic_psl(
 
     Returns
     -------
-    A tuple of two dictionaries: the first contains the drift time maps for different crystal axes, keyed by angle.
-    The second contains the corresponding pulse shape libraries.
+    A tuple of two dictionaries: the first contains the drift-time maps for different crystal axes, keyed by angle.
+    The second contains the corresponding pulse-shape libraries.
     If no valid maps are found, ``None`` is returned for both.
 
     Note
@@ -237,7 +237,7 @@ def load_hpge_realistic_psl(
     )
 
     if len(lh5.ls(psl_file, f"{det_name}/drift_time_*")) >= 2:
-        log.debug("loading drift time maps from %s", psl_file)
+        log.debug("loading drift-time maps from %s", psl_file)
         # both axes needed: hpge_corrected_drift_time() blends them (and small)
         dt_map = {
             angle: reboost.hpge.utils.get_hpge_rz_field(
@@ -275,9 +275,9 @@ def load_hpge_realistic_psl(
 def load_hpge_dtmaps(
     config: SimflowConfig, det_name: str, runid: str
 ) -> dict[str, reboost.hpge.utils.HPGeRZField] | None:
-    """Load HPGe drift time maps from disk.
+    """Load HPGe drift-time maps from disk.
 
-    Automatically finds and loads drift time maps for crystal axes <100> <110>.
+    Automatically finds and loads drift-time maps for crystal axes <100> <110>.
     If no map is found, ``None`` is returned.
 
     Parameters
@@ -300,7 +300,7 @@ def load_hpge_dtmaps(
     )
 
     if len(lh5.ls(hpge_dtmap_file, f"{det_name}/drift_time_*")) >= 2:
-        log.debug("loading drift time maps")
+        log.debug("loading drift-time maps")
         dt_map = {}
         for angle in ("000", "045"):
             dt_map[angle] = reboost.hpge.utils.get_hpge_rz_field(
@@ -394,7 +394,7 @@ def extract_psd_observables(
 ) -> ak.Array:
     """Extract PSD observables for a chunk of events in an HPGe detector.
 
-    This function calculates the A/E observable, its classifier, and the single-site flag for a chunk of events in an HPGe detector, using the provided drift time maps and current model parameters.
+    This function calculates the A/E observable, its classifier, and the single-site flag for a chunk of events in an HPGe detector, using the provided drift-time maps and current model parameters.
 
     Parameters
     ----------
@@ -405,7 +405,7 @@ def extract_psd_observables(
     energy
         Energy deposited in the active volume, used for A/E calculation.
     dt_map
-        Dictionary of drift time maps for different crystal axes, as returned by `load_hpge_dtmaps()`.
+        Dictionary of drift-time maps for different crystal axes, as returned by `load_hpge_dtmaps()`.
     currmod_pars
         Dictionary of parameters for the current model, (see
         :func:`reboost.hpge.psd.get_current_template`)
@@ -491,7 +491,7 @@ def extract_detailed_psd_observables(
 ) -> ak.Array:
     """Extract PSD observables for a chunk of events in an HPGe detector.
 
-    This function calculates the A/E observable, its classifier, and the single-site flag for a chunk of events in an HPGe detector, using the provided drift time maps and current model parameters.
+    This function calculates the A/E observable, its classifier, and the single-site flag for a chunk of events in an HPGe detector, using the provided drift-time maps and current model parameters.
 
     Parameters
     ----------
@@ -502,7 +502,7 @@ def extract_detailed_psd_observables(
     energy
         Energy deposited in the active volume, used for A/E calculation.
     dt_map
-        Dictionary of drift time maps for different crystal axes, as returned by `load_hpge_dtmaps()`.
+        Dictionary of drift-time maps for different crystal axes, as returned by `load_hpge_dtmaps()`.
     pulse_shape_lib
         Dictionary of waveform templates for different crystal axes, as returned by `load_hpge_realistic_psl()`.
     det_loc

--- a/workflow/src/legendsimflow/scripts/extract_hpge_current_pulse_model.py
+++ b/workflow/src/legendsimflow/scripts/extract_hpge_current_pulse_model.py
@@ -43,7 +43,7 @@ def _plot_currmod_from_metadata(
     ax.set_xlim(-500, 1500)
     ax.set_xlabel("time [ns]")
     ax.set_ylabel("current [a.u.]")
-    ax.set_title(f"{hpge} in {runid}: current pulse model (from metadata)")
+    ax.set_title(f"{hpge} in {runid}: current-pulse model (from metadata)")
     with PdfPages(plot_file) as pdf:
         decorate(fig)
         pdf.savefig(fig)
@@ -62,7 +62,7 @@ def _plot_currmod_from_metadata(
 )
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Extract the HPGe current pulse model for a LEGEND run."
+        description="Extract the HPGe current-pulse model for a LEGEND run."
     )
     parser.add_argument(
         "--runid",
@@ -78,7 +78,7 @@ def main() -> None:
     parser.add_argument(
         "--pars-file",
         required=True,
-        help="output YAML file for the current pulse model parameters",
+        help="output YAML file for the current-pulse model parameters",
     )
     parser.add_argument(
         "--plot-file",
@@ -130,7 +130,7 @@ def main() -> None:
     if l200data is None:
         msg = (
             "l200data is not configured and no currmod metadata with a 'default' "
-            "key was found — cannot extract current pulse model"
+            "key was found — cannot extract current-pulse model"
         )
         raise RuntimeError(msg)
 

--- a/workflow/src/legendsimflow/scripts/extract_hpge_elec_response_model.py
+++ b/workflow/src/legendsimflow/scripts/extract_hpge_elec_response_model.py
@@ -17,7 +17,7 @@
 
 """Tune the electronics response parameters (sigma, tau) against data superpulses.
 
-Reads an ideal pulse shape library and data superpulses from LH5, fits the
+Reads an ideal pulse-shape library and data superpulses from LH5, fits the
 Gaussian sigma and exponential tau of the system response kernel by minimising
 the mean RMS between simulated and measured current superpulses, and writes
 the best-fit parameters to a YAML file.

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -70,7 +70,7 @@ def main() -> None:
     parser.add_argument("--hit-file", required=True, help="output hit tier file")
     parser.add_argument("--geom-file", required=True, help="GDML geometry file")
     parser.add_argument(
-        "--dtmap-files", nargs="*", default=[], help="HPGe drift time map files"
+        "--dtmap-files", nargs="*", default=[], help="HPGe drift-time map files"
     )
     parser.add_argument(
         "--currmod-files",
@@ -230,7 +230,7 @@ def main() -> None:
             aoe_res_pars=aoeresmod_pars_all,
         )
 
-        log.debug("loading current pulse model parameters")
+        log.debug("loading current-pulse model parameters")
 
         currmod_pars_file = patterns.output_currmod_merged_filename(
             config, runid=runid, has_psd=simulate_psd
@@ -463,7 +463,7 @@ def main() -> None:
                     energy_res / 2.35482,
                 )
 
-                # PSD: if the drift time map is none, it means that we don't
+                # PSD: if the drift-time map is none, it means that we don't
                 # have the detector model to simulate PSD in a more advanced
                 # way
 
@@ -501,7 +501,7 @@ def main() -> None:
 
                 if can_model_psd_with_psl:
                     log.info(
-                        "computing detailed PSD observables based on realistic pulse shape libraries"
+                        "computing detailed PSD observables based on realistic pulse-shape libraries"
                     )
                     with perf_block("extract_detailed_psd_observables()"):
                         psd_fields_detailed = (


### PR DESCRIPTION
## Summary

Adds documentation for the HPGe pulse-shape-library (PSL) chain, which was previously undocumented in the manual.

- **`manual/pipeline.md`**: six new `par`-tier subsections — a concise PSL-based PSD workflow overview and input-data summary, then drift-time maps, the ideal PSL, data superpulses, the electronics-response model, and the realistic PSL. Covers the recently added behaviour: superpulses from calibration data (the reference calibration run is used for `phy` runs), the `build_per_runid` per-run mode, and the `t0_field`-based event selection.
- **`manual/meta.md`**: reference tables for the user-configurable superpulse settings and the elecmod metadata defaults, plus an SSD-settings anchor for cross-references.
- **`index.md`**: PSL mode added to the workflow overview.

Documentation only. `cd docs && make` builds cleanly.

## Note (out of scope, for follow-up)

The electronics-model fit-tuning settings (`sigma_start`, `tau_start`, `dt_range_tuning`, `max_num_superpulses`, …) are mapped in the script's `@snakemake_compatible` decorator but `extract_electronics_model_pars` does not declare a `settings` input, so they are only configurable via the CLI `--settings`, not through metadata. They are therefore left undocumented as configurable; flagged here in case the input should be wired up.
