### PR TITLE
test: exercise PSL-based PSD in the l1000 integration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ including Pixi configuration.
 - Lint/format: `pre-commit run --all-files` — run before committing; every
   commit must pass
 - Build docs: `cd docs && make` — verify after any documentation change
+- Note about `snakemake --touch`: the _only_ thing it does is to update the
+  modification times of empty files
 
 ## Architecture
 

--- a/docs/source/developer.md
+++ b/docs/source/developer.md
@@ -81,15 +81,15 @@ Test data for LEGEND-200 is stored in `tests/l200data/`.
 Some integration tests require **remage**, which is only available inside the
 pixi `test` environment. The table below summarises what each test needs:
 
-| Test                  | Command                                   | Needs pixi | Needs NERSC/l200data |
-| --------------------- | ----------------------------------------- | ---------- | -------------------- |
-| `test_dag`            | `pytest tests/test_workflow.py::test_dag` | no         | no                   |
-| `test_l1000_workflow` | `pixi run -e test test-l1000-workflow`    | **yes**    | no                   |
-| `test_l200_workflow`  | `pixi run -e test test-l200-workflow`     | **yes**    | **yes**              |
-| unit / script tests   | `pytest tests/`                           | no         | no                   |
+| Test                  | Command                                | Needs pixi | Needs NERSC/l200data |
+| --------------------- | -------------------------------------- | ---------- | -------------------- |
+| DAG tests             | `pytest tests/test_dag.py`             | no         | no                   |
+| `test_l1000_workflow` | `pixi run -e test test-l1000-workflow` | **yes**    | no                   |
+| `test_l200_workflow`  | `pixi run -e test test-l200-workflow`  | **yes**    | **yes**              |
+| unit / script tests   | `pytest tests/`                        | no         | no                   |
 
 **Always run `pixi run -e test test-l1000-workflow` before committing changes
-that touch the workflow, scripts, or metadata.** The `test_dag` dry-run alone is
+that touch the workflow, scripts, or metadata.** The dry-run DAG tests alone are
 not sufficient to catch runtime failures.
 
 ## Code style and linting

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -52,13 +52,34 @@ contains constant 1000 ns drift times on a 1 mm grid for detector V05261B at
 4200 V. The `legend_dtmap_path` fixture uses this file directly so that the
 Julia drift-time map script does not need to run during unit tests.
 
+## DAG tests (`test_dag.py`)
+
+Assert on the resolved DAG structure (via `dag.jobs`, not run logs); no
+remage/NERSC, run in the default suite. Builds use the **touch** executor on a
+throwaway output dir, not a dry run: touch marks the `cache_modelable_hpges`
+checkpoint complete, so `smk_load_hpge_cache` falls back to metadata and the
+per-detector rules downstream of it (PSL / drift-time map builds) expand (a dry
+run leaves them unresolved); the throwaway dir keeps placeholders out of the
+real `generated*` dirs.
+
+- `test_dag` / `test_dag_simlist`: full DAG resolves; a simlist target schedules
+  the PSD-gated drift-time map plots.
+- `test_make_steps_selects_tiers`: `make_steps` selects which tier rules enter
+  the DAG (tiers are decoupled, e.g. hit without opt).
+- `test_simulate_psd[_with_psl]_toggles_*`: the hit-tier `simulate_psd_with_psl`
+  / `simulate_psd` settings (edited in a temp metadata copy) add/remove exactly
+  the PSL / drift-time-map rules; guards the YAML-to-DAG wiring the dead
+  `has_detailed_psd` key broke.
+- `test_skip_{opt,hit}_drops_*` / `..._mutually_exclusive`: the evt-tier
+  `skip_opt` / `skip_hit` switches drop the opt / hit jobs (negative case: the
+  same `make_steps` is unsatisfiable without the switch); both-skip is rejected
+  at build time.
+
 ## Integration tests (`test_workflow.py`)
 
-The workflow tests form a progression:
+The remage-driven workflow tests form a progression:
 
