### PR TITLE
feat: make aoemeanmod metadata mandatory with default expansion

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -639,6 +639,61 @@ Each entry must contain:
 See {ref}`hpge-aoeresmod-extraction` for a description of how these files are
 used at runtime.
 
+(aoemeanmod-metadata-dir)=
+
+### A/E mean energy-dependence model
+
+A **mandatory** validity-based metadata directory providing the HPGe A/E mean as
+a function of energy. Unlike {ref}`eresmod-metadata-dir`,
+{ref}`aoeresmod-metadata-dir` and {ref}`psdcuts-metadata-dir`, this model cannot
+be extracted from `l200data`, so the metadata is the only source and must be
+present for every simulated run. It is read directly when building the `hit`
+tier.
+
+```{code-block} yaml
+:caption: simprod/config/pars/{experiment}/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
+
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+
+# optional per-detector override
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0
+```
+
+- `default` _(optional)_: model applied to all HPGe detectors not listed
+  explicitly. When present it is expanded across all `geds` detectors in the
+  channel map, mirroring {ref}`aoeresmod-metadata-dir`.
+- `<detector>` _(optional)_: per-detector override.
+
+Each entry must provide a `single_template` and a `psl` block (one per PSD
+simulation type), and each block must contain:
+
+- `expression`: a Python expression for the A/E mean as a function of the energy
+  `x` (in keV), using the parameters `a` and `b`
+- `pars`: mapping of the parameters `a` and `b` to their values
+
+A detector with neither an explicit entry nor a `default` falls back to a flat
+A/E mean of 1 (a warning is logged for `on` detectors).
+
 (psdcuts-metadata-dir)=
 
 ### PSD cut defaults

--- a/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l1000dsg01/geds/aoemeanmod/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-aoemeanmod.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-aoemeanmod.yaml

--- a/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/l200cfg01/geds/aoemeanmod/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-aoemeanmod.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-aoemeanmod.yaml

--- a/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/l200-p02-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/l200-p03-r%-T%-all-aoemeanmod.yaml
@@ -1,0 +1,22 @@
+default:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000001
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000002
+      b: 1.0
+V02160A:
+  single_template:
+    expression: a * x + b
+    pars:
+      a: -0.000003
+      b: 1.0
+  psl:
+    expression: a * x + b
+    pars:
+      a: -0.000004
+      b: 1.0

--- a/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/validity.yaml
+++ b/tests/dummyprod/inputs/simprod/config/pars/legend/geds/aoemeanmod/validity.yaml
@@ -1,0 +1,7 @@
+- valid_from: 20220102T000000Z
+  apply:
+    - l200-p02-r%-T%-all-aoemeanmod.yaml
+
+- valid_from: 20230312T000000Z
+  apply:
+    - l200-p03-r%-T%-all-aoemeanmod.yaml

--- a/workflow/src/legendsimflow/hpge_pars.py
+++ b/workflow/src/legendsimflow/hpge_pars.py
@@ -1208,7 +1208,9 @@ def build_aoe_mean_func_dict(
     Parameters
     ----------
     aoe_mean_pars
-        Parameters of the aoe energy depenndence model.
+        Parameters of the A/E energy-dependence model. May contain a
+        ``default`` entry, which the caller is expected to have already
+        expanded across the relevant detectors.
     sim_type
         Type of PSD simulation (`single_template` or `psl`)
     """

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -188,6 +188,31 @@ def main() -> None:
         aoemean_mod = mutils.simpars(
             metadata, "geds.aoemeanmod", runid, config.experiment, default=None
         )
+        # unlike eresmod/aoeresmod/psdcuts, the A/E mean model cannot be
+        # extracted from l200data, so this metadata is the only source and is
+        # mandatory
+        if aoemean_mod is None:
+            msg = (
+                f"no A/E mean energy-dependence model (geds.aoemeanmod) found "
+                f"for {runid}: this metadata is mandatory"
+            )
+            raise RuntimeError(msg)
+
+        # expand the "default" entry across all geds detectors in the channel
+        # map, applying per-detector overrides where present (mirrors the
+        # aoeresmod collection in extract_hpge_observables_models)
+        aoemean_default = aoemean_mod.get("default", None)
+        if aoemean_default is not None:
+            tstamp = mutils.runinfo(metadata, runid).start_key
+            chmap = metadata.channelmap(tstamp, skip_version_check=True)
+            aoemean_mod = AttrsDict(
+                {
+                    name: aoemean_mod.get(name, aoemean_default)
+                    for name, info in chmap.items()
+                    if getattr(info, "system", None) == "geds"
+                }
+            )
+
         aoemean_func_psl = hpge_pars.build_aoe_mean_func_dict(
             aoemean_mod, sim_type="psl"
         )
@@ -257,6 +282,13 @@ def main() -> None:
                 usability = det_info.usability
                 psd_usability = det_info.psd_usability
             psd_usability_code = mutils.encode_psd_usability(psd_usability)
+
+            if usability == "on" and det_name not in aoemean_func:
+                log.warning(
+                    "%s is ON but has no A/E mean energy-dependence model "
+                    "(geds.aoemeanmod); falling back to a flat A/E mean of 1",
+                    det_name,
+                )
 
             log.debug("looking for indices of hit table rows to read...")
             with perf_block("get_remage_hit_range()"):


### PR DESCRIPTION
## Summary

The A/E mean energy-dependence model (`geds.aoemeanmod`) cannot be extracted from `l200data`, unlike `eresmod`/`aoeresmod`/`psdcuts`, so the metadata is the only source. Previously, when the file was absent `simpars(..., default=None)` returned `None` and every detector silently fell back to a flat A/E mean of 1, with no error or warning.

This makes the metadata mandatory and gives it the same `default`-key ergonomics as `aoeresmod`.

## Changes

- **`hit.py`**
  - Raise a `RuntimeError` if no `geds.aoemeanmod` model resolves for a run (the metadata is now mandatory).
  - Support a `default` entry, expanded across all `geds` detectors in the channel map with per-detector overrides applied on top, mirroring the collection logic in `extract_hpge_observables_models.py`. The channel map is only resolved when a `default` is present.
  - Log a warning for an `on` detector that has neither an explicit entry nor a `default` (it still falls back to a flat A/E mean of 1).
- **`hpge_pars.py`**: fix the `build_aoe_mean_func_dict` docstring (typo + note that the caller expands `default`).
- **Fixtures**: add `geds/aoemeanmod/` (validity + p02 + p03) for all three dummyprod experiments (`legend`, `l1000dsg01`, `l200cfg01`). `l200cfg01` needs it precisely because this model has no `l200data` extraction path.
- **Docs**: add the previously-undocumented `aoemeanmod` metadata directory section to `manual/meta.md`, flagged as mandatory.

## Testing

- `pre-commit run --all-files`: pass (run via the commit hook).
- `make -C docs`: build succeeded, no warnings.
- `pixi run test-python`: 298 passed. The two unrelated failures (`test_superpulses.py::test_plot`, `test_extract_hpge_electronics_model.py`) are pre-existing on `main`: a matplotlib `tight layout` `UserWarning` promoted to an error by `filterwarnings=error`.
- `pytest tests/scripts/test_tier_hit.py -m needs_remage`: 1 passed (real remage run exercising the `default`-expansion path through `hit.main()`).