### PR TITLE
build: bump LegendDataManagement.jl to 0.6.7, disable cylindrical asymmetry

### DIFF
--- a/workflow/src/LegendSimflow.jl/Project.toml
+++ b/workflow/src/LegendSimflow.jl/Project.toml
@@ -15,7 +15,7 @@ SolidStateDetectors = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-LegendDataManagement = "=0.6.5"
+LegendDataManagement = "=0.6.7"
 LegendHDF5IO = "=0.1.18"
 RadiationDetectorDSP = "=0.2.18"
 SolidStateDetectors = "=0.11.3"

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -490,7 +490,8 @@ function setup_hpge_simulation(meta_path::String,
         meta,
         xtal,
         HPGeEnvironment(medium, temperature*u"K"),
-        operational_voltage = opv_val*u"V"
+        operational_voltage = opv_val*u"V",
+        allow_cylindrical_asymmetry = false
     )
 
     @info "Calculating electric potential at $(opv_val) V..."


### PR DESCRIPTION
## Summary

- Bump the pinned `LegendDataManagement.jl` compat from `=0.6.5` to `=0.6.7` in `workflow/src/LegendSimflow.jl/Project.toml`.
- Pass `allow_cylindrical_asymmetry = false` to the `Simulation{T}(LegendData, …)` constructor in `setup_hpge_simulation` (`pulse_shape_sim_helpers.jl`).

The `allow_cylindrical_asymmetry` keyword was introduced in legend-exp/LegendDataManagement.jl#179 (first released in `0.6.7`). With it set to `false`, symmetry-breaking geometry features (e.g. metadata-defined cracks) are ignored and the HPGe drift-time / pulse-shape SSD simulation stays azimuthally symmetric (2D), instead of expanding the grid to a full 3D phi range (0–360°).

## Compatibility

`0.6.7`'s compat (`SolidStateDetectors = "0.10.25, 0.11.3"`, `LegendHDF5IO = "0.1.14"`) is satisfied by the existing pins (`SolidStateDetectors = "=0.11.3"`, `LegendHDF5IO = "=0.1.18"`), so no other compat bounds needed changing.

## Testing

- `pixi run test-julia`: **52/52 pass** (LegendDataManagement resolves to `0.6.7`; the `map_generation` testset exercises the full `setup_hpge_simulation` path with the new keyword).
- `pre-commit run` on the changed files: all hooks pass (incl. JuliaFormatter).

## Related

- legend-exp/LegendDataManagement.jl#179