-1. **`test_dag`** — touch executor, no remage needed; verifies DAG resolution
-   only. Run directly: `pytest tests/test_workflow.py::test_dag`
-2. **`test_l1000_workflow`** (`needs_remage`) — runs vtx→pdf with real remage,
+1. **`test_l1000_workflow`** (`needs_remage`) — runs vtx→pdf with real remage,
    experiment `l1000dsg01`; runs in CI. **Requires pixi** (remage is only in the
    pixi environment): `pixi run -e test test-l1000-workflow`. The `l1000dsg01`
    hit settings enable the `simulate_psd_with_psl` tier setting (the live name
@@ -66,7 +87,7 @@ The workflow tests form a progression:
    exercises the PSL-based "detailed" PSD path: the realistic pulse-shape
    library is built in the par tier, consumed by the hit tier into a `psd_psl`
    sub-table, and read back by the evt tier into `geds/psd_psl`.
-3. **`test_l200_workflow`** (`needs_nersc`, `needs_remage`) — full vtx→cvt
+2. **`test_l200_workflow`** (`needs_nersc`, `needs_remage`) — full vtx→cvt
    pipeline, experiment `l200cfg01`, requires `l200data`, NERSC-only. Run with:
    `pixi run -e test test-l200-workflow`
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -60,7 +60,12 @@ The workflow tests form a progression:
    only. Run directly: `pytest tests/test_workflow.py::test_dag`
 2. **`test_l1000_workflow`** (`needs_remage`) — runs vtx→pdf with real remage,
    experiment `l1000dsg01`; runs in CI. **Requires pixi** (remage is only in the
-   pixi environment): `pixi run -e test test-l1000-workflow`
+   pixi environment): `pixi run -e test test-l1000-workflow`. The `l1000dsg01`
+   hit settings enable the `simulate_psd_with_psl` tier setting (the live name
+   of what used to be the unread `has_detailed_psd` key), so this test also
+   exercises the PSL-based "detailed" PSD path: the realistic pulse-shape
+   library is built in the par tier, consumed by the hit tier into a `psd_psl`
+   sub-table, and read back by the evt tier into `geds/psd_psl`.
 3. **`test_l200_workflow`** (`needs_nersc`, `needs_remage`) — full vtx→cvt
    pipeline, experiment `l200cfg01`, requires `l200data`, NERSC-only. Run with:
    `pixi run -e test test-l200-workflow`

--- a/tests/dummyprod/inputs/simprod/config/tier/hit/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/hit/l1000dsg01/settings.yaml
@@ -1,6 +1,6 @@
 dead_layer_fraction: 0.5
 buffer_len: 500*MB
-has_detailed_psd: true
+simulate_psd_with_psl: true
 
 eresmod_default:
   expression: FWHMLinear

--- a/tests/dummyprod/inputs/simprod/config/tier/hit/l200cfg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/hit/l200cfg01/settings.yaml
@@ -1,6 +1,6 @@
 dead_layer_fraction: 0.5
 buffer_len: 500*MB
-has_detailed_psd: false
+simulate_psd_with_psl: false
 
 eresmod_default:
   expression: FWHMLinear

--- a/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/hit/legend/settings.yaml
@@ -1,6 +1,6 @@
 dead_layer_fraction: 0.5
 buffer_len: 500*MB
