### PR TITLE
fix: re-initialize Julia env when Project.toml changes

### DIFF
--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -75,11 +75,17 @@ rule print_benchmark_stats:
 
 
 # we use a dedicated dummy rule to initialize the Julia environment, in this
-# way it's still possible to use Julia from a rule-specific conda env
+# way it's still possible to use Julia from a rule-specific conda env.
+#
+# Project.toml is an input so that editing it re-triggers instantiate; without it
+# the input-less rule would be considered permanently up-to-date. Manifest.toml
+# is gitignored (regenerated locally) so it must not be declared here.
 rule _init_julia_env:
     localrule: True
     message:
         "Initializing Julia environment"
+    input:
+        "workflow/src/LegendSimflow.jl/Project.toml",
     output:
         config.paths.generated / ".julia-env-initialized",
     log:

--- a/workflow/src/legendsimflow/scripts/init-julia-env.jl
+++ b/workflow/src/legendsimflow/scripts/init-julia-env.jl
@@ -20,5 +20,17 @@ if !ispath(joinpath(first(DEPOT_PATH), "registries", "LegendJuliaRegistry"))
     Pkg.Registry.add(url = "https://github.com/legend-exp/LegendJuliaRegistry.git")
 end
 
+# If Project.toml changed since the (gitignored) Manifest was resolved,
+# regenerate the Manifest from scratch so a re-run picks up the updated packages.
+# A plain instantiate() would silently keep the stale versions and resolve()
+# refuses to upgrade already-pinned packages; only a fresh resolve honors a
+# bumped compat bound.
+proj = dirname(Base.active_project())
+if Pkg.is_manifest_current(proj) !== true
+    @info("Project.toml changed, regenerating the Julia environment")
+    Pkg.Registry.update()
+    rm(joinpath(proj, "Manifest.toml"); force = true)
+end
+
 Pkg.instantiate()
 Pkg.precompile()

--- a/workflow/src/legendsimflow/warmup.py
+++ b/workflow/src/legendsimflow/warmup.py
@@ -20,7 +20,8 @@ legendsimflow.warmup``, wired to the ``warmup`` pixi task). A lazily-compiled
 only on its first *call*; parallel jobs racing to write it segfault. Warming
 each kernel once here leaves them only reading the cache.
 """
-# heavy imports are for their side effects, all inside the warmup function
+# heavy imports are kept inside the function so importing this module stays
+# cheap (e.g. sphinx autodoc can import it without the full runtime stack).
 # ruff: noqa: F401, ICN001, PLC0415
 
 from __future__ import annotations
@@ -29,8 +30,7 @@ from __future__ import annotations
 def warm_numba_caches() -> None:
     """Warm the heavy imports and the Numba kernels the workflow calls."""
     # importing these pays their one-off cost (Matplotlib font cache, ...) and
-    # compiles their vectorized kernels (dspeed/lh5 were ``import *``, illegal
-    # inside a function; a plain import triggers the same compilation)
+    # compiles their vectorized kernels
     import dspeed.processors
     import lh5.compression
     import matplotlib
@@ -42,6 +42,16 @@ def warm_numba_caches() -> None:
     import reboost
     import remage
     import revertex
+
+    # dspeed.processors/lh5.compression expose their members lazily (PEP 562), so
+    # a plain import leaves their eager @guvectorize kernels (e.g.
+    # moving_window_multi, used by the parallel realistic-PSL rule) uncompiled and
+    # the parallel jobs race the cache and segfault. The precompile task this
+    # replaced used `import *` to force every name to load and compile; `import *`
+    # is illegal inside a function, so reproduce it by materializing __all__.
+    for _module in (dspeed.processors, lh5.compression):
+        for _name in _module.__all__:
+            getattr(_module, _name)
 
     # lazily-compiled kernels must be called once, with the exact runtime type
     # signature (Numba caches per signature). These are the only cache=True


### PR DESCRIPTION
The `_init_julia_env` rule had no inputs, so once its `.julia-env-initialized` sentinel existed Snakemake treated the rule as permanently up-to-date. Editing `workflow/src/LegendSimflow.jl/Project.toml` therefore never re-ran the environment initialization. Goal: run a production, later update `Project.toml`, re-run, and get the updated packages installed and used.

## Changes

- **`aux.smk`**: declare `Project.toml` as an input of `_init_julia_env`, so editing it invalidates the sentinel and re-triggers initialization. `Manifest.toml` is deliberately not declared: it is gitignored and regenerated locally, so it is absent on a fresh clone and would break the DAG.
- **`init-julia-env.jl`**: detect an out-of-date Manifest with `Pkg.is_manifest_current(proj)` and, when it no longer matches `Project.toml`, update the registry and regenerate the Manifest from scratch, then `instantiate` + `precompile`. When the Manifest is already in sync, the fast path (`instantiate` only) is taken.

## Why not just instantiate, or resolve?

Both were tried and are wrong for a bumped compat bound (e.g. `SolidStateDetectors = "=0.11.3"` -> `"=0.11.4"` with a Manifest still pinned at `0.11.3`), verified empirically with Julia 1.12.6:

- `Pkg.instantiate()` alone does **not** error on a tightened compat bound: it prints a warning and silently keeps the stale version.
- `Pkg.resolve()` calls `up(; level = UPLEVEL_FIXED)`, which keeps already-resolved packages pinned and refuses to upgrade them, failing with `empty intersection between SolidStateDetectors@0.11.3 and project compatibility 0.11.4` even though `0.11.4` resolves fine from scratch.

A from-scratch resolve (remove the gitignored Manifest, then `instantiate`) is the only operation that reliably picks up the update. This surfaced as a real failure in the `needs_nersc` workflow test.

## Verification

Reproduced all four states with Julia 1.12.6 (matching the pixi pin) using a minimal registered package: fresh clone (no Manifest), already-in-sync re-run (fast path, no regeneration), tightened compat bound (regenerates to the new version), and a newly added dependency (regenerates with the dep). Also confirmed against the NERSC prodenv that the cached Manifest was pinned at `SolidStateDetectors 0.11.3` while `Project.toml` requires `=0.11.4`.

## Note

This assumes `Manifest.toml` stays gitignored (regenerated locally). If it is later committed to pin transitive dependencies, this logic should be revisited to preserve the committed pins instead of regenerating.

---

## Second commit: warm dspeed/lh5 lazy kernels (fixes the `convolve_hpge_ideal_pulse_shape_lib` failure)

The `Test LEGEND-1000 workflow` job was failing on `main` (and here) in rule `convolve_hpge_ideal_pulse_shape_lib`, independent of the Julia-env change. Root cause: the `precompile` task that the warmup module replaced ran `from dspeed.processors import *` and `from lh5.compression import *`. Both modules expose their members lazily via PEP 562 `__getattr__`, so the star import forced every public name to load, compiling the eager `@guvectorize` kernels (notably `moving_window_multi`, reached by the parallel realistic-PSL rule) into the shared Numba cache. The warmup module downgraded these to plain `import` statements, which do not load the submodules, leaving the kernels uncompiled; the parallel jobs then raced to compile `moving_window_multi` and segfaulted.

`import *` is illegal inside a function, so the fix reproduces its effect by materializing `__all__` for both modules. Verified that `python -m legendsimflow.warmup` now materializes `moving_window_multi` (and the other 89 dspeed processors + 5 lh5 codecs).
