### PR TITLE
fix: silence pygeoml200 warnings that leaked into the log

### DIFF
--- a/workflow/src/legendsimflow/geometry.py
+++ b/workflow/src/legendsimflow/geometry.py
@@ -91,6 +91,10 @@ def make_hpge_mass_plot(
 
     os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
 
+    # silence pygeoml200's expected noise (per-detector dummy-enrichment
+    # warnings, public-geometry notice) that would otherwise spam the log
+    logging.getLogger("pygeoml200").setLevel(logging.ERROR)
+
     fig, ax = plt.subplots(figsize=(13, 3.5))
     plot_hpge_mass_comparison(geom_config, ax=ax)
     decorate(fig, rotate=True)
@@ -113,10 +117,9 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     os.environ["VTK_DEFAULT_OPENGL_WINDOW"] = "vtkOSOpenGLRenderWindow"
     os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
 
-    # pygeoml200 warns once per detector missing an enrichment value in
-    # metadata, but it already substitutes a documented dummy value, so the
-    # warning is expected and would otherwise spam the Snakemake log
-    logging.getLogger("pygeoml200.hpge_strings").setLevel(logging.ERROR)
+    # silence pygeoml200's expected noise (per-detector dummy-enrichment
+    # warnings, public-geometry notice) that would otherwise spam the log
+    logging.getLogger("pygeoml200").setLevel(logging.ERROR)
 
     scene = load_vis_scene(config)
     if scene.pop("fine_mesh", False):  # must be applied before building the geometry


### PR DESCRIPTION
A previous commit tried to suppress these `pygeoml200` messages but silenced the wrong logger, so they still spam the workflow log:

```
P00712A has no enrichment in metadata, setting to dummy value 0.92
...
CONSTRUCTING GEOMETRY FROM PUBLIC DATA ONLY
```

## Root cause

The suppression set `pygeoml200.hpge_strings` to `ERROR`, but the messages that actually appear are emitted by *other* `pygeoml200` submodules:

- `"... has no enrichment in metadata, setting to dummy value 0.92"` comes from `pygeoml200.hpge_mass_check` (reached by the mass-comparison plot in `make_hpge_mass_plot`, which had no suppression at all). Note `hpge_strings` emits a *different* variant (`"- setting to dummy value 0.9!"`) that never appears here.
- `"CONSTRUCTING GEOMETRY FROM PUBLIC DATA ONLY"` comes from `pygeoml200.core` (reached by `render_geometry` via `core.construct`), which the `hpge_strings`-targeted line did not cover.

## Fix

Silence the `pygeoml200` parent logger (at `ERROR`) in both `make_hpge_mass_plot` and `render_geometry`. Because the submodule loggers have no level of their own, the parent level applies to all of them, so this filters the expected noise regardless of which submodule emits it, and is robust against the same submodule-targeting mistake recurring.

Verified with the logging machinery that the old `hpge_strings`-only target leaves both `hpge_mass_check` and `core` warnings enabled, while silencing the `pygeoml200` parent disables both.