-has_detailed_psd: false
+simulate_psd_with_psl: false
 
 eresmod_default:
   expression: FWHMLinear

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,0 +1,330 @@
+"""DAG-structure tests for the dummy production.
+
+These tests resolve the Snakemake dependency graph and assert on its structure.
+They are built with the *touch* executor: it constructs the graph and creates
+empty placeholder outputs without running any real job, and (unlike a dry run)
+it marks the modelable-HPGe checkpoint (``cache_modelable_hpges``) complete. That
+makes ``smk_load_hpge_cache`` fall back to computing the detector list from
+metadata, so the per-detector rules downstream of the checkpoint (the PSL and
+drift-time map builds) expand too; a dry run would leave them unresolved.
+
+Every build is pointed at a throwaway output directory, so the placeholder
+outputs never touch the real ``generated*`` dirs and the resolved graph is
+deterministic regardless of what already exists on disk. No remage, Julia or
+NERSC access is required, so they run in the default test suite.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+import yaml
+from snakemake import api as smkapi
+from snakemake.exceptions import MissingInputException, WorkflowError
+
+dummyprod = Path(__file__).parent / "dummyprod"
+default_config = dummyprod / "simflow-config.yaml"
+l1000_config = dummyprod / "simflow-config-l1000.yaml"
+all_cores = os.cpu_count() or 1
+
+# the file-producing rule of each tier, used to assert tier (de)selection
+TIER_BUILD_RULE = {
+    "vtx": "build_tier_vtx",
+    "stp": "build_tier_stp",
+    "opt": "build_tier_opt",
+    "hit": "build_tier_hit",
+    "evt": "build_tier_evt",
+    "cvt": "build_tier_cvt",
+    "pdf": "build_tier_pdf",
+}
+TIERS = tuple(TIER_BUILD_RULE)
+
+# rules building the realistic HPGe pulse-shape library for the detailed,
+# PSL-based PSD; gated by the hit-tier `simulate_psd_with_psl` setting
+PSL_PSD_RULES = {
+    "build_hpge_pulse_shape_library",
+    "convolve_hpge_ideal_pulse_shape_lib",
+    "merge_hpge_realistic_psls",
+    "extract_electronics_model_pars",
+    "merge_electronics_model_pars",
+}
+
+# rules building the drift-time maps and current-pulse model for the standard
+# PSD; gated by the hit-tier `simulate_psd` setting
+STD_PSD_RULES = {
+    "build_hpge_drift_time_map",
+    "merge_hpge_drift_time_maps",
+    "plot_hpge_drift_time_maps",
+    "extract_current_pulse_model",
+    "merge_current_pulse_model_pars",
+}
+
+
+def _output_paths(base: Path) -> dict:
+    """Redirect every generated output under *base* (a throwaway directory)."""
+    gen = base / "generated"
+    return {
+        "generated": str(gen),
+        "benchmarks": str(gen / "benchmarks"),
+        "log": str(gen / "log"),
+        "pars": str(gen / "pars"),
+        "macros": str(gen / "macros"),
+        "pdf_releases": str(gen / "releases"),
+        "tier": {t: str(gen / "tier" / t) for t in TIERS},
+    }
+
+
+def _metadata_paths(
+    base: Path, experiment: str, settings_by_tier: Mapping[str, Mapping]
+) -> dict:
+    """Copy the dummyprod metadata under *base* with overridden tier settings.
+
+    ``settings_by_tier`` maps a tier name to the settings keys to overwrite for
+    *experiment* (e.g. ``{"evt": {"skip_opt": True}}``). Editing the copy keeps
+    the committed metadata untouched.
+    """
+    meta = base / "inputs"
+    shutil.copytree(dummyprod / "inputs", meta)
+    for tier, overlay in settings_by_tier.items():
+        f = meta / "simprod/config/tier" / tier / experiment / "settings.yaml"
+        data = yaml.safe_load(f.read_text())
+        data.update(overlay)
+        f.write_text(yaml.safe_dump(data))
+    return {
+        "metadata": str(meta),
+        "config": str(meta / "simprod/config"),
+        "optical_maps": {"lar": str(meta / "simprod/l200cfg01-optmap-dummy.lh5")},
+    }
+
+
+def overrides(
+    base: Path,
+    *,
+    make_steps: list[str] | None = None,
+    simlist: str | None = None,
+    experiment: str | None = None,
+    settings_by_tier: Mapping[str, Mapping] | None = None,
+) -> dict:
+    """Build config overrides: a throwaway output dir plus the requested knobs.
+
+    When *settings_by_tier* is given the metadata is copied to *base* and edited,
+    so the tier settings take effect without mutating the committed metadata.
+    """
+    paths = _output_paths(base)
+    if settings_by_tier:
+        assert experiment is not None
+        paths |= _metadata_paths(base, experiment, settings_by_tier)
+    cfg: dict = {"paths": paths}
+    if make_steps is not None:
+        cfg["make_steps"] = make_steps
+    if simlist is not None:
+        cfg["simlist"] = simlist
+    return cfg
+
+
+def dag_rule_names(configfile: Path, config_overrides: Mapping) -> set[str]:
+    """Return the set of rule names making up the resolved workflow DAG.
+
+    Built with the touch executor (see the module docstring), so rules both
+    upstream and downstream of the modelable-HPGe checkpoint appear, independent
+    of what exists on disk. Raises if the DAG cannot be resolved (e.g. an input
+    has no producing rule).
+    """
+    output = smkapi.OutputSettings(verbose=False)
+    with smkapi.SnakemakeApi(output) as api:
+        wf_api = api.workflow(
+            snakefile=dummyprod / "workflow/Snakefile",
+            workdir=dummyprod,
+            config_settings=smkapi.ConfigSettings(
+                configfiles=(configfile,), config=dict(config_overrides)
+            ),
+            storage_settings=smkapi.StorageSettings(),
+            resource_settings=smkapi.ResourceSettings(cores=all_cores),
+        )
+        dag = wf_api.dag()
+        # the touch executor dumps the full job list to stdout; swallow it
+        with contextlib.redirect_stdout(io.StringIO()):
+            dag.execute_workflow(executor="touch")
+        # the public API exposes no DAG accessor, so reach into the workflow
+        # object for the resolved graph
+        return {job.rule.name for job in wf_api._workflow.dag.jobs}
+
+
+def test_dag(tmp_path):
+    """The default (full) DAG resolves without error and covers every tier."""
+    rules = dag_rule_names(default_config, overrides(tmp_path))
+    assert "all" in rules
+    assert set(TIER_BUILD_RULE.values()) <= rules
+
+
+def test_dag_simlist(tmp_path):
+    """An explicit simlist target pulls in the PSD-gated drift-time map plots.
+
+    The par tier contributes the drift-time map plots through
+    ``process_simlist``; requesting a hit-tier simid must schedule them.
+    """
+    rules = dag_rule_names(
+        default_config, overrides(tmp_path, simlist="hit.pen_plates_Ra224_to_Pb208")
+    )
+    assert "build_tier_hit" in rules
+    assert "plot_hpge_drift_time_maps" in rules
+
+
+@pytest.mark.parametrize(
+    ("make_steps", "present", "absent"),
+    [
+        # only the lowest tiers
+        (["vtx", "stp"], {"vtx", "stp"}, {"opt", "hit", "evt", "cvt", "pdf"}),
+        # tiers are decoupled: hit can be built without opt
+        (["vtx", "stp", "par", "hit"], {"vtx", "stp", "hit"}, {"opt", "evt"}),
+        # the full pipeline
+        (
+            ["vtx", "stp", "par", "opt", "hit", "evt", "cvt", "pdf"],
+            {"vtx", "stp", "opt", "hit", "evt", "cvt", "pdf"},
+            set(),
+        ),
+    ],
+)
+def test_make_steps_selects_tiers(tmp_path, make_steps, present, absent):
+    """`make_steps` controls which tiers (and their build rules) enter the DAG."""
+    rules = dag_rule_names(default_config, overrides(tmp_path, make_steps=make_steps))
+    assert {TIER_BUILD_RULE[t] for t in present} <= rules
+    assert {TIER_BUILD_RULE[t] for t in absent}.isdisjoint(rules)
+
+
+# the PSD switches gate per-detector rules downstream of the modelable-HPGe
+# checkpoint; the touch executor (see dag_rule_names) is what expands them
+STEPS_TO_HIT = ["vtx", "stp", "par", "opt", "hit"]
+
+
+def test_simulate_psd_with_psl_toggles_psl_rules(tmp_path):
+    """The hit-tier `simulate_psd_with_psl` setting gates the PSL build chain."""
+    on = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "on",
+            make_steps=STEPS_TO_HIT,
+            experiment="l1000dsg01",
+            settings_by_tier={"hit": {"simulate_psd_with_psl": True}},
+        ),
+    )
+    off = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "off",
+            make_steps=STEPS_TO_HIT,
+            experiment="l1000dsg01",
+            settings_by_tier={"hit": {"simulate_psd_with_psl": False}},
+        ),
+    )
+    assert on >= PSL_PSD_RULES
+    assert PSL_PSD_RULES.isdisjoint(off)
+    # flipping the switch changes nothing but the PSL rules
+    assert on - off == PSL_PSD_RULES
+
+
+def test_simulate_psd_toggles_dtmap_rules(tmp_path):
+    """The hit-tier `simulate_psd` setting gates the drift-time map build chain."""
+    on = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "on",
+            make_steps=STEPS_TO_HIT,
+            experiment="l1000dsg01",
+            settings_by_tier={"hit": {"simulate_psd": True}},
+        ),
+    )
+    off = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "off",
+            make_steps=STEPS_TO_HIT,
+            experiment="l1000dsg01",
+            settings_by_tier={"hit": {"simulate_psd": False}},
+        ),
+    )
+    assert on >= STD_PSD_RULES
+    assert STD_PSD_RULES.isdisjoint(off)
+    # flipping the switch changes nothing but the drift-time map rules
+    assert on - off == STD_PSD_RULES
+
+
+def test_skip_opt_drops_opt_tier(tmp_path):
+    """The evt-tier `skip_opt` setting drops the opt tier from the DAG.
+
+    Setting ``skip_opt`` removes the opt-tier file from the ``build_tier_evt``
+    inputs; with opt left out of ``make_steps`` the opt jobs then have no
+    consumer and disappear from the graph. Without ``skip_opt`` the same
+    ``make_steps`` is unsatisfiable (evt requires an opt file that no rule
+    produces), which is exactly what the switch is there to allow.
+    """
+    steps = ["vtx", "stp", "par", "hit", "evt"]  # note: no opt
+    rules = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "skip",
+            make_steps=steps,
+            experiment="l1000dsg01",
+            settings_by_tier={"evt": {"skip_opt": True}},
+        ),
+    )
+    assert {"build_tier_evt", "build_tier_hit"} <= rules
+    assert "build_tier_opt" not in rules
+
+    with pytest.raises(MissingInputException):
+        dag_rule_names(
+            l1000_config,
+            overrides(
+                tmp_path / "noskip",
+                make_steps=steps,
+                experiment="l1000dsg01",
+                settings_by_tier={"evt": {"skip_opt": False}},
+            ),
+        )
+
+
+def test_skip_hit_drops_hit_tier(tmp_path):
+    """The evt-tier `skip_hit` setting drops the hit tier from the DAG."""
+    steps = ["vtx", "stp", "par", "opt", "evt"]  # note: no hit
+    rules = dag_rule_names(
+        l1000_config,
+        overrides(
+            tmp_path / "skip",
+            make_steps=steps,
+            experiment="l1000dsg01",
+            settings_by_tier={"evt": {"skip_hit": True}},
+        ),
+    )
+    assert {"build_tier_evt", "build_tier_opt"} <= rules
+    assert "build_tier_hit" not in rules
+
+    with pytest.raises(MissingInputException):
+        dag_rule_names(
+            l1000_config,
+            overrides(
+                tmp_path / "noskip",
+                make_steps=steps,
+                experiment="l1000dsg01",
+                settings_by_tier={"evt": {"skip_hit": False}},
+            ),
+        )
+
+
+def test_skip_opt_and_hit_are_mutually_exclusive(tmp_path):
+    """Skipping both the opt and hit tiers is rejected at DAG-build time."""
+    with pytest.raises(WorkflowError, match="skip_opt and skip_hit"):
+        dag_rule_names(
+            l1000_config,
+            overrides(
+                tmp_path,
+                make_steps=["vtx", "stp", "par", "evt"],
+                experiment="l1000dsg01",
+                settings_by_tier={"evt": {"skip_opt": True, "skip_hit": True}},
+            ),
+        )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -90,53 +90,8 @@ def _assert_psd_psl_in_evt(generated: Path) -> None:
     assert saw_psd_psl, "no evt file contains an evt/geds/psd_psl sub-table"
 
 
-def test_dag():
-    output = smkapi.OutputSettings(verbose=False)
-
-    # build workflow and DAG, execute with touch executor (no remage needed)
-    with smkapi.SnakemakeApi(output) as api:
-        wf_api = api.workflow(
-            snakefile=dummyprod / "workflow/Snakefile",
-            workdir=dummyprod,
-            config_settings=smkapi.ConfigSettings(
-                configfiles=(dummyprod / "simflow-config.yaml",)
-            ),
-            storage_settings=smkapi.StorageSettings(),
-            resource_settings=smkapi.ResourceSettings(cores=all_cores),
-        )
-        dag = wf_api.dag()
-        dag.execute_workflow(executor="touch")
-
-
-def test_dag_simlist():
-    # the explicit-simlist path must schedule the (PSD-gated) dtmap plots, which
-    # the par tier contributes through process_simlist. The touch executor does
-    # not create output files, so we check the scheduled jobs in the run log
-    # instead (it also completes the modelable-HPGe checkpoint pulled in by the
-    # requested hit tier, which a dry run would leave unresolved).
-    output = smkapi.OutputSettings(verbose=False)
-
-    with smkapi.SnakemakeApi(output) as api:
-        wf_api = api.workflow(
-            snakefile=dummyprod / "workflow/Snakefile",
-            workdir=dummyprod,
-            config_settings=smkapi.ConfigSettings(
-                configfiles=(dummyprod / "simflow-config.yaml",),
-                config={"simlist": "hit.pen_plates_Ra224_to_Pb208"},
-            ),
-            storage_settings=smkapi.StorageSettings(),
-            resource_settings=smkapi.ResourceSettings(cores=all_cores),
-        )
-        dag = wf_api.dag()
-        dag.execute_workflow(executor="touch")
-
-    logs = sorted(
-        (dummyprod / ".snakemake/log").glob("*.snakemake.log"),
-        key=lambda p: p.stat().st_mtime,
-    )
-    assert "plot_hpge_drift_time_maps" in logs[-1].read_text(), (
-        "dtmap plots not scheduled via the simlist path"
-    )
+# NOTE: the dry-run DAG-structure tests (DAG resolution, simlist scheduling,
+# make_steps tier selection, PSD switches) live in test_dag.py.
 
 
 @pytest.mark.needs_remage

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,11 +4,90 @@ import os
 import shutil
 from pathlib import Path
 
+import lh5
+import numpy as np
 import pytest
 from snakemake import api as smkapi
 
 dummyprod = Path(__file__).parent / "dummyprod"
 all_cores = os.cpu_count() or 1
+
+# fields written by the PSL-based (detailed) PSD path
+_HIT_PSD_PSL_FIELDS = {
+    "drift_time_amax",
+    "aoe_raw",
+    "aoe_corr",
+    "aoe",
+    "is_single_site",
+    "is_bb_like",
+    "is_high_aoe",
+}
+_EVT_PSD_PSL_FIELDS = {
+    "aoe",
+    "has_aoe",
+    "aoe_corr",
+    "drift_time_amax",
+    "is_single_site",
+    "is_bb_like",
+    "is_high_aoe",
+}
+
+
+def _assert_psd_psl_in_hit(generated: Path) -> None:
+    """Check the PSL-based detailed PSD output in the hit tier.
+
+    A ``psd_psl`` sub-table must be produced for the modelable detector
+    ``V05261B`` (it has a realistic pulse-shape library and drift-time map), and
+    its A/E values must be at least partly finite, proving the detailed path
+    actually ran rather than falling back to the all-NaN default.
+    """
+    hit_files = sorted((generated / "tier/hit").rglob("*.lh5"))
+    assert hit_files, f"no hit output files found under {generated}/tier/hit"
+
+    saw_psd_psl = False
+    saw_finite_aoe = False
+    for f in hit_files:
+        if "hit/V05261B" not in lh5.ls(f, "hit/"):
+            continue
+        if "hit/V05261B/psd_psl" not in lh5.ls(f, "hit/V05261B/"):
+            continue
+        saw_psd_psl = True
+        fields = {
+            x.removeprefix("hit/V05261B/psd_psl/")
+            for x in lh5.ls(f, "hit/V05261B/psd_psl/")
+        }
+        missing = _HIT_PSD_PSL_FIELDS - fields
+        assert not missing, f"hit psd_psl fields {missing} missing in {f}; got {fields}"
+        aoe = lh5.read_as("hit/V05261B/psd_psl/aoe", str(f), library="np")
+        if np.any(np.isfinite(aoe)):
+            saw_finite_aoe = True
+
+    assert saw_psd_psl, "no hit file contains a hit/V05261B/psd_psl sub-table"
+    assert saw_finite_aoe, (
+        "hit/V05261B/psd_psl/aoe is all-NaN across all hit files; the PSL-based "
+        "detailed PSD path did not compute real A/E values"
+    )
+
+
+def _assert_psd_psl_in_evt(generated: Path) -> None:
+    """Check that the evt tier reads the detailed PSD back into geds/psd_psl."""
+    evt_files = sorted((generated / "tier/evt").rglob("*.lh5"))
+    assert evt_files, f"no evt output files found under {generated}/tier/evt"
+
+    saw_psd_psl = False
+    for f in evt_files:
+        if "evt/geds" not in lh5.ls(f, "evt/"):
+            continue
+        if "evt/geds/psd_psl" not in lh5.ls(f, "evt/geds/"):
+            continue
+        saw_psd_psl = True
+        fields = {
+            x.removeprefix("evt/geds/psd_psl/") for x in lh5.ls(f, "evt/geds/psd_psl/")
+        }
+        missing = _EVT_PSD_PSL_FIELDS - fields
+        assert not missing, f"evt psd_psl fields {missing} missing in {f}; got {fields}"
+
+    assert saw_psd_psl, "no evt file contains an evt/geds/psd_psl sub-table"
 
 
 def test_dag():
@@ -77,6 +156,13 @@ def test_l1000_workflow():
         )
         dag = wf_api.dag()
         dag.execute_workflow()
+
+    # the l1000dsg01 hit settings enable simulate_psd_with_psl, so the detailed
+    # (PSL-based) PSD must be produced in the hit tier and read back in the evt
+    # tier
+    generated = dummyprod / "generated-l1000"
+    _assert_psd_psl_in_hit(generated)
+    _assert_psd_psl_in_evt(generated)
 
 
 @pytest.mark.needs_nersc

--- a/workflow/rules/hit.smk
+++ b/workflow/rules/hit.smk
@@ -55,8 +55,8 @@ rule build_tier_hit:
         hpges_realistic_psls=lambda wc: aggregate.gen_list_of_merged_realistic_psls(
             config,
             wc.simid,
-            has_detailed_psd=get_tier_settings(config, "hit").get(
-                "simulate_psd_with_psl", True
+            simulate_psd_with_psl=get_tier_settings(config, "hit").get(
+                "simulate_psd_with_psl", False
             ),
         ),
         hpge_psdcuts=lambda wc: aggregate.gen_list_of_psdcuts(config, wc.simid),

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -413,7 +413,7 @@ def gen_list_of_realistic_psls(
     config: SimflowConfig,
     runid: str,
     cache: dict[str, dict[str, int]] | None = None,
-    has_detailed_psd: bool = True,
+    simulate_psd_with_psl: bool = True,
 ) -> list[Path]:
     """Generate the list of realistic HPGe pulse-shape library files for a `runid`.
 
