### PR TITLE
feat: warm Numba caches serially to avoid concurrent-compilation segfaults

### DIFF
--- a/docs/source/developer.md
+++ b/docs/source/developer.md
@@ -252,6 +252,31 @@ After adding the script, also:
 3. **Add a test** in `tests/scripts/test_tier_foo.py` following the pattern in
    `tests/scripts/test_tier_cvt.py`.
 
+## Warming Numba caches
+
+Numba `@njit(cache=True)` kernels are compiled to machine code and written to a
+shared on-disk cache only on their **first call** with a given type signature.
+Importing the module merely defines the kernel; it does not compile it. When
+many parallel Snakemake jobs hit an uncached kernel at once, they race to write
+the same cache file and segfault.
+
+The `legendsimflow.warmup` module (run by the `warmup` pixi task, a `depends-on`
+prerequisite of the production and test tasks) sidesteps this by calling every
+such kernel once, serially, before the parallel fan-out, so the jobs only ever
+read the cache.
+
+:::{important}
+
+Whenever you add code that calls a new lazily-compiled `@njit(cache=True)`
+kernel from a rule that runs in parallel (whether defined here or in a
+dependency such as `reboost`), add a call to it in
+{func}`legendsimflow.warmup.warm_numba_caches`, using the **exact** argument
+dtypes seen at run time (Numba caches per type signature). Verify with
+`NUMBA_DEBUG_CACHE=1 pixi run warmup` that the kernel's `.nbc`/`.nbi` files get
+written.
+
+:::
+
 ## Contributing
 
 ### Git workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,8 +160,8 @@ default = { solve-group = "default" }
 test = { features = ["test"], solve-group = "default" }
 
 [tool.pixi.tasks]
-snakemake = { cmd = "snakemake", depends-on = ["precompile"] }
-snakemake-nersc = { cmd = "snakemake-nersc", depends-on = ["precompile"] }
+snakemake = { cmd = "snakemake", depends-on = ["warmup"] }
+snakemake-nersc = { cmd = "snakemake-nersc", depends-on = ["warmup"] }
 dry = { cmd = "snakemake --dry-run" }
 touch = { cmd = "snakemake --touch" }
 
@@ -180,31 +180,31 @@ args = [
   {arg = "profile", default = "default"},
   {arg = "logger", default = "snkmt rich"},
 ]
-depends-on = ["precompile"]
+depends-on = ["warmup"]
 
 [tool.pixi.tasks.prodnodes]
 # NOTE: snkmt does not work here because of race condition
 cmd = "snakemake-nersc --nodes {{ n_nodes }}"
 args = ["n_nodes"]
-depends-on = ["precompile"]
+depends-on = ["warmup"]
 
 [tool.pixi.tasks.prodsubmit]
-# NOTE: no need to depend on precompile since this command calls `pixi run
+# NOTE: no need to depend on warmup since this command calls `pixi run
 # snakemake[-nersc]` internally
 cmd = "snakemake-nersc-batch"
 
-[tool.pixi.tasks.precompile]
-cmd = "python -c 'from dspeed.processors import *; from lh5.compression import *; import matplotlib; import pygama; import pygeomhpges; import pygeomoptics; import pygeomtools; import reboost; import remage; import revertex' && touch .pixi/precompile.stamp"
-outputs = [".pixi/precompile.stamp"]
+[tool.pixi.tasks.warmup]
+cmd = "python -m legendsimflow.warmup && touch .pixi/warmup.stamp"
+outputs = [".pixi/warmup.stamp"]
 
 [tool.pixi.feature.test.tasks]
 test-python = { cmd = "pytest -vvv" }
 init-julia-env = { cmd = "julia --project=workflow/src/LegendSimflow.jl workflow/src/legendsimflow/scripts/init-julia-env.jl && touch .pixi/julia-env.stamp", outputs = [".pixi/julia-env.stamp"] }
 test-julia = { cmd = "julia --project=. -e 'using Pkg; Pkg.test()'", cwd = "workflow/src/LegendSimflow.jl", depends-on = ["init-julia-env"] }
 test-julia-ci = { cmd = "julia --code-coverage=user --project=. -e 'using Pkg; Pkg.test(coverage=true)'", cwd = "workflow/src/LegendSimflow.jl", depends-on = ["init-julia-env"] }
-test-python-pixi = { cmd = "pytest -vvv -m 'not needs_nersc' --ignore=tests/test_workflow.py --cov=legendsimflow --cov-report=xml", depends-on = ["precompile", "init-julia-env"] }
-test-l1000-workflow = { cmd = "pytest -s -m 'needs_remage and not needs_nersc' tests/test_workflow.py::test_l1000_workflow", depends-on = ["precompile"] }
-test-l200-workflow = { cmd = "pytest -s -m needs_nersc", depends-on = ["precompile"] }
+test-python-pixi = { cmd = "pytest -vvv -m 'not needs_nersc' --ignore=tests/test_workflow.py --cov=legendsimflow --cov-report=xml", depends-on = ["warmup", "init-julia-env"] }
+test-l1000-workflow = { cmd = "pytest -s -m 'needs_remage and not needs_nersc' tests/test_workflow.py::test_l1000_workflow", depends-on = ["warmup"] }
+test-l200-workflow = { cmd = "pytest -s -m needs_nersc", depends-on = ["warmup"] }
 test = { depends-on = ["test-python", "test-julia"] }
 
 [tool.uv.workspace]

