### PR TITLE
build(deps): bump reboost to >=0.12.3, drop particle <1 workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,7 @@ dependencies = [
     "pygama >=2.3.6",
     "pylegendmeta >=1.4.4",
     "pyyaml",
-    "reboost >=0.12.2,<0.13",
-    # particle 1.0 made charge() return a Fraction, which numba cannot type in reboost
-    "particle <1",
+    "reboost >=0.12.3,<0.13",
     "revertex >=0.1.2",
     "ruamel.yaml",
     "snakemake >=9.19,<9.20",
@@ -144,9 +142,7 @@ mplhep = ">=1.0"
 legend-pygeom-hpges = ">=0.9,<0.10"
 pyg4ometry = "*"
 pygama = ">=2.3.6,<2.4"
-reboost = ">=0.12.2,<0.13"
-# particle 1.0 made charge() return a Fraction, which numba cannot type in reboost
-particle = "<1"
+reboost = ">=0.12.3,<0.13"
 
 # tier stp
 remage = ">=0.24,<0.25"


### PR DESCRIPTION
## Summary

- Removes the temporary `particle <1` pin introduced in #266 (commit 7b5d336)
- Bumps the reboost minimum from `0.12.2` to `0.12.3`

reboost 0.12.3 fixes the numba JIT incompatibility with `particle >= 1` by
patching `pdg_func.charge` with a float-returning wrapper at import time when
`particle >= 1` is detected (`optmap/numba_pdg.py`), so numba can type it in
nopython mode.

Closes #268.