@@ -421,7 +421,7 @@ def gen_list_of_realistic_psls(
     ``runid -> {hpge: voltage}`` and avoids repeated metadata lookups.
     """
     files = []
-    if not has_detailed_psd:
+    if not simulate_psd_with_psl:
         return []
 
     hpges = (
@@ -440,10 +440,10 @@ def gen_list_of_realistic_psls(
 
 
 def gen_list_of_merged_realistic_psls(
-    config: SimflowConfig, simid: str, has_detailed_psd: bool = True
+    config: SimflowConfig, simid: str, simulate_psd_with_psl: bool = True
 ) -> list[Path]:
     r"""Generate the list of (merged) HPGe PSL files for all requested `runid`\ s."""
-    if not has_detailed_psd:
+    if not simulate_psd_with_psl:
         return []
 
     return [

--- a/workflow/src/legendsimflow/reboost.py
+++ b/workflow/src/legendsimflow/reboost.py
@@ -236,7 +236,10 @@ def load_hpge_realistic_psl(
         ),
     )
 
-    if len(lh5.ls(psl_file, f"{det_name}/drift_time_*")) >= 2:
+    if (
+        Path(psl_file).exists()
+        and len(lh5.ls(psl_file, f"{det_name}/drift_time_*")) >= 2
+    ):
         log.debug("loading drift-time maps from %s", psl_file)
         # both axes needed: hpge_corrected_drift_time() blends them (and small)
         dt_map = {

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -464,7 +464,7 @@ def main() -> None:
 
                     aoe_corr = _read_hits(tcm, "hit", "psd_psl/aoe_corr")
                     out_table.add_field(
-                        "geds/psd/aoe_corr",
+                        "geds/psd_psl/aoe_corr",
                         VectorOfVectors(ak.values_astype(aoe_corr[hitsel], np.float32)),
                     )
 
@@ -488,13 +488,13 @@ def main() -> None:
                     out_table.add_field(
                         "geds/psd_psl/is_single_site", VectorOfVectors(is_ss[hitsel])
                     )
-                    is_bb_like = _read_hits(tcm, "hit", "psd/is_bb_like")
+                    is_bb_like = _read_hits(tcm, "hit", "psd_psl/is_bb_like")
                     out_table.add_field(
-                        "geds/psd/is_bb_like", VectorOfVectors(is_bb_like[hitsel])
+                        "geds/psd_psl/is_bb_like", VectorOfVectors(is_bb_like[hitsel])
                     )
-                    is_high_aoe = _read_hits(tcm, "hit", "psd/is_high_aoe")
+                    is_high_aoe = _read_hits(tcm, "hit", "psd_psl/is_high_aoe")
                     out_table.add_field(
-                        "geds/psd/is_high_aoe", VectorOfVectors(is_high_aoe[hitsel])
+                        "geds/psd_psl/is_high_aoe", VectorOfVectors(is_high_aoe[hitsel])
                     )
                 # compute multiplicity
                 geds_multiplicity = ak.sum(hitsel, axis=-1)


### PR DESCRIPTION
## Summary

The PSL-based ("detailed") pulse-shape-discrimination path (A/E simulated
from a realistic HPGe pulse-shape library instead of a single analytic
current template) was exercised by **no test** and, because of a dead
config key, ran nowhere. This PR makes it actually execute and asserts it
end-to-end in the l1000 Snakemake workflow (hit + evt tiers), fixing the
latent bugs that surfaced once the path was turned on.

## Background

- The hit-tier `settings.yaml` files declared `has_detailed_psd`, but no
  code reads that key. The live switch is `simulate_psd_with_psl`
  (`hit.py`, `evt.py`, `hit.smk`), which was off everywhere.
- The DAG already builds the realistic PSLs (`hit.smk`'s gate defaulted to
  `True`), so the workflow paid the cost of building them but never
  consumed them.

## Changes

- **Make the switch live**: rename the dead `has_detailed_psd` key to
  `simulate_psd_with_psl` in the dummyprod hit settings (`true` for
  `l1000dsg01`, `false` for `legend`/`l200cfg01`), and align the `hit.smk`
  DAG-gate default with the script default (`False`).
- **Fix the evt-tier consumer** (never executed before): route all
  PSL-derived fields under `geds/psd_psl`, and read `is_bb_like` /
  `is_high_aoe` from `psd_psl/...`. Previously they were read from a
  nonexistent `psd/...` (would crash), and `aoe_corr` was overwriting the
  standard `geds/psd/aoe_corr` field.
- **Harden `load_hpge_realistic_psl`**: return `(None, None)` for a missing
  PSL file instead of raising `FileNotFoundError`, so detectors/runs
  without a library degrade to NaN PSD (mirrors the existing "no maps"
  branch).
- **Test + docs**: `test_l1000_workflow` now asserts the hit
  `hit/V05261B/psd_psl` sub-table (all fields, finite A/E proving the real
  path ran) and the evt `geds/psd_psl` table; documented in the testing
  `AGENTS.md`.

## Validation

- `pre-commit run --all-files`: clean.
- `pixi run -e test test-l1000-workflow`: passes (46/46 steps); realistic
  PSLs are built and consumed, `psd_psl` produced with finite A/E.
- Script-level `test_tier_hit` / `test_tier_evt` and the DAG tests: pass.

## Follow-up (separate repo)

The real `legend-simflow-config` production hit settings likely still carry
the dead `has_detailed_psd` key; it should be renamed to
`simulate_psd_with_psl` there for detailed PSD to run in production.
