### PR TITLE
feat: warm the HPGe DSP-chain Numba kernels in the warmup step

### DIFF
--- a/docs/source/developer.md
+++ b/docs/source/developer.md
@@ -265,12 +265,18 @@ prerequisite of the production and test tasks) sidesteps this by calling every
 such kernel once, serially, before the parallel fan-out, so the jobs only ever
 read the cache.
 
+Some rules instead run a whole processing chain (e.g. a `dspeed`
+`WaveformBrowser` DSP chain) that lazily compiles dozens of kernels on first
+execution; these are warmed the same way by
+{func}`legendsimflow.warmup.warm_hpge_dsp_cache`, see its docstring for details.
+
 :::{important}
 
-Whenever you add code that calls a new lazily-compiled `@njit(cache=True)`
-kernel from a rule that runs in parallel (whether defined here or in a
-dependency such as `reboost`), add a call to it in
-{func}`legendsimflow.warmup.warm_numba_caches`, using the **exact** argument
+Whenever you add code that needs any lazily-compiled, on-disk-cached Numba
+kernel (`@njit(cache=True)`, a `dspeed`/`reboost` processing chain, or any other
+Numba-cached dependency) from a rule that runs in parallel, warm it in
+{func}`legendsimflow.warmup.warm_numba_caches` or
+{func}`legendsimflow.warmup.warm_hpge_dsp_cache`, using the **exact** argument
 dtypes seen at run time (Numba caches per type signature). Verify with
 `NUMBA_DEBUG_CACHE=1 pixi run warmup` that the kernel's `.nbc`/`.nbi` files get
 written.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,10 @@ depends-on = ["warmup"]
 cmd = "snakemake-nersc-batch"
 
 [tool.pixi.tasks.warmup]
-cmd = "python -m legendsimflow.warmup && touch .pixi/warmup.stamp"
+# the config lets the warmup discover the DSP chain to warm in l200data (as the
+# workflow does); defaults to the prod-cycle config in the current directory
+cmd = "python -m legendsimflow.warmup {{ config }} && touch .pixi/warmup.stamp"
+args = [{ arg = "config", default = "simflow-config.yaml" }]
 outputs = [".pixi/warmup.stamp"]
 
 [tool.pixi.feature.test.tasks]
