### PR TITLE
feat: geometry validation plots in the stp tier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
     "legend-dataflow-scripts >=0.3.0a5",
     "legend-lh5io >=0.2",
     "legend-pydataobj >=2",
-    "legend-pygeom-l200 >=0.8.4",
-    "legend-pygeom-tools >=0.2",
+    "legend-pygeom-l200 >=0.10.1",
+    "legend-pygeom-tools >=0.5",
     "legend-pygeom-hpges >=0.9",
     "matplotlib",
     "mplhep >=1.0",
@@ -118,8 +118,8 @@ dbetto = ">=1.3.3"
 # legend-dataflow-scripts = "..."  # not on conda-forge
 legend-lh5io = ">=0.2,<0.3"
 legend-pydataobj = ">=2,<2.1"
-legend-pygeom-l200 = ">=0.8.4,<0.9"
-legend-pygeom-tools = ">=0.2,<0.3"
+legend-pygeom-l200 = ">=0.10.1,<0.11"
+legend-pygeom-tools = ">=0.5,<0.6"
 dspeed = ">=2.1.4,<2.2"
 matplotlib = "*"
 numpy = "*"
@@ -143,6 +143,8 @@ legend-pygeom-hpges = ">=0.9,<0.10"
 pyg4ometry = "*"
 pygama = ">=2.3.6,<2.4"
 reboost = ">=0.12.3,<0.13"
+# software OpenGL (OSMesa) for the head-less stp geometry rendering
+mesalib = "*"
 
 # tier stp
 remage = ">=0.24,<0.25"

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -328,3 +328,9 @@ def test_skip_opt_and_hit_are_mutually_exclusive(tmp_path):
                 settings_by_tier={"evt": {"skip_opt": True, "skip_hit": True}},
             ),
         )
+
+
+def test_geom_plots_scheduled(tmp_path):
+    """The geometry validation plots are scheduled with the stp tier."""
+    rules = dag_rule_names(default_config, overrides(tmp_path))
+    assert "plot_geom" in rules

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import yaml
+from dbetto import AttrsDict
+
+from legendsimflow import geometry
+from legendsimflow.geometry import DEFAULT_VIS_SCENE
+
+
+def _cfg(config_dir, experiment="legend"):
+    return AttrsDict({"paths": {"config": str(config_dir)}, "experiment": experiment})
+
+
+def test_load_vis_scene_default(tmp_path):
+    """Without a metadata override, the built-in default scene is returned."""
+    scene = geometry.load_vis_scene(_cfg(tmp_path))
+    assert scene == DEFAULT_VIS_SCENE
+    # a deep copy is returned: mutating it must not affect the default
+    scene["window_size"][0] = -1
+    assert DEFAULT_VIS_SCENE["window_size"][0] != -1
+
+
+def test_load_vis_scene_override(tmp_path):
+    """A per-experiment metadata file overrides the default per top-level key."""
+    geom = tmp_path / "geom"
+    geom.mkdir()
+    (geom / "legend-vis-config.yaml").write_text(
+        yaml.safe_dump({"window_size": [10, 20]})
+    )
+
+    scene = geometry.load_vis_scene(_cfg(tmp_path))
+    assert scene["window_size"] == [10, 20]
+    # keys not present in the override are kept from the default
+    assert scene["color_overrides"] == DEFAULT_VIS_SCENE["color_overrides"]

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -186,3 +186,27 @@ rule plot_tier_stp_vertices:
     priority: 100  # prioritize producing the needed input files over the others
     script:
         "../src/legendsimflow/scripts/plots/tier_stp_vertices.py"
+
+
+rule plot_geom:
+    """Produce the geometry validation plots (HPGe mass comparison and rendering).
+
+    Both are derived from the `stp` geometry config by
+    {func}`legendsimflow.geometry.make_hpge_mass_plot` and
+    {func}`legendsimflow.geometry.render_geometry`.
+
+    Uses wildcard `simid`.
+    """
+    input:
+        patterns.geom_config_filename(config, tier="stp"),
+    output:
+        mass=patterns.plot_geom_hpge_mass_filename(config),
+        rendering=patterns.plot_geom_rendering_filename(config),
+    run:
+        from dbetto import utils as dbetto_utils
+
+        from legendsimflow import geometry
+
+        geom_config = dbetto_utils.load_dict(input[0])
+        geometry.make_hpge_mass_plot(config, geom_config, output.mass)
+        geometry.render_geometry(config, geom_config, output.rendering)

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -89,7 +89,12 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str):
             patterns.plot_tier_opt_observables_filename(config, simid=simid),
         ]
     if tier == "stp":
-        return [patterns.plot_tier_stp_vertices_filename(config, simid=simid)]
+        # geometry validation plots, a byproduct of the stp geometry build
+        return [
+            patterns.plot_tier_stp_vertices_filename(config, simid=simid),
+            patterns.plot_geom_rendering_filename(config, simid=simid),
+            patterns.plot_geom_hpge_mass_filename(config, simid=simid),
+        ]
     if tier == "par":
         # HPGe drift-time map plots, a byproduct of the par step; only produced
         # when PSD is simulated in the hit tier

