### PR TITLE
feat: derive nr_sim_events from the remage stp file

### DIFF
--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -132,6 +132,12 @@ tier skipped). See {ref}`evt-tier-settings-meta` for details.
 
 :::
 
+Each `evt` file also carries a root-level `number_of_simulated_events` scalar,
+forwarded verbatim from the `number_of_simulated_events` field that _remage_
+writes into the `stp` file. The `cvt` tier sums these per-job counts into a
+single `number_of_simulated_events` scalar, which the `pdf` tier reads back as
+`nr_sim_events`.
+
 ### `trigger/` — event metadata
 
 Constant fields identifying each event.
@@ -241,9 +247,9 @@ attribute in the LH5 attrs.
 
 ### Root-level fields
 
-| Field           | Type     | Units | Description                                                                                                                        |
-| --------------- | -------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `nr_sim_events` | `Scalar` | —     | Total number of simulated primary events (`primaries_per_job` × `number_of_jobs`). Used to normalise PDFs to physical event rates. |
+| Field           | Type     | Units | Description                                                                                                                                                                                                                             |
+| --------------- | -------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nr_sim_events` | `Scalar` | —     | Total number of simulated primary events, read from the `number_of_simulated_events` scalar that _remage_ stores in each `stp` file and that is summed over all jobs at the `cvt` tier. Used to normalise PDFs to physical event rates. |
 
 ### `pdf/` — histogram struct
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ reboost = ">=0.12.2,<0.13"
 particle = "<1"
 
 # tier stp
-remage = ">=0.19.5,<0.20"
+remage = ">=0.24,<0.25"
 
 # drift-time maps and other SSD.jl jobs
 julia = ">=1.12,<1.13"

--- a/tests/dummyprod/inputs/simprod/config/tier/stp/l1000dsg01/template.mac
+++ b/tests/dummyprod/inputs/simprod/config/tier/stp/l1000dsg01/template.mac
@@ -19,8 +19,8 @@
 /RMG/Output/Scintillator/StoreSinglePrecisionEnergy
 /RMG/Output/Vertex/StoreSinglePrecisionPosition
 
-# do not track optical photons if no energy in germanium
-/RMG/Output/Germanium/DiscardPhotonsIfNoGermaniumEdep
+# drop deferred (e.g. optical photon) tracks if no energy in germanium
+/RMG/Output/Germanium/DiscardWaitingTracksUnlessGermaniumEdep
 
 # do not store events with no energy deposition in germanium
 /RMG/Output/Germanium/EdepCutLow 1 eV

--- a/tests/dummyprod/inputs/simprod/config/tier/stp/l200cfg01/template.mac
+++ b/tests/dummyprod/inputs/simprod/config/tier/stp/l200cfg01/template.mac
@@ -19,8 +19,8 @@
 /RMG/Output/Scintillator/StoreSinglePrecisionEnergy
 /RMG/Output/Vertex/StoreSinglePrecisionPosition
 
-# do not track optical photons if no energy in germanium
-/RMG/Output/Germanium/DiscardPhotonsIfNoGermaniumEdep
+# drop deferred (e.g. optical photon) tracks if no energy in germanium
+/RMG/Output/Germanium/DiscardWaitingTracksUnlessGermaniumEdep
 
 # do not store events with no energy deposition in germanium
 /RMG/Output/Germanium/EdepCutLow 1 eV

--- a/tests/scripts/test_tier_cvt.py
+++ b/tests/scripts/test_tier_cvt.py
@@ -4,9 +4,10 @@ import sys
 from pathlib import Path
 
 import lh5
+import numpy as np
 import pytest
 import yaml
-from lgdo import Scalar, Struct, Table
+from lgdo import Array, Scalar, Struct, Table
 
 from legendsimflow.scripts.tier import cvt
 
@@ -57,21 +58,19 @@ def test_union_detector_uids_uid_collision_raises(tmp_path):
         cvt.union_detector_uids([f1, f2])
 
 
-def test_cvt_script_cli(tmp_path, monkeypatch):
+def _write_config(tmp_path: Path) -> Path:
     config_path = tmp_path / "simflow-config.yaml"
     raw_config = yaml.safe_load((dummyprod / "simflow-config.yaml").read_text())
     raw_config["paths"]["metadata"] = str(dummyprod / "inputs")
     config_path.write_text(yaml.safe_dump(raw_config))
+    return config_path
 
-    evt_file = tmp_path / "evt.lh5"
-    lh5.write(Table(), "evt", evt_file, wo_mode="write_safe")
 
-    cvt_file = tmp_path / "cvt.lh5"
-
+def _run_cvt(monkeypatch, evt_files: list[Path], cvt_file: Path, config_path: Path):
     argv = [
         "cvt",
         "--evt-files",
-        str(evt_file),
+        *[str(f) for f in evt_files],
         "--cvt-file",
         str(cvt_file),
         "--simflow-config",
@@ -80,5 +79,43 @@ def test_cvt_script_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", argv)
     cvt.main()
 
+
+def test_cvt_script_cli(tmp_path, monkeypatch):
+    config_path = _write_config(tmp_path)
+
+    evt_file = tmp_path / "evt.lh5"
+    lh5.write(Table(), "evt", evt_file, wo_mode="write_safe")
+    lh5.write(Scalar(1000), "number_of_simulated_events", evt_file, wo_mode="append")
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _run_cvt(monkeypatch, [evt_file], cvt_file, config_path)
+
     assert cvt_file.exists()
     assert "evt" in lh5.ls(cvt_file)
+    # the single-file copy path must preserve number_of_simulated_events
+    assert lh5.read("number_of_simulated_events", cvt_file).value == 1000
+
+
+def test_cvt_script_cli_sums_number_of_events(tmp_path, monkeypatch):
+    """With multiple evt files, number_of_events is summed across jobs."""
+    config_path = _write_config(tmp_path)
+
+    evt_files = []
+    for i, n in enumerate((1000, 2500)):
+        evt_file = tmp_path / f"evt_{i}.lh5"
+        lh5.write(
+            Table(col_dict={"x": Array(np.arange(3, dtype="int32"))}),
+            "evt",
+            evt_file,
+            wo_mode="write_safe",
+        )
+        _write_detector_uids(evt_file, {"V01": 11})
+        lh5.write(Scalar(n), "number_of_simulated_events", evt_file, wo_mode="append")
+        evt_files.append(evt_file)
+
+    cvt_file = tmp_path / "cvt.lh5"
+    _run_cvt(monkeypatch, evt_files, cvt_file, config_path)
+
+    assert cvt_file.exists()
+    assert "evt" in lh5.ls(cvt_file)
+    assert lh5.read("number_of_simulated_events", cvt_file).value == 3500

--- a/tests/scripts/test_tier_pdf.py
+++ b/tests/scripts/test_tier_pdf.py
@@ -14,12 +14,22 @@ from legendsimflow.scripts.tier import pdf
 
 dummyprod = Path(__file__).parent.parent / "dummyprod"
 
+# number of simulated primary events stored in the synthetic cvt files; the pdf
+# script reads it back and writes it as ``nr_sim_events``.
+_N_SIM_EVENTS = 1000
 
-def _write_detector_uids(path: Path, names: list[str], uids: list[int]) -> None:
+
+def _write_cvt_root(
+    path: Path, names: list[str], uids: list[int], n_sim_events: int = _N_SIM_EVENTS
+) -> None:
+    """Write the cvt root metadata: detector_uids and number_of_simulated_events."""
     detector_uids = Struct(
         {name: Scalar(int(uid)) for name, uid in zip(names, uids, strict=True)}
     )
     lh5.write(detector_uids, "detector_uids", path, wo_mode="append")
+    lh5.write(
+        Scalar(n_sim_events), "number_of_simulated_events", path, wo_mode="append"
+    )
 
 
 _SIMID_LEGEND = "birds_nest_K40"
@@ -119,7 +129,7 @@ def _make_cvt_file(path: Path) -> None:
     coincident = Table(col_dict={"spms": spms})
     evt = Table(col_dict={"geds": geds, "coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
-    _write_detector_uids(path, ["V01", "B02"], [1, 2])
+    _write_cvt_root(path, ["V01", "B02"], [1, 2])
 
 
 def test_pdf_script_cli(tmp_path, monkeypatch):
@@ -133,6 +143,8 @@ def test_pdf_script_cli(tmp_path, monkeypatch):
     assert "nr_sim_events" in root_keys
     nr_sim_events = lh5.read("nr_sim_events", pdf_file)
     assert np.issubdtype(type(nr_sim_events.value), np.integer)
+    # the pdf script must read number_of_events back from the cvt file
+    assert nr_sim_events.value == _N_SIM_EVENTS
 
     inner_keys = lh5.ls(pdf_file, "pdf/")
     for name in (
@@ -218,7 +230,7 @@ def _make_cvt_file_no_spms(path: Path) -> None:
     )
     evt = Table(col_dict={"geds": geds, "coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
-    _write_detector_uids(path, ["V01", "B02"], [1, 2])
+    _write_cvt_root(path, ["V01", "B02"], [1, 2])
 
 
 def _make_cvt_file_no_geds(path: Path) -> None:
@@ -229,7 +241,7 @@ def _make_cvt_file_no_geds(path: Path) -> None:
     evt = Table(col_dict={"coincident": coincident})
     lh5.write(evt, "evt", path, wo_mode="write_safe")
     # detector_uids is still present (skip_hit produces an empty mapping at evt tier)
-    _write_detector_uids(path, [], [])
+    _write_cvt_root(path, [], [])
 
 
 def test_pdf_script_cli_skip_opt(tmp_path, monkeypatch):

--- a/workflow/src/legendsimflow/scripts/tier/cvt.py
+++ b/workflow/src/legendsimflow/scripts/tier/cvt.py
@@ -102,6 +102,8 @@ def main() -> None:
     log.info("starting cvt merge")
 
     if len(evt_files) == 1:
+        # the single evt file already carries the root-level
+        # number_of_simulated_events scalar, which is copied along verbatim.
         shutil.copy(evt_files[0], cvt_file)
     else:
         # detector_uids may differ across jobs because low-rate decays can leave
@@ -113,10 +115,24 @@ def main() -> None:
         lh5.write(merged, "detector_uids", cvt_file, wo_mode="write_safe")
 
         for table in lh5.ls(evt_files[0]):
-            if table == "detector_uids":
+            # number_of_simulated_events is a root-level scalar summed below,
+            # not a table
+            if table in ("detector_uids", "number_of_simulated_events"):
                 continue
             for chunk in lh5.LH5Iterator(evt_files, table, buffer_len=buffer_len):
                 lh5.write(chunk, table, cvt_file, wo_mode="append")
+
+        # total number of simulated primary events for this simid is the sum of
+        # the per-job counts forwarded from the stp files by the evt tier.
+        total_n_events = sum(
+            int(lh5.read("number_of_simulated_events", f).value) for f in evt_files
+        )
+        lh5.write(
+            Scalar(total_n_events),
+            "number_of_simulated_events",
+            cvt_file,
+            wo_mode="append",
+        )
 
     move2cfs()
 

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -647,6 +647,16 @@ def main() -> None:
     )
     lh5.write(detector_uids, "detector_uids", evt_file, wo_mode="append")
 
+    # forward the number of simulated primary events that remage stores at the
+    # root of the stp file, so it can be summed across jobs at the cvt tier and
+    # used to normalise the pdf histograms.
+    lh5.write(
+        lh5.read("number_of_simulated_events", stp_file),
+        "number_of_simulated_events",
+        evt_file,
+        wo_mode="append",
+    )
+
     with perf_block("move_to_cfs()"):
         move2cfs()
 

--- a/workflow/src/legendsimflow/scripts/tier/opt.py
+++ b/workflow/src/legendsimflow/scripts/tier/opt.py
@@ -260,7 +260,7 @@ def main() -> None:
             msg = f"looking for data from sensitive volume {det_name} table (uid={geom_meta.uid})..."
             log.debug(msg)
 
-            if f"stp/{det_name}" not in lh5.ls(stp_file, "*/*"):
+            if f"stp/{det_name}" not in lh5.ls(stp_file, "stp/*"):
                 msg = (
                     f"detector {det_name} not found in {stp_file}. "
                     "possibly because it was not read-out or there were no hits recorded"

--- a/workflow/src/legendsimflow/scripts/tier/pdf.py
+++ b/workflow/src/legendsimflow/scripts/tier/pdf.py
@@ -28,7 +28,7 @@ from lgdo import Histogram, Scalar, Struct
 from snakemake_argparse_bridge import snakemake_compatible
 
 from legendsimflow import nersc, utils
-from legendsimflow.metadata import get_simconfig, get_tier_settings
+from legendsimflow.metadata import get_tier_settings
 from legendsimflow.scripts import log_script_invocation
 
 
@@ -64,7 +64,6 @@ def main() -> None:
     cvt_file = nersc.dvs_ro(config, args.cvt_file)
     pdf_file = args.pdf_file
     log_file = args.log_file
-    simid = args.simid
 
     log = ldfs.utils.build_log(config.metadata.simprod.config.logging, log_file)
     log_script_invocation(log, "tier-pdf", parser, args)
@@ -108,13 +107,16 @@ def main() -> None:
         buffer_len=buffer_len,
     )
 
-    # TODO: in future, read number_of_primaries directly from the stp file
-    simconfig_block = get_simconfig(config, "stp", simid)
-    number_of_primaries = (
-        simconfig_block.primaries_per_job * simconfig_block.number_of_jobs
+    # the number of simulated primary events is written by remage at the root
+    # of each stp file, forwarded through the evt tier and summed over all jobs
+    # at the cvt tier.
+    number_of_primaries = int(
+        lh5.read("number_of_simulated_events", str(cvt_file)).value
     )
 
-    log.info("... extracted number of primaries from simconfig %s", number_of_primaries)
+    log.info(
+        "... read number of simulated events from cvt file %s", number_of_primaries
+    )
 
     # 1 keV/bin over 0-6000 keV; boost-histogram only provides Double (float64) storage
     h1 = hist.new.Reg(6000, 0, 6000).Double


### PR DESCRIPTION
## Summary

Fixes #201. The `pdf` tier normalises its histograms by the number of simulated
primary events. Until now this was the *requested* count derived from the
simconfig (`primaries_per_job × number_of_jobs`), which can differ from the
number of events actually simulated.

remage (≥ 0.23) writes the real count as a root-level `number_of_simulated_events`
scalar in each `stp` file. This PR forwards that value through the tiers and uses
it instead.

## Changes

**Propagation (issue #201)**
- `evt`: copy `number_of_simulated_events` from the `stp` file to the `evt` output
- `cvt`: sum the per-job scalars over all `evt` files of a simid
- `pdf`: read the summed value from the `cvt` file and write it as `nr_sim_events`
  (drops the old simconfig computation)

**remage 0.24 upgrade** (separate commit)

The feature requires remage ≥ 0.23; this bumps the pin to `>=0.24,<0.25` and
fixes the two breaking changes that the upgrade surfaced:
- the `/RMG/Output/Germanium/DiscardPhotonsIfNoGermaniumEdep` macro command was
  renamed to `DiscardWaitingTracksUnlessGermaniumEdep` (test template macros updated)
- the new root-level scalar broke `lh5.ls(stp_file, "*/*")` in the `opt` tier;
  the glob is now scoped to `stp/*`, matching the `hit` tier

> [!NOTE]
> The macro-command rename is a remage-side breaking change: real production
> `template.mac` files (user metadata, not in this repo) using
> `DiscardPhotonsIfNoGermaniumEdep` must be updated when moving to remage 0.24.

## Validation
- Full `test_l1000_workflow` integration test passes against real remage 0.24.0
  (vtx→pdf); verified the value propagates: stp `1000` → evt `1000` → cvt `1000`
  → pdf `nr_sim_events` `1000`
- Added a `cvt` multi-file summing unit test and a `pdf` read-back assertion;
  synthetic test fixtures now carry the scalar
- `pre-commit run --all-files` clean