--- a/workflow/AGENTS.md
+++ b/workflow/AGENTS.md
@@ -15,6 +15,11 @@
   Avoid using it repeatedly in functions invoked at Snakemake DAG build time.
   `LegendMetadata.channelmap()` also calls `.on()`. Consider caching strategies
   instead
+- When adding code that calls a new lazily-compiled `@njit(cache=True)` kernel
+  from a rule that runs in parallel (here or in a dependency like `reboost`),
+  add a call to it in `warm_numba_caches` (`legendsimflow/warmup.py`) with the
+  exact runtime dtypes, else parallel jobs race the on-disk cache and segfault.
+  Verify with `NUMBA_DEBUG_CACHE=1 pixi run warmup`. See `developer.md`.
 - Other conventions are enforced by pre-commit
 
 ## Resource constraints

--- a/workflow/src/legendsimflow/warmup.py
+++ b/workflow/src/legendsimflow/warmup.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2025 Luigi Pertoldi <gipert@pm.me>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Serial warmup of heavy dependencies and Numba caches.
+
+Run once before the parallel Snakemake jobs (via ``python -m
+legendsimflow.warmup``, wired to the ``warmup`` pixi task). A lazily-compiled
+``@njit(cache=True)`` kernel is compiled and written to a shared on-disk cache
+only on its first *call*; parallel jobs racing to write it segfault. Warming
+each kernel once here leaves them only reading the cache.
+"""
+# heavy imports are for their side effects, all inside the warmup function
+# ruff: noqa: F401, ICN001, PLC0415
+
+from __future__ import annotations
+
+
+def warm_numba_caches() -> None:
+    """Warm the heavy imports and the Numba kernels the workflow calls."""
+    # importing these pays their one-off cost (Matplotlib font cache, ...) and
+    # compiles their vectorized kernels (dspeed/lh5 were ``import *``, illegal
+    # inside a function; a plain import triggers the same compilation)
+    import dspeed.processors
+    import lh5.compression
+    import matplotlib
+    import numpy as np
+    import pygama
+    import pygeomhpges
+    import pygeomoptics
+    import pygeomtools
+    import reboost
+    import remage
+    import revertex
+
+    # lazily-compiled kernels must be called once, with the exact runtime type
+    # signature (Numba caches per signature). These are the only cache=True
+    # kernels the parallel rules reach.
+    from reboost.hpge.psd import _current_pulse_model
+
+    from .reboost import _cluster_photoelectrons_flat
+
+    # currmod fit: float64 time array + seven float64 scalars
+    _current_pulse_model(
+        np.linspace(-500.0, 1500.0, 16), 1.0, 0.0, 60.0, 0.6, 100.0, 0.2, 60.0
+    )
+    # opt tier: int64 list offsets, float64 time/amplitude content
+    _cluster_photoelectrons_flat(
+        np.array([0, 2, 3], dtype=np.int64),
+        np.array([0.0, 1.0, 5.0]),
+        np.array([1.0, 2.0, 3.0]),
+        10.0,
+    )
+
+
+if __name__ == "__main__":
+    warm_numba_caches()


### PR DESCRIPTION
Closes #190.

## Problem

`@numba.njit(cache=True)` kernels are compiled to machine code and written to a shared on-disk cache only on their first *call* with a given type signature. Importing the module merely *defines* the kernel; it does not compile it. When many parallel Snakemake jobs all hit an uncached kernel at once, they race to write the same cache file and segfault (issue #190, observed in the current-pulse-model extraction).

The old `precompile` pixi task only *imported* a list of heavy modules, so it never actually warmed these lazily-compiled kernels.

## Fix

Move the task's code into a dedicated `legendsimflow.warmup` module and rename the pixi task `precompile` -> `warmup` (it is already a `depends-on` prerequisite of the `snakemake`/`prod`/test tasks, so it runs once, serially, before the parallel fan-out).

The module now *calls* every lazily-compiled `cache=True` kernel the workflow reaches, with the exact runtime type signature, so the parallel jobs only ever read the cache:

- `reboost.hpge.psd._current_pulse_model` (+ the transitive `_njit_erf`) — current-pulse-model extraction
- `legendsimflow.reboost._cluster_photoelectrons_flat` — opt tier

The heavy imports that trigger vectorized-kernel compilation already at import time (`dspeed.processors`, `lh5.compression`, ...) are kept.

## Audit of the race surface

I checked the full disk-cache race surface, not just the reported crash:

- `dspeed`, `lh5`, `pygama`, `legendhpges` carry **no** `cache=True` kernels, so no disk-cache race there.
- **None** of reboost's `cache=True` kernels compile at import (verified with `NUMBA_DEBUG_CACHE=1`), so importing never warms them.
- Tracing every parallel-run script (hit/evt/opt tiers, currmod, realistic-PSL), the only `cache=True` kernels actually reached are the two warmed here. The remaining reboost kernels (optmap create/convolve, surface diffusion, DAQ, pulse-shape/drift-map building) belong to steps this workflow does not run or loads as pre-built inputs.

## Verification

- `pixi run warmup` writes the `.nbc`/`.nbi` files for all three kernels; a fresh process then loads them from cache instead of recompiling.
- `pre-commit run --all-files` passes; `pixi run test-python` passes (the two failing plotting tests are a pre-existing matplotlib tight-layout warning, unrelated to this change and failing identically on the base branch).

## Note on docs

Issue #190 also floats a docs "Troubleshooting" section. This PR removes the root cause, so that is no longer needed for this specific segfault; happy to add a short note if you still want one.