@@ -204,7 +207,7 @@ test-julia = { cmd = "julia --project=. -e 'using Pkg; Pkg.test()'", cwd = "work
 test-julia-ci = { cmd = "julia --code-coverage=user --project=. -e 'using Pkg; Pkg.test(coverage=true)'", cwd = "workflow/src/LegendSimflow.jl", depends-on = ["init-julia-env"] }
 test-python-pixi = { cmd = "pytest -vvv -m 'not needs_nersc' --ignore=tests/test_workflow.py --cov=legendsimflow --cov-report=xml", depends-on = ["warmup", "init-julia-env"] }
 test-l1000-workflow = { cmd = "pytest -s -m 'needs_remage and not needs_nersc' tests/test_workflow.py::test_l1000_workflow", depends-on = ["warmup"] }
-test-l200-workflow = { cmd = "pytest -s -m needs_nersc", depends-on = ["warmup"] }
+test-l200-workflow = { cmd = "pytest -s -m needs_nersc", depends-on = [{ task = "warmup", args = ["tests/dummyprod/simflow-config-l200.yaml"] }] }
 test = { depends-on = ["test-python", "test-julia"] }
 
 [tool.uv.workspace]

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from legendsimflow import utils
+from legendsimflow.warmup import _resolve_dsp_config, warm_hpge_dsp_cache
+
+l200data = Path(__file__).parent / "l200data" / "v3.0.0"
+
+
+def test_lookup_dsp_config():
+    cfg = utils.lookup_dsp_config(l200data)
+    assert cfg.exists()
+    assert "ICPC-dsp_proc_chain" in cfg.name
+
+
+def test_warm_hpge_dsp_cache():
+    """Warm the real current-pulse DSP chain on a small synthetic waveform (must not raise)."""
+    warm_hpge_dsp_cache(utils.lookup_dsp_config(l200data))
+
+
+def test_resolve_dsp_config_skips_without_l200data(tmp_path):
+    """No DSP warmup when the config has no ``l200data``."""
+    cfg = tmp_path / "simflow-config.yaml"
+    cfg.write_text(yaml.safe_dump({"experiment": "l200cfg09", "paths": {}}))
+    assert _resolve_dsp_config(cfg) is None
+
+
+def test_resolve_dsp_config_skips_when_missing():
+    """No DSP warmup when the config path is missing or ``None``."""
+    assert _resolve_dsp_config("does-not-exist.yaml") is None
+    assert _resolve_dsp_config(None) is None

--- a/workflow/AGENTS.md
+++ b/workflow/AGENTS.md
@@ -15,9 +15,10 @@
   Avoid using it repeatedly in functions invoked at Snakemake DAG build time.
   `LegendMetadata.channelmap()` also calls `.on()`. Consider caching strategies
   instead
-- When adding code that calls a new lazily-compiled `@njit(cache=True)` kernel
-  from a rule that runs in parallel (here or in a dependency like `reboost`),
-  add a call to it in `warm_numba_caches` (`legendsimflow/warmup.py`) with the
+- When adding code that needs any lazily-compiled, on-disk-cached Numba kernel
+  (`@njit(cache=True)`, a `dspeed`/`reboost` processing chain, or any other
+  Numba-cached dependency) from a rule that runs in parallel, warm it in
+  `legendsimflow/warmup.py` (`warm_numba_caches`/`warm_hpge_dsp_cache`) with the
   exact runtime dtypes, else parallel jobs race the on-disk cache and segfault.
   Verify with `NUMBA_DEBUG_CACHE=1 pixi run warmup`. See `developer.md`.
 - Other conventions are enforced by pre-commit

--- a/workflow/src/legendsimflow/hpge_pars.py
+++ b/workflow/src/legendsimflow/hpge_pars.py
@@ -816,19 +816,7 @@ def lookup_currmod_fit_inputs(
         msg = f"no hit tier files found in {hit_path}/cal/{period}/{run}"
         raise ValueError(msg)
 
-    dsp_cfg_regex = r"l200-*-r%-T%-ICPC-dsp_proc_chain.*"
-    dsp_cfg_files = list(
-        (l200data / "inputs/dataprod/config/tier_dsp").glob(dsp_cfg_regex)
-    )
-
-    if dsp_cfg_files == []:
-        dsp_cfg_files = list(
-            (l200data / "inputs/dataprod/config/tier/dsp").glob(dsp_cfg_regex)
-        )
-
-    if len(dsp_cfg_files) != 1:
-        msg = f"could not find a suitable dsp config file in {l200data} (or multiple found)"
-        raise RuntimeError(msg)
+    dsp_cfg_file = utils.lookup_dsp_config(l200data)
 
     lh5_group = mutils._get_lh5_table(metadata, hit_files[0], hpge, "hit", runid)
 
@@ -851,7 +839,7 @@ def lookup_currmod_fit_inputs(
     msg = "determined %d raw file/event pairs for simultaneous fitting"
     log.debug(msg, len(raw_wf_pairs))
 
-    return raw_wf_pairs, dsp_cfg_files[0], all_dts, selected_dts
+    return raw_wf_pairs, dsp_cfg_file, all_dts, selected_dts
 
 
 def _lookup_generated_pars_file(

--- a/workflow/src/legendsimflow/superpulses.py
+++ b/workflow/src/legendsimflow/superpulses.py
@@ -292,23 +292,13 @@ def lookup_superpulse_inputs(
         msg = f"no evt tier files found for {data_runid}."
         raise FileNotFoundError(msg)
 
-    dsp_cfg_regex = r"l200-*-r%-T%-ICPC-dsp_proc_chain.*"
-    dsp_cfg_files = list(
-        (l200data / "inputs/dataprod/config/tier_dsp").glob(dsp_cfg_regex)
-    )
-    if dsp_cfg_files == []:
-        dsp_cfg_files = list(
-            (l200data / "inputs/dataprod/config/tier/dsp").glob(dsp_cfg_regex)
-        )
-    if len(dsp_cfg_files) != 1:
-        msg = f"could not find a suitable dsp config file in {l200data} (or multiple found)"
-        raise RuntimeError(msg)
+    dsp_cfg_file = utils.lookup_dsp_config(l200data)
 
     tstamp = mutils.runinfo(metadata, data_runid).start_key
     chmap = metadata.channelmap(tstamp, skip_version_check=True)
     tab_map = {hpge: chmap[hpge]["daq"]["rawid"]}
 
-    return raw_files, evt_files, dsp_cfg_files[0], tab_map, data_runid
+    return raw_files, evt_files, dsp_cfg_file, tab_map, data_runid
 
 
 def _read_and_sel_evts(

--- a/workflow/src/legendsimflow/utils.py
+++ b/workflow/src/legendsimflow/utils.py
@@ -422,6 +422,35 @@ def lookup_dataflow_config(l200data: Path | str) -> AttrsDict:
     return df_cfg
 
 
+def lookup_dsp_config(l200data: str | Path) -> Path:
+    """Find the ICPC DSP processing-chain configuration file in an l200data production.
+
+    Parameters
+    ----------
+    l200data
+        The path to the L200 data production cycle.
+
+    Returns
+    -------
+    path to the single matching DSP configuration file.
+    """
+    if not isinstance(l200data, Path):
+        l200data = Path(l200data)
+
+    dsp_cfg_regex = r"l200-*-r%-T%-ICPC-dsp_proc_chain.*"
+    dsp_cfg_files: list[Path] = []
+    for sub in ("inputs/dataprod/config/tier_dsp", "inputs/dataprod/config/tier/dsp"):
+        dsp_cfg_files = list((l200data / sub).glob(dsp_cfg_regex))
+        if dsp_cfg_files:
+            break
+
+    if len(dsp_cfg_files) != 1:
+        msg = f"could not find a suitable dsp config file in {l200data} (or multiple found)"
+        raise RuntimeError(msg)
+
+    return dsp_cfg_files[0]
+
+
 def init_generated_pars_db(
     l200data: str | Path, tier: str | None = None, lazy: bool = True
 ) -> TextDB:

--- a/workflow/src/legendsimflow/warmup.py
+++ b/workflow/src/legendsimflow/warmup.py
@@ -15,10 +15,10 @@
 """Serial warmup of heavy dependencies and Numba caches.
 
 Run once before the parallel Snakemake jobs (via ``python -m
-legendsimflow.warmup``, wired to the ``warmup`` pixi task). A lazily-compiled
-``@njit(cache=True)`` kernel is compiled and written to a shared on-disk cache
-only on its first *call*; parallel jobs racing to write it segfault. Warming
-each kernel once here leaves them only reading the cache.
+legendsimflow.warmup [simflow-config.yaml]``, wired to the ``warmup`` pixi
+task). A lazily-compiled ``@njit(cache=True)`` kernel is compiled and written to
+a shared on-disk cache only on its first *call*; parallel jobs racing to write
+it segfault. Warming each kernel once here leaves them only reading the cache.
 """
 # heavy imports are kept inside the function so importing this module stays
 # cheap (e.g. sphinx autodoc can import it without the full runtime stack).
@@ -26,8 +26,13 @@ each kernel once here leaves them only reading the cache.
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 
-def warm_numba_caches() -> None:
+log = logging.getLogger(__name__)
+
+
+def warm_numba_caches(simflow_config: str | Path | dict | None = None) -> None:
     """Warm the heavy imports and the Numba kernels the workflow calls."""
     # importing these pays their one-off cost (Matplotlib font cache, ...) and
     # compiles their vectorized kernels
@@ -72,6 +77,122 @@ def warm_numba_caches() -> None:
         10.0,
     )
 
+    # HPGe DSP-chain kernels raced by the parallel par-tier rules, warmed only
+    # when this production actually runs them (see _resolve_dsp_config). Warn and
+    # skip on any problem rather than aborting: warmup gates every rule, and the
+    # par-tier rules would surface a real misconfiguration themselves.
+    try:
+        dsp_config = _resolve_dsp_config(simflow_config)
+        if dsp_config is not None:
+            log.info("warming the HPGe DSP-chain with config %s", dsp_config)
+            warm_hpge_dsp_cache(dsp_config)
+    except Exception:
+        log.warning(
+            "could not warm the HPGe DSP-chain; the parallel par-tier rules may "
+            "race the Numba cache and segfault",
+            exc_info=True,
+        )
+
+
+def _resolve_dsp_config(simflow_config: str | Path | dict | None) -> Path | None:
+    """DSP config to warm, or ``None`` if the par-tier rules that race it won't run."""
+    if simflow_config is None:
+        return None
+    if isinstance(simflow_config, (str, Path)) and not Path(simflow_config).exists():
+        return None
+
+    import dbetto
+
+    from legendsimflow import utils
+    from legendsimflow.metadata import get_tier_settings
+
+    # cheap peek before the heavier full context init
+    raw = (
+        simflow_config
+        if isinstance(simflow_config, dict)
+        else dbetto.utils.load_dict(str(simflow_config))
+    )
+    if "l200data" not in raw.get("paths", {}):
+        return None
+
+    config = utils.init_simflow_context(simflow_config).config
+    hit = get_tier_settings(config, "hit")
+    if not (hit.get("simulate_psd", True) and hit.get("simulate_psd_with_psl", True)):
+        return None
+
+    return utils.lookup_dsp_config(config.paths.l200data)
+
+
+def _make_dummy_raw_file(path: str, lh5_group: str = "ch0/raw", n_wfs: int = 4) -> str:
+    """Write a small synthetic HPGe raw file to drive the DSP-chain warmup, return the LH5 group written."""
+    import lh5
+    import numpy as np
+    from lgdo import Array, Table, WaveformTable
+    from reboost.hpge.psd import _current_pulse_model
+
+    # shaped current -> integrated charge (see tests/conftest.py make_cal_data)
+    t = np.linspace(0, 99968, 6249)
+    curr = _current_pulse_model(t, 1.0, 51000.0, 50.0, 0.55, 150.0, 0.2, 80.0)
+    curr /= np.sum(curr) * 16
+    charge = np.cumsum(curr)
+    windowed = charge[2625:4025]  # 1400-sample high-resolution window
+    presummed = charge[::8][:-1] * 8  # 781-sample presummed (16 ns -> 128 ns)
+
+    energy = np.full(n_wfs, 1593.0)
+    win = (np.vstack([windowed] * n_wfs) * energy[:, None]).astype("int32")
+    presum = (np.vstack([presummed] * n_wfs) * energy[:, None]).astype("int32")
+
+    tb = Table(size=n_wfs)
+    tb.add_field(
+        "waveform_presummed",
+        WaveformTable(values=presum, dt=128, dt_units="ns", t0=0, t0_units="ns"),
+    )
+    tb.add_field(
+        "waveform_windowed",
+        WaveformTable(values=win, dt=16, dt_units="ns", t0=42000, t0_units="ns"),
+    )
+    tb.add_field("presum_rate", Array(np.full(n_wfs, 8, dtype="float32")))
+
+    lh5.write(tb, lh5_group, path, wo_mode="of")
+    return lh5_group
+
+
+def warm_hpge_dsp_cache(dsp_config: str | Path) -> None:
+    """Compile the HPGe DSP-chain (and fit) kernels raced by the par-tier rules."""
+    import tempfile
+    import warnings
+
+    import numpy as np
+    from scipy.stats import norm
+
+    from legendsimflow import hpge_pars, superpulses
+
+    dsp = str(dsp_config)
+    # only compiling kernels here; numpy warnings from the synthetic pulse are noise
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with tempfile.TemporaryDirectory() as tmp:
+            raw_file = str(Path(tmp) / "dummy-raw.lh5")
+            lh5_group = _make_dummy_raw_file(raw_file)
+            n = 4
+
+            # current-pulse chain (also warms the tp_aoe_max alignment conversions)
+            hpge_pars.get_current_pulse(
+                raw_file, lh5_group, 0, dsp, "curr_av", "tp_aoe_max"
+            )
+            # superpulse chain: charge (wf_pz_win) + current + baseline + energy outputs
+            superpulses.get_wfs_for_slice(
+                [raw_file], lh5_group, list(range(n)), [0] * n, dsp_config=dsp
+            )
+
+        # iminuit noise fit (deterministic Gaussian sample, no RNG)
+        hpge_pars.fit_noise_gauss(norm.ppf(np.linspace(1e-3, 1 - 1e-3, 2000)), bins=100)
+
 
 if __name__ == "__main__":
-    warm_numba_caches()
+    import sys
+
+    # the prod invocation runs from the prod-cycle cwd, where the config lives;
+    # override the path as first arg (e.g. for the test tasks)
+    config_file = sys.argv[1] if len(sys.argv) > 1 else "simflow-config.yaml"
+    warm_numba_caches(config_file)


### PR DESCRIPTION
## Problem

The `build_superpulses_from_data` and `extract_current_pulse_model` par-tier rules each run a dspeed `WaveformBrowser` DSP chain, whose `@njit(cache=True)` kernels are compiled lazily on first execution. When many of these jobs fan out in parallel they compile the same kernels at once and race the shared on-disk Numba cache, which segfaults (exit 139). Importing `dspeed.processors` (already done in the warmup) only warms the eager `@guvectorize` kernels, not the chain's runtime signatures.

## Fix

Warm the chain once, serially, in the `warmup` step by reusing the real production path (`hpge_pars.get_current_pulse`) on a synthetic waveform, so the parallel jobs only ever read the cache.

The DSP configuration is discovered in `l200data` at run time exactly as the workflow does, via a new `utils.lookup_dsp_config` (factored out of the identical inline globs in `hpge_pars` and `superpulses`), rather than shipping a config with the package. The `warmup` pixi task now takes the production's Simflow config (defaulting to `simflow-config.yaml` in the prod-cycle cwd) to locate `l200data`, and:

- skips the DSP-chain warmup entirely when the production reads no `l200data` or has PSD-with-PSL disabled (i.e. when those rules won't run);
- warns and skips (never aborts) if a problem occurs while warming, since the warmup gates every rule and the par-tier rules would surface a real misconfiguration themselves.

The `needs_nersc` test task passes its `dummyprod` config to the warmup through pixi `depends-on` args.

## Tests

New `tests/test_warmup.py` (CI-runnable): exercises the real current-pulse DSP chain on a synthetic waveform using the DSP config from the bundled `tests/l200data`, plus the skip decisions (no `l200data`, missing/`None` config). Pre-commit and the docs build pass.

## Notes

Split out of #287 (the l200cfg09 workflow test), which keeps the test itself and will consume this once merged.