--- a/workflow/src/legendsimflow/geometry.py
+++ b/workflow/src/legendsimflow/geometry.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2025 Luigi Pertoldi <gipert@pm.me>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Helpers producing the `stp` geometry validation plots."""
+
+from __future__ import annotations
+
+import copy
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+import dbetto
+
+from . import SimflowConfig, patterns
+
+# NOTE: the heavy plotting/geometry packages (matplotlib, VTK via pyg4ometry /
+# pygeomtools, pygeoml200) are imported lazily inside the two functions below,
+# not at module level, so the module stays light for `load_vis_scene` and tests.
+
+# default scene passed to :func:`pygeomtools.viewer.visualize`. It hides the large
+# opaque enclosures and the outer fiber barrel to expose the detector array,
+# makes the inner fiber barrel translucent, and uses a fixed 3/4 view of the
+# LEGEND-200 array (world frame, mm). Productions can override it (wholesale, per top-level key) with a
+# `<experiment>-vis-config.yaml` file next to the geometry config in the
+# metadata; see :func:`load_vis_scene`. The `fine_mesh` key is handled by the
+# rendering rule (it must be applied before the geometry is built) and the
+# `export_and_exit` output path is injected there too.
+DEFAULT_VIS_SCENE: dict = {
+    "window_size": [1600, 2600],
+    "fine_mesh": True,
+    "light": {"pos": [-5000, 0, 5000], "shadow": True},
+    "default": {
+        "focus": [2.67, -48.24, 711.62],
+        "up": [0.26, -0.27, 1.0],
+        "camera": [-2440.94, 2563.88, 2184.31],
+        "parallel": False,
+    },
+    "color_overrides": {
+        "cryostat_steel": False,
+        "liquid_argon": False,
+        "gaseous_argon": False,
+    },
+}
+
+
+def load_vis_scene(config: SimflowConfig) -> dict:
+    """Return the geometry rendering scene for the current experiment.
+
+    Starts from ``DEFAULT_VIS_SCENE`` and merges (shallow, per top-level key) an
+    optional per-experiment override read from
+    `<paths.config>/geom/<experiment>-vis-config.yaml` in the metadata.
+    """
+    scene = copy.deepcopy(DEFAULT_VIS_SCENE)
+    override = patterns.geom_vis_config_filename(config)
+    if override.exists():
+        scene |= dbetto.utils.load_dict(override)
+    return scene
+
+
+def make_hpge_mass_plot(
+    config: SimflowConfig, geom_config: Mapping, output: str
+) -> None:
+    """Write the simulated-vs-measured HPGe mass comparison plot to *output*.
+
+    Compares the mass of each detector built by {mod}`pygeoml200` to the measured
+    mass in `legend-metadata` (or the public testdata masses for a public
+    geometry).
+    """
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+    from pygeoml200.hpge_mass_check import plot_hpge_mass_comparison  # noqa: PLC0415
+
+    from .plot import decorate  # noqa: PLC0415
+
+    # pygeoml200.hpge_mass_check pulls in VTK (via pygeomtools), which switches
+    # matplotlib to a Qt backend; force the head-less Agg backend back
+    plt.switch_backend("agg")
+
+    os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
+
+    fig, ax = plt.subplots(figsize=(13, 3.5))
+    plot_hpge_mass_comparison(geom_config, ax=ax)
+    decorate(fig, rotate=True)
+    fig.savefig(output, bbox_inches="tight")
+
+
+def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) -> None:
+    """Render the geometry off-screen to *output* (PNG) using :func:`load_vis_scene`.
+
+    Rebuilds the geometry with the light-weight segmented fiber model (the
+    simulation GDML uses the detailed one, far too heavy to render). Rendering
+    goes through the software OSMesa backend, so no GPU or X server is needed.
+    """
+    from pyg4ometry import config as meshconfig  # noqa: PLC0415
+    from pygeoml200 import cli, core  # noqa: PLC0415
+    from pygeomtools import viewer  # noqa: PLC0415
+
+    # software OSMesa off-screen rendering; must be set before the render window
+    # is created
+    os.environ["VTK_DEFAULT_OPENGL_WINDOW"] = "vtkOSOpenGLRenderWindow"
+    os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
+
+    scene = load_vis_scene(config)
+    if scene.pop("fine_mesh", False):  # must be applied before building the geometry
+        meshconfig.setGlobalMeshSliceAndStack(100)
+
+    registry = core.construct(
+        assemblies=cli._parse_assemblies(geom_config.get("assemblies")),
+        use_detailed_fiber_model=False,
+        config=geom_config,
+        public_geometry=geom_config.get("public_geom", False),
+    )
+
+    # `viewer._export_png` refuses to overwrite, so clear a stale target first
+    Path(output).unlink(missing_ok=True)
+    scene["export_and_exit"] = str(output)
+    viewer.visualize(registry, scene)

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -128,6 +128,11 @@ def geom_gdml_filename(config: SimflowConfig, **kwargs) -> Path:
     return _expand(pat, **kwargs)
 
 
+def geom_vis_config_filename(config: SimflowConfig) -> Path:
+    """The path to the optional geometry rendering vis config for the experiment."""
+    return Path(config.paths.config) / "geom" / (config.experiment + "-vis-config.yaml")
+
+
 def geom_log_filename(config: SimflowConfig, **kwargs) -> str:
     """The log file path for geometry generation for a `tier` and `simid`."""
     pat = (
@@ -221,6 +226,20 @@ def plot_tier_stp_vertices_filename(config: SimflowConfig, **kwargs) -> Path:
     """The path to the primary vertex validation plot for a `stp` `simid`."""
     return _expand(
         plots_dirname(config, "stp") / "{simid}-tier-stp-vertices.pdf", **kwargs
+    )
+
+
+def plot_geom_hpge_mass_filename(config: SimflowConfig, **kwargs) -> Path:
+    """The path to the simulated-vs-measured HPGe mass plot for a `stp` `simid`."""
+    return _expand(
+        plots_dirname(config, "stp") / "{simid}-tier-stp-geom-hpge-mass.pdf", **kwargs
+    )
+
+
+def plot_geom_rendering_filename(config: SimflowConfig, **kwargs) -> Path:
+    """The path to the geometry rendering for a `stp` `simid`."""
+    return _expand(
+        plots_dirname(config, "stp") / "{simid}-tier-stp-geom-rendering.png", **kwargs
     )
 
 

--- a/workflow/src/legendsimflow/plot.py
+++ b/workflow/src/legendsimflow/plot.py
@@ -31,16 +31,41 @@ USABILITY_COLOR = {
 }
 
 
-def decorate(fig):
-    fig.text(
-        1,
-        0,
-        f"legend-simflow · {date.today().isoformat()}",
-        ha="right",
-        va="bottom",
-        fontsize=8,
-        color="0.4",
-    )
+def decorate(fig, rotate=False):
+    """Add the ``legend-simflow`` watermark to *fig*.
+
+    By default it sits horizontally at the bottom-right corner; with `rotate` it
+    is placed vertically (rotated 90°) along the right edge.
+    """
+    text = f"legend-simflow · {date.today().isoformat()}"
+    if rotate:
+        # place it vertically just outside the right spine of the (last) axes,
+        # following the legend-styles watermark convention (the offset is in
+        # font-size units, so it scales with the font)
+        fig.axes[-1].annotate(
+            text,
+            xy=(1, 1),
+            xytext=(1.1, 0),
+            xycoords="axes fraction",
+            textcoords="offset fontsize",
+            rotation=270,
+            rotation_mode="anchor",
+            ha="left",
+            va="top",
+            fontsize=8,
+            color="0.4",
+            annotation_clip=False,
+        )
+    else:
+        fig.text(
+            1,
+            0,
+            text,
+            ha="right",
+            va="bottom",
+            fontsize=8,
+            color="0.4",
+        )
 
 
 def save_page(pdf, make_fig):


### PR DESCRIPTION
## Summary

Two per-`simid` geometry validation plots produced alongside the `stp` geometry
build:

- **`plot_geom_hpge_mass`** — simulated-vs-measured HPGe mass comparison
  (`(MC - measured) / measured` per detector, grouped by manufacturer), via
  `pygeoml200.hpge_mass_check.plot_hpge_mass_comparison`. Works for real
  geometries and, with `legend-pygeom-l200 >=0.10.1`, for public/testdata
  geometries too.
- **`plot_geom_rendering`** — head-less VTK rendering of the geometry (rebuilt
  with the light-weight segmented fiber model), via the public
  `pygeomtools.viewer.visualize`.

Both are `run:` rules keyed on the stp geometry config and added to the stp plot
list.

## Head-less rendering

The render runs off-screen through **software OSMesa**: `mesalib` is added to the
pixi env and the rule forces `VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow`,
so no GPU or X server is required (compute nodes, CI). No dependency on any
upstream `pygeom-tools` change.

## Configurable render scene

The scene (`window_size`, `fine_mesh`, `light`, camera, `color_overrides`) lives
in `legendsimflow.geometry.DEFAULT_VIS_SCENE` and can be overridden per
experiment with a `<config>/geom/<experiment>-vis-config.yaml` file in the
metadata (`load_vis_scene`). The default hides the enclosures, makes the outer
fiber shroud translucent, and uses a fixed 3/4 view of the array.

## Dependencies

- `legend-pygeom-l200 >=0.10.1` (mass comparison, incl. public geometry)
- `legend-pygeom-tools >=0.5` (required by pygeom-l200 0.10)
- `mesalib` (software OSMesa for head-less rendering)

## Testing

- `tests/test_dag.py::test_geom_plots_scheduled` — both plots enter the DAG.
- `tests/test_geometry.py` — vis-scene default / metadata override.
- The `test_l1000_workflow` integration test exercises both plots end-to-end
  under the public geometry.