### PR TITLE
Restructure PSD fields in the hit and evt tiers

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -434,11 +434,11 @@ psdcuts_default:
   per-detector entry. See {ref}`build-tier-hit-hpge` for when this fallback is
   triggered.
 - `simulate_psd` (bool, default `True`): enable the single-template A/E PSD
-  simulation, written to the `geds/psd/single_temp` subtable of the `hit` tier.
+  simulation, written to the `psd/single_temp` subtable of the `hit` tier.
 - `simulate_psd_with_psl` (bool, default `False`): enable the
   pulse-shape-library based PSD simulation (see {ref}`hpge-psl-overview`),
-  written to the `geds/psd/pulse_lib` subtable. The two flags are independent:
-  enable either, both, or neither. Setting both to `False` disables the HPGe PSD
+  written to the `psd/pulse_lib` subtable. The two flags are independent: enable
+  either, both, or neither. Setting both to `False` disables the HPGe PSD
   simulation entirely.
 - `psdcuts_default` — PSD cut values applied to detectors without a per-detector
   entry. See {ref}`build-tier-hit-hpge` for when this fallback is triggered.

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -434,11 +434,11 @@ psdcuts_default:
   per-detector entry. See {ref}`build-tier-hit-hpge` for when this fallback is
   triggered.
 - `simulate_psd` (bool, default `True`): enable the single-template A/E PSD
-  simulation, written to the `geds/psd` subtable of the `hit` tier.
+  simulation, written to the `geds/psd/single_temp` subtable of the `hit` tier.
 - `simulate_psd_with_psl` (bool, default `False`): enable the
   pulse-shape-library based PSD simulation (see {ref}`hpge-psl-overview`),
-  written to the `geds/psd_psl` subtable. The two flags are independent: enable
-  either, both, or neither. Setting both to `False` disables the HPGe PSD
+  written to the `geds/psd/pulse_lib` subtable. The two flags are independent:
+  enable either, both, or neither. Setting both to `False` disables the HPGe PSD
   simulation entirely.
 - `psdcuts_default` — PSD cut values applied to detectors without a per-detector
   entry. See {ref}`build-tier-hit-hpge` for when this fallback is triggered.

--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -209,27 +209,37 @@ and are from non-OFF detectors.
 | `is_good_channel` | `VectorOfVectors` | —     | Boolean. `True` if the detector usability is ON (not AC or OFF). Variable-length per event.                             |
 | `multiplicity`    | `Array`           | —     | Number of HPGe hits above threshold per event. Scalar per event.                                                        |
 
-#### `geds/psd/` and `geds/psd_psl` — PSD fields
+#### `geds/psd/` — PSD fields
 
-These two subtables are optional and gated by the `hit`-tier settings
-({ref}`hit-tier-settings`): `geds/psd` is present when `simulate_psd: True` and
-`geds/psd_psl` when `simulate_psd_with_psl: True`. Each carries the same-named
-fields forwarded from the corresponding `hit`-tier subtable (`psd` is
-single-template, `psd_psl` is PSL based; see {ref}`hpge-psl-overview`), so a
-field's meaning depends on which subtable it is in. All fields are
-`VectorOfVectors` (variable-length per event).
+The optional `geds/psd` subtable holds HPGe pulse-shape-discrimination fields.
+Flags common to every PSD method live directly under `geds/psd`, while
+method-specific fields are grouped in dedicated subtables, one per simulation
+method:
 
-| Field             | Units | Subtable         | Description                                                                                                                                                                                             |
-| ----------------- | ----- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `is_good`         |       | `psd`            | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data.                                                                                                                                  |
-| `is_valid_sim`    |       | `psd`            | Boolean. `True` when the crystal metadata needed to model the detector is usable, so its simulated response can be trusted. Reshaped from the `hit`-tier `is_valid_sim` field (see {ref}`par-detinfo`). |
-| `aoe`             |       | `psd`, `psd_psl` | A/E classifier values forwarded from the `hit` tier.                                                                                                                                                    |
-| `aoe_corr`        |       | `psd`, `psd_psl` | Energy-corrected A/E values forwarded from the `hit` tier.                                                                                                                                              |
-| `drift_time_amax` | ns    | `psd`, `psd_psl` | Drift time at the maximum-current position, forwarded from the `hit` tier.                                                                                                                              |
-| `has_aoe`         |       | `psd`, `psd_psl` | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed).                                                                                                                                  |
-| `is_single_site`  |       | `psd`, `psd_psl` | Boolean single-site PSD flag forwarded from the `hit` tier.                                                                                                                                             |
-| `is_bb_like`      |       | `psd_psl`        | Boolean flag for $0\nu\beta\beta$-like single-site events, forwarded from `hit`.                                                                                                                        |
-| `is_high_aoe`     |       | `psd_psl`        | Boolean high-A/E flag forwarded from the `hit` tier.                                                                                                                                                    |
+- `geds/psd/single_temp` — single-template A/E simulation, present when
+  `simulate_psd: True` in {ref}`hit-tier-settings`.
+- `geds/psd/pulse_lib` — pulse-shape-library (PSL) based simulation, present
+  when `simulate_psd_with_psl: True` (see {ref}`hpge-psl-overview`).
+
+The `geds/psd` subtable itself is present whenever at least one of the two
+methods is enabled. The two method subtables carry the same-named A/E fields but
+their **meaning differs**: `single_temp` values come from a single per-detector
+current-pulse template, while `pulse_lib` values come from the per-pixel
+pulse-shape library (see {ref}`hpge-psl-overview`). All fields are forwarded
+from the corresponding `hit`-tier subtable and are `VectorOfVectors`
+(variable-length per event).
+
+| Field             | Units | Subtable                   | Description                                                                                                                                                                                             |
+| ----------------- | ----- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `is_good`         |       | `psd`                      | Boolean. `True` if the PSD usability flag is valid in LEGEND-200 data.                                                                                                                                  |
+| `is_valid_sim`    |       | `psd`                      | Boolean. `True` when the crystal metadata needed to model the detector is usable, so its simulated response can be trusted. Reshaped from the `hit`-tier `is_valid_sim` field (see {ref}`par-detinfo`). |
+| `aoe`             |       | `single_temp`, `pulse_lib` | A/E classifier values forwarded from the `hit` tier.                                                                                                                                                    |
+| `aoe_corr`        |       | `single_temp`, `pulse_lib` | Energy-corrected A/E values forwarded from the `hit` tier.                                                                                                                                              |
+| `drift_time_amax` | ns    | `single_temp`, `pulse_lib` | Drift time at the maximum-current position, forwarded from the `hit` tier.                                                                                                                              |
+| `has_aoe`         |       | `single_temp`, `pulse_lib` | Boolean. `True` if the A/E value is not `NaN` (i.e. PSD was computed).                                                                                                                                  |
+| `is_single_site`  |       | `single_temp`, `pulse_lib` | Boolean single-site PSD flag forwarded from the `hit` tier.                                                                                                                                             |
+| `is_bb_like`      |       | `pulse_lib`                | Boolean flag for $0\nu\beta\beta$-like single-site events, forwarded from `hit`.                                                                                                                        |
+| `is_high_aoe`     |       | `pulse_lib`                | Boolean high-A/E flag forwarded from the `hit` tier.                                                                                                                                                    |
 
 ### `spms/` — SiPM (LAr scintillation) array
 
@@ -317,24 +327,24 @@ to be an ON detector (not AC or OFF). Per-group filtering restricts which
 detector energies are accumulated into the histogram; the event-level cuts
 themselves are unchanged and applied globally.
 
-| Cut           | Description                                                                                                                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `hit`         | All individual HPGe energy deposits in ON-channel events, with no multiplicity requirement.                                                                                                                                    |
-| `mul`         | Multiplicity-1 events: exactly one ON detector fired (`geds.multiplicity == 1`).                                                                                                                                               |
-| `mul_lar`     | Multiplicity-1 events passing the LAr anti-coincidence cut. Events are vetoed when `coincident.spms` is `True` (SiPMs detected scintillation light in liquid argon). Present only when SiPM data is available.                 |
-| `mul_psd`     | Multiplicity-1 events passing the PSD single-site cut. Requires `psd.is_good`, `psd.has_aoe`, and `psd.is_single_site` for all hits. Events where PSD is not valid or not simulated are classified as background and excluded. |
-| `mul_lar_psd` | Multiplicity-1 events passing both the LAr anti-coincidence and PSD single-site cuts (combination of `mul_lar` and `mul_psd`). Present only when SiPM data is available.                                                       |
+| Cut           | Description                                                                                                                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hit`         | All individual HPGe energy deposits in ON-channel events, with no multiplicity requirement.                                                                                                                                                            |
+| `mul`         | Multiplicity-1 events: exactly one ON detector fired (`geds.multiplicity == 1`).                                                                                                                                                                       |
+| `mul_lar`     | Multiplicity-1 events passing the LAr anti-coincidence cut. Events are vetoed when `coincident.spms` is `True` (SiPMs detected scintillation light in liquid argon). Present only when SiPM data is available.                                         |
+| `mul_psd`     | Multiplicity-1 events passing the PSD single-site cut. Requires `psd.is_good`, `psd.single_temp.has_aoe`, and `psd.single_temp.is_single_site` for all hits. Events where PSD is not valid or not simulated are classified as background and excluded. |
+| `mul_lar_psd` | Multiplicity-1 events passing both the LAr anti-coincidence and PSD single-site cuts (combination of `mul_lar` and `mul_psd`). Present only when SiPM data is available.                                                                               |
 
 :::{warning}
 
 When a detector is ON with valid PSD in the data but its PSD response could not
 be simulated (e.g. because it is not included in the simulation model), the
-corresponding events will have `psd.has_aoe = False` in the `cvt` tier. Such
-events are treated as background and excluded from `mul_psd` and `mul_lar_psd`.
-This is a conservative choice: rather than keeping events we cannot
-characterise, we cut them. The `fail/psd` histogram does **not** include these
-events either, since it is restricted to events where both `psd.is_good = True`
-and `psd.has_aoe = True`.
+corresponding events will have `psd.single_temp.has_aoe = False` in the `cvt`
+tier. Such events are treated as background and excluded from `mul_psd` and
+`mul_lar_psd`. This is a conservative choice: rather than keeping events we
+cannot characterise, we cut them. The `fail/psd` histogram does **not** include
+these events either, since it is restricted to events where both
+`psd.is_good = True` and `psd.single_temp.has_aoe = True`.
 
 :::
 
@@ -355,7 +365,7 @@ explicitly rejected by a cut, providing a way to characterise the vetoed
 background. Like the pass histograms, each cut contains one `Histogram` per
 detector group (`pdf/fail/<cut>/<group>`).
 
-| Cut   | Description                                                                                                                                                                 |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lar` | Multiplicity-1 events failing the LAr veto (`coincident.spms == True`). Present only when SiPM data is available.                                                           |
-| `psd` | Multiplicity-1 events with valid PSD (`psd.is_good == True`) that fail the single-site cut (`psd.is_single_site == False`). Events without valid PSD are not included here. |
+| Cut   | Description                                                                                                                                                                             |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lar` | Multiplicity-1 events failing the LAr veto (`coincident.spms == True`). Present only when SiPM data is available.                                                                       |
+| `psd` | Multiplicity-1 events with valid PSD (`psd.is_good == True`) that fail the single-site cut (`psd.single_temp.is_single_site == False`). Events without valid PSD are not included here. |

--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -102,33 +102,33 @@ These fields are carried over from the
 | `psd_usability` | `Array` | —     | Encoded PSD usability flag (e.g. `valid`). Indicates whether PSD parameters are valid in LEGEND-200 data for this detector and run. Decode with {func}`legendsimflow.metadata.decode_psd_usability`.                                                                                            |
 | `is_valid_sim`  | `Array` | —     | Boolean. `True` when the crystal metadata needed to model this detector is usable (`crystal_metadata_usability` is `valid`, see {ref}`par-detinfo`), so the simulated detector response can be trusted. `False` otherwise. Reshaped into `geds/psd/is_valid_sim` by the [`evt` tier](evt-tier). |
 
-The `hit` tier can add HPGe pulse-shape-discrimination (PSD) fields in two
-optional subtables, selected by the metadata settings in
-{ref}`hit-tier-settings`:
+The `hit` tier can add HPGe pulse-shape-discrimination (PSD) fields in the `psd`
+subtable, which groups one method-specific subtable per simulation method,
+selected by the metadata settings in {ref}`hit-tier-settings`:
 
-- `psd` — single-template A/E simulation, present only when `simulate_psd: True`
-  (the default).
-- `psd_psl` — pulse-shape-library (PSL) based simulation, present only when
-  `simulate_psd_with_psl: True` (see {ref}`hpge-psl-overview`).
+- `psd/single_temp` — single-template A/E simulation, present only when
+  `simulate_psd: True` (the default).
+- `psd/pulse_lib` — pulse-shape-library (PSL) based simulation, present only
+  when `simulate_psd_with_psl: True` (see {ref}`hpge-psl-overview`).
 
 :::{note}
 
 The two subtables hold the same-named A/E fields, but their **meaning differs**:
-the `psd` values come from a single per-detector current-pulse template, while
-the `psd_psl` values come from the per-pixel pulse-shape library (see
+the `single_temp` values come from a single per-detector current-pulse template,
+while the `pulse_lib` values come from the per-pixel pulse-shape library (see
 {ref}`hpge-psl-overview`).
 
 :::
 
-| Field             | Type    | Units | Subtable         | Description                                                                                                                                                                                                                                                                                            |
-| ----------------- | ------- | ----- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `drift_time_amax` | `Array` | ns    | `psd`, `psd_psl` | Drift time at the maximum-current (A) position of the simulated current pulse. Set to `NaN` when no drift-time map or current-pulse model is available for the detector.                                                                                                                               |
-| `aoe_raw`         | `Array` |       | `psd`, `psd_psl` | Raw A/E value: maximum current amplitude divided by energy. The maximum current (A) is obtained from the simulated current pulse and includes electronic noise effects.                                                                                                                                |
-| `aoe_corr`        | `Array` |       | `psd`, `psd_psl` | Energy-corrected A/E value, obtained by correcting `aoe_raw` for the observed energy dependence.                                                                                                                                                                                                       |
-| `aoe`             | `Array` |       | `psd`, `psd_psl` | A/E classifier value: `(aoe_corr - 1) / aoe_resolution`. Used for pulse-shape discrimination (PSD). Set to `NaN` when PSD simulation is not available (i.e., when the drift-time map or current-pulse model is missing). This is distinct from the usability flags that track LEGEND-200 data quality. |
-| `is_single_site`  | `Array` |       | `psd`, `psd_psl` | Boolean PSD flag. `True` when the A/E classifier `aoe` exceeds the lower single-site cut `psdcuts.aoe.low_side` (extracted from LEGEND-200 data).                                                                                                                                                      |
-| `is_bb_like`      | `Array` |       | `psd_psl`        | Boolean PSD flag. `True` for $0\nu\beta\beta$-like single-site events: `aoe` above `psdcuts.aoe.low_side` and not above the upper cut `psdcuts.aoe.high_side`.                                                                                                                                         |
-| `is_high_aoe`     | `Array` |       | `psd_psl`        | Boolean PSD flag. `True` when `aoe` exceeds the upper cut `psdcuts.aoe.high_side` (high-A/E events, e.g. surface or $\alpha$).                                                                                                                                                                         |
+| Field             | Type    | Units | Subtable                   | Description                                                                                                                                                                                                                                                                                            |
+| ----------------- | ------- | ----- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `drift_time_amax` | `Array` | ns    | `single_temp`, `pulse_lib` | Drift time at the maximum-current (A) position of the simulated current pulse. Set to `NaN` when no drift-time map or current-pulse model is available for the detector.                                                                                                                               |
+| `aoe_raw`         | `Array` |       | `single_temp`, `pulse_lib` | Raw A/E value: maximum current amplitude divided by energy. The maximum current (A) is obtained from the simulated current pulse and includes electronic noise effects.                                                                                                                                |
+| `aoe_corr`        | `Array` |       | `single_temp`, `pulse_lib` | Energy-corrected A/E value, obtained by correcting `aoe_raw` for the observed energy dependence.                                                                                                                                                                                                       |
+| `aoe`             | `Array` |       | `single_temp`, `pulse_lib` | A/E classifier value: `(aoe_corr - 1) / aoe_resolution`. Used for pulse-shape discrimination (PSD). Set to `NaN` when PSD simulation is not available (i.e., when the drift-time map or current-pulse model is missing). This is distinct from the usability flags that track LEGEND-200 data quality. |
+| `is_single_site`  | `Array` |       | `single_temp`, `pulse_lib` | Boolean PSD flag. `True` when the A/E classifier `aoe` exceeds the lower single-site cut `psdcuts.aoe.low_side` (extracted from LEGEND-200 data).                                                                                                                                                      |
+| `is_bb_like`      | `Array` |       | `pulse_lib`                | Boolean PSD flag. `True` for $0\nu\beta\beta$-like single-site events: `aoe` above `psdcuts.aoe.low_side` and not above the upper cut `psdcuts.aoe.high_side`.                                                                                                                                         |
+| `is_high_aoe`     | `Array` |       | `pulse_lib`                | Boolean PSD flag. `True` when `aoe` exceeds the upper cut `psdcuts.aoe.high_side` (high-A/E events, e.g. surface or $\alpha$).                                                                                                                                                                         |
 
 ## `opt` tier — optical (SiPM) post-processing
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -328,10 +328,10 @@ Document the optical hit building step.
 
 HPGe PSD simulation runs in two independent, optional modes selected in
 {ref}`hit-tier-settings`: set `simulate_psd: True` (default) for the
-single-template A/E estimate (`geds/psd` output) and
+single-template A/E estimate (`geds/psd/single_temp` output) and
 `simulate_psd_with_psl: True` for the pulse-shape-library based estimate
-(`geds/psd_psl` output, see {ref}`hpge-psl-overview`). Either, both, or neither
-can be enabled; with both `False` no PSD columns are written.
+(`geds/psd/pulse_lib` output, see {ref}`hpge-psl-overview`). Either, both, or
+neither can be enabled; with both `False` no PSD columns are written.
 
 :::
 

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -328,10 +328,10 @@ Document the optical hit building step.
 
 HPGe PSD simulation runs in two independent, optional modes selected in
 {ref}`hit-tier-settings`: set `simulate_psd: True` (default) for the
-single-template A/E estimate (`geds/psd/single_temp` output) and
+single-template A/E estimate (`psd/single_temp` output) and
 `simulate_psd_with_psl: True` for the pulse-shape-library based estimate
-(`geds/psd/pulse_lib` output, see {ref}`hpge-psl-overview`). Either, both, or
-neither can be enabled; with both `False` no PSD columns are written.
+(`psd/pulse_lib` output, see {ref}`hpge-psl-overview`). Either, both, or neither
+can be enabled; with both `False` no PSD columns are written.
 
 :::
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -85,8 +85,9 @@ The remage-driven workflow tests form a progression:
    hit settings enable the `simulate_psd_with_psl` tier setting (the live name
    of what used to be the unread `has_detailed_psd` key), so this test also
    exercises the PSL-based "detailed" PSD path: the realistic pulse-shape
-   library is built in the par tier, consumed by the hit tier into a `psd_psl`
-   sub-table, and read back by the evt tier into `geds/psd_psl`.
+   library is built in the par tier, consumed by the hit tier into a
+   `psd/pulse_lib` sub-table, and read back by the evt tier into
+   `geds/psd/pulse_lib`.
 2. **`test_l200_workflow`** (`needs_nersc`, `needs_remage`) — full vtx→cvt
    pipeline, experiment `l200cfg01`, requires `l200data`, NERSC-only. Run with:
    `pixi run -e test test-l200-workflow`

--- a/tests/scripts/test_tier_evt.py
+++ b/tests/scripts/test_tier_evt.py
@@ -86,8 +86,17 @@ def test_evt_script_cli(
     psd_fields = {
         f.removeprefix("evt/geds/psd/") for f in lh5.ls(evt_file, "evt/geds/psd/")
     }
-    for field in ("is_good", "is_valid_sim", "aoe", "has_aoe", "is_single_site"):
+    for field in ("is_good", "is_valid_sim", "single_temp"):
         assert field in psd_fields, f"'geds/psd/{field}' missing; got {psd_fields}"
+
+    single_temp_fields = {
+        f.removeprefix("evt/geds/psd/single_temp/")
+        for f in lh5.ls(evt_file, "evt/geds/psd/single_temp/")
+    }
+    for field in ("aoe", "has_aoe", "is_single_site"):
+        assert field in single_temp_fields, (
+            f"'geds/psd/single_temp/{field}' missing; got {single_temp_fields}"
+        )
 
     spms_fields = {f.removeprefix("evt/spms/") for f in lh5.ls(evt_file, "evt/spms/")}
     for field in (

--- a/tests/scripts/test_tier_hit.py
+++ b/tests/scripts/test_tier_hit.py
@@ -118,10 +118,19 @@ def test_hit_script_cli(
     def _field(det: str, name: str) -> np.ndarray:
         return lh5.read_as(f"{det}/{name}", hit_file, library="np")
 
+    # method-specific PSD fields live under the psd/single_temp subtable
+    psd_fields = {
+        f.removeprefix(first_det + "/psd/")
+        for f in lh5.ls(hit_file, first_det + "/psd/")
+    }
+    assert "single_temp" in psd_fields, (
+        f"'psd/single_temp' missing from {first_det}; got {psd_fields}"
+    )
+
     # r000 has a dtmap for V05261B → finite PSD; r001 has none → NaN
     # both partitions land in the same hit/V05261B table, distinguishable by run
     assert "hit/V05261B" in det_tables, "V05261B not found in hit output"
-    v_drift = _field("hit/V05261B/psd", "drift_time_amax")
+    v_drift = _field("hit/V05261B/psd/single_temp", "drift_time_amax")
     v_run = _field("hit/V05261B", "run")
     assert not np.all(np.isnan(v_drift[v_run == 0])), (
         "r000 V05261B drift_time_amax is all NaN despite having a dtmap"

--- a/tests/scripts/test_tier_pdf.py
+++ b/tests/scripts/test_tier_pdf.py
@@ -110,11 +110,16 @@ def _make_cvt_file(path: Path) -> None:
     )
     spms = Array(np.array([False, False, False, True, False, False]))
 
+    single_temp = Table(
+        col_dict={
+            "has_aoe": has_aoe,
+            "is_single_site": is_single_site,
+        }
+    )
     psd = Table(
         col_dict={
             "is_good": is_good,
-            "has_aoe": has_aoe,
-            "is_single_site": is_single_site,
+            "single_temp": single_temp,
         }
     )
     geds = Table(
@@ -208,11 +213,16 @@ def _make_cvt_file_no_spms(path: Path) -> None:
     is_single_site = VectorOfVectors(
         data=[[True], [False], [False], [True], [True, True], [False]]
     )
+    single_temp = Table(
+        col_dict={
+            "has_aoe": has_aoe,
+            "is_single_site": is_single_site,
+        }
+    )
     psd = Table(
         col_dict={
             "is_good": is_good,
-            "has_aoe": has_aoe,
-            "is_single_site": is_single_site,
+            "single_temp": single_temp,
         }
     )
     geds = Table(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -36,7 +36,7 @@ _EVT_PSD_PSL_FIELDS = {
 def _assert_psd_psl_in_hit(generated: Path) -> None:
     """Check the PSL-based detailed PSD output in the hit tier.
 
-    A ``psd_psl`` sub-table must be produced for the modelable detector
+    A ``psd/pulse_lib`` sub-table must be produced for the modelable detector
     ``V05261B`` (it has a realistic pulse-shape library and drift-time map), and
     its A/E values must be at least partly finite, proving the detailed path
     actually ran rather than falling back to the all-NaN default.
@@ -49,28 +49,28 @@ def _assert_psd_psl_in_hit(generated: Path) -> None:
     for f in hit_files:
         if "hit/V05261B" not in lh5.ls(f, "hit/"):
             continue
-        if "hit/V05261B/psd_psl" not in lh5.ls(f, "hit/V05261B/"):
+        if "hit/V05261B/psd/pulse_lib" not in lh5.ls(f, "hit/V05261B/psd/"):
             continue
         saw_psd_psl = True
         fields = {
-            x.removeprefix("hit/V05261B/psd_psl/")
-            for x in lh5.ls(f, "hit/V05261B/psd_psl/")
+            x.removeprefix("hit/V05261B/psd/pulse_lib/")
+            for x in lh5.ls(f, "hit/V05261B/psd/pulse_lib/")
         }
         missing = _HIT_PSD_PSL_FIELDS - fields
         assert not missing, f"hit psd_psl fields {missing} missing in {f}; got {fields}"
-        aoe = lh5.read_as("hit/V05261B/psd_psl/aoe", str(f), library="np")
+        aoe = lh5.read_as("hit/V05261B/psd/pulse_lib/aoe", str(f), library="np")
         if np.any(np.isfinite(aoe)):
             saw_finite_aoe = True
 
-    assert saw_psd_psl, "no hit file contains a hit/V05261B/psd_psl sub-table"
+    assert saw_psd_psl, "no hit file contains a hit/V05261B/psd/pulse_lib sub-table"
     assert saw_finite_aoe, (
-        "hit/V05261B/psd_psl/aoe is all-NaN across all hit files; the PSL-based "
-        "detailed PSD path did not compute real A/E values"
+        "hit/V05261B/psd/pulse_lib/aoe is all-NaN across all hit files; the "
+        "PSL-based detailed PSD path did not compute real A/E values"
     )
 
 
 def _assert_psd_psl_in_evt(generated: Path) -> None:
-    """Check that the evt tier reads the detailed PSD back into geds/psd_psl."""
+    """Check that the evt tier reads the detailed PSD into geds/psd/pulse_lib."""
     evt_files = sorted((generated / "tier/evt").rglob("*.lh5"))
     assert evt_files, f"no evt output files found under {generated}/tier/evt"
 
@@ -78,16 +78,17 @@ def _assert_psd_psl_in_evt(generated: Path) -> None:
     for f in evt_files:
         if "evt/geds" not in lh5.ls(f, "evt/"):
             continue
-        if "evt/geds/psd_psl" not in lh5.ls(f, "evt/geds/"):
+        if "evt/geds/psd/pulse_lib" not in lh5.ls(f, "evt/geds/psd/"):
             continue
         saw_psd_psl = True
         fields = {
-            x.removeprefix("evt/geds/psd_psl/") for x in lh5.ls(f, "evt/geds/psd_psl/")
+            x.removeprefix("evt/geds/psd/pulse_lib/")
+            for x in lh5.ls(f, "evt/geds/psd/pulse_lib/")
         }
         missing = _EVT_PSD_PSL_FIELDS - fields
         assert not missing, f"evt psd_psl fields {missing} missing in {f}; got {fields}"
 
-    assert saw_psd_psl, "no evt file contains an evt/geds/psd_psl sub-table"
+    assert saw_psd_psl, "no evt file contains an evt/geds/psd/pulse_lib sub-table"
 
 
 # NOTE: the dry-run DAG-structure tests (DAG resolution, simlist scheduling,

--- a/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
@@ -119,24 +119,26 @@ base_mask = (  # noqa: E731
     lambda evt: evt.coincident.geds
     & (evt.geds.multiplicity == 1)
     & evt.geds.is_good_channel
-    & evt.geds.psd.has_aoe
+    & evt.geds.psd.single_temp.has_aoe
     & evt.geds.psd.is_good
 )
 _plot_ehist(
     ax,
     base_mask,
     color="silver",
-    label="geds.is_good_channel & geds.psd.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
+    label="geds.is_good_channel & geds.psd.single_temp.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
 )
 _plot_ehist(
     ax,
-    lambda evt: base_mask(evt) & evt.geds.psd.is_single_site,
+    lambda evt: base_mask(evt) & evt.geds.psd.single_temp.is_single_site,
     color="tab:green",
-    label="... geds.psd.is_single_site",
+    label="... geds.psd.single_temp.is_single_site",
 )
 _plot_ehist(
     ax,
-    lambda evt: base_mask(evt) & evt.geds.psd.is_single_site & ~evt.coincident.spms,
+    lambda evt: base_mask(evt)
+    & evt.geds.psd.single_temp.is_single_site
+    & ~evt.coincident.spms,
     color="tab:red",
     label="... ~coincident.spms",
 )

--- a/workflow/src/legendsimflow/scripts/plots/tier_hit_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_hit_observables.py
@@ -80,7 +80,7 @@ def fig(table):
 
     # A/E
     ax = fig.add_subplot(gs_mid[0, 0])
-    aoe_raw = data.psd.aoe_corr[data.energy > 100]
+    aoe_raw = data.psd.single_temp.aoe_corr[data.energy > 100]
     h_aoe = hist.new.Reg(200, 0, 2, name="A/E").Double()
     h_aoe.fill(aoe_raw)
 
@@ -90,7 +90,7 @@ def fig(table):
             ax,
             color="tab:red",
             label="energy > 100 keV",
-            n_nans=n_nans(data.psd.aoe_corr),
+            n_nans=n_nans(data.psd.single_temp.aoe_corr),
         )
         if plotted:
             ax.legend()
@@ -102,7 +102,7 @@ def fig(table):
     h_dt = hist.new.Reg(
         300, 0, 3000, name="drift time · $t_{max(A)} - t_0$ (ns)"
     ).Double()
-    dt = data.psd.drift_time_amax[data.energy > 100]
+    dt = data.psd.single_temp.drift_time_amax[data.energy > 100]
     h_dt.fill(dt)
 
     if len(dt) > 0:
@@ -111,7 +111,7 @@ def fig(table):
             ax,
             color="tab:orange",
             label="energy > 100 keV",
-            n_nans=n_nans(data.psd.drift_time_amax),
+            n_nans=n_nans(data.psd.single_temp.drift_time_amax),
         )
         if plotted:
             ax.legend()
@@ -132,12 +132,12 @@ def fig(table):
 
     # A/E classifier
     _d = data[data.energy > 1000][:10_000]
-    _ss = _d.psd.is_single_site
+    _ss = _d.psd.single_temp.is_single_site
 
     ax1 = fig.add_subplot(gs_bot[0, 0])
-    h_aoec = hist.new.Reg(100, -20, 5).Double().fill(_d.psd.aoe[_ss])
+    h_aoec = hist.new.Reg(100, -20, 5).Double().fill(_d.psd.single_temp.aoe[_ss])
     plot.plot_hist(
-        hist.new.Reg(100, -20, 5).Double().fill(_d.psd.aoe[~_ss]),
+        hist.new.Reg(100, -20, 5).Double().fill(_d.psd.single_temp.aoe[~_ss]),
         ax1,
         color="tab:gray",
         flow="none",
@@ -166,9 +166,13 @@ def fig(table):
 
     ax2 = fig.add_subplot(gs_bot[0, 1], sharey=ax1)
     ax2.scatter(
-        _d.energy[_ss], _d.psd.aoe[_ss], s=2, color="tab:red", label="is_single_site"
+        _d.energy[_ss],
+        _d.psd.single_temp.aoe[_ss],
+        s=2,
+        color="tab:red",
+        label="is_single_site",
     )
-    ax2.scatter(_d.energy[~_ss], _d.psd.aoe[~_ss], s=2, color="tab:gray")
+    ax2.scatter(_d.energy[~_ss], _d.psd.single_temp.aoe[~_ss], s=2, color="tab:gray")
     ax2.set_xlim(1000, None)
     ax2.set_ylim(-20, 5)
     ax2.set_xlabel("energy (keV)")

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -422,8 +422,9 @@ def main() -> None:
                     "geds/hit_idx", VectorOfVectors(tcm["hit"].row_in_table[hitsel])
                 )
 
-                # PSD subtable
-                if simulate_psd:
+                # PSD subtable: common flags live directly under psd, while
+                # method-specific fields go into dedicated subtables
+                if simulate_psd or simulate_psd_with_psl:
                     out_table.add_field("geds/psd", Table(size=len(unified_tcm)))
                     out_table.add_field(
                         "geds/psd/is_good",
@@ -436,69 +437,83 @@ def main() -> None:
                         VectorOfVectors(is_valid_sim[hitsel]),
                     )
 
+                # single-template A/E PSD
+                if simulate_psd:
+                    out_table.add_field(
+                        "geds/psd/single_temp", Table(size=len(unified_tcm))
+                    )
+
                     aoe = _read_hits(tcm, "hit", "psd/aoe")
                     out_table.add_field(
-                        "geds/psd/aoe",
+                        "geds/psd/single_temp/aoe",
                         VectorOfVectors(ak.values_astype(aoe[hitsel], np.float32)),
                     )
                     drift_time = _read_hits(tcm, "hit", "psd/drift_time_amax")
                     out_table.add_field(
-                        "geds/psd/drift_time_amax",
+                        "geds/psd/single_temp/drift_time_amax",
                         VectorOfVectors(
                             ak.values_astype(drift_time[hitsel], np.float32)
                         ),
                     )
                     aoe_corr = _read_hits(tcm, "hit", "psd/aoe_corr")
                     out_table.add_field(
-                        "geds/psd/aoe_corr",
+                        "geds/psd/single_temp/aoe_corr",
                         VectorOfVectors(ak.values_astype(aoe_corr[hitsel], np.float32)),
                     )
                     out_table.add_field(
-                        "geds/psd/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel]))
+                        "geds/psd/single_temp/has_aoe",
+                        VectorOfVectors(~np.isnan(aoe[hitsel])),
                     )
 
                     is_ss = _read_hits(tcm, "hit", "psd/is_single_site")
                     out_table.add_field(
-                        "geds/psd/is_single_site", VectorOfVectors(is_ss[hitsel])
+                        "geds/psd/single_temp/is_single_site",
+                        VectorOfVectors(is_ss[hitsel]),
                     )
 
-                # PSL based PSD
+                # pulse-shape-library (PSL) based PSD
                 if simulate_psd_with_psl:
-                    out_table.add_field("geds/psd_psl", Table(size=len(unified_tcm)))
+                    out_table.add_field(
+                        "geds/psd/pulse_lib", Table(size=len(unified_tcm))
+                    )
 
                     aoe_corr = _read_hits(tcm, "hit", "psd_psl/aoe_corr")
                     out_table.add_field(
-                        "geds/psd_psl/aoe_corr",
+                        "geds/psd/pulse_lib/aoe_corr",
                         VectorOfVectors(ak.values_astype(aoe_corr[hitsel], np.float32)),
                     )
 
                     aoe = _read_hits(tcm, "hit", "psd_psl/aoe")
 
                     out_table.add_field(
-                        "geds/psd_psl/aoe",
+                        "geds/psd/pulse_lib/aoe",
                         VectorOfVectors(ak.values_astype(aoe[hitsel], np.float32)),
                     )
                     out_table.add_field(
-                        "geds/psd_psl/has_aoe", VectorOfVectors(~np.isnan(aoe[hitsel]))
+                        "geds/psd/pulse_lib/has_aoe",
+                        VectorOfVectors(~np.isnan(aoe[hitsel])),
                     )
                     drift_time = _read_hits(tcm, "hit", "psd_psl/drift_time_amax")
                     out_table.add_field(
-                        "geds/psd_psl/drift_time_amax",
+                        "geds/psd/pulse_lib/drift_time_amax",
                         VectorOfVectors(
                             ak.values_astype(drift_time[hitsel], np.float32)
                         ),
                     )
                     is_ss = _read_hits(tcm, "hit", "psd_psl/is_single_site")
                     out_table.add_field(
-                        "geds/psd_psl/is_single_site", VectorOfVectors(is_ss[hitsel])
+                        "geds/psd/pulse_lib/is_single_site",
+                        VectorOfVectors(is_ss[hitsel]),
                     )
                     is_bb_like = _read_hits(tcm, "hit", "psd_psl/is_bb_like")
                     out_table.add_field(
-                        "geds/psd_psl/is_bb_like", VectorOfVectors(is_bb_like[hitsel])
+                        "geds/psd/pulse_lib/is_bb_like",
+                        VectorOfVectors(is_bb_like[hitsel]),
                     )
                     is_high_aoe = _read_hits(tcm, "hit", "psd_psl/is_high_aoe")
                     out_table.add_field(
-                        "geds/psd_psl/is_high_aoe", VectorOfVectors(is_high_aoe[hitsel])
+                        "geds/psd/pulse_lib/is_high_aoe",
+                        VectorOfVectors(is_high_aoe[hitsel]),
                     )
                 # compute multiplicity
                 geds_multiplicity = ak.sum(hitsel, axis=-1)

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -443,19 +443,21 @@ def main() -> None:
                         "geds/psd/single_temp", Table(size=len(unified_tcm))
                     )
 
-                    aoe = _read_hits(tcm, "hit", "psd/aoe")
+                    aoe = _read_hits(tcm, "hit", "psd/single_temp/aoe")
                     out_table.add_field(
                         "geds/psd/single_temp/aoe",
                         VectorOfVectors(ak.values_astype(aoe[hitsel], np.float32)),
                     )
-                    drift_time = _read_hits(tcm, "hit", "psd/drift_time_amax")
+                    drift_time = _read_hits(
+                        tcm, "hit", "psd/single_temp/drift_time_amax"
+                    )
                     out_table.add_field(
                         "geds/psd/single_temp/drift_time_amax",
                         VectorOfVectors(
                             ak.values_astype(drift_time[hitsel], np.float32)
                         ),
                     )
-                    aoe_corr = _read_hits(tcm, "hit", "psd/aoe_corr")
+                    aoe_corr = _read_hits(tcm, "hit", "psd/single_temp/aoe_corr")
                     out_table.add_field(
                         "geds/psd/single_temp/aoe_corr",
                         VectorOfVectors(ak.values_astype(aoe_corr[hitsel], np.float32)),
@@ -465,7 +467,7 @@ def main() -> None:
                         VectorOfVectors(~np.isnan(aoe[hitsel])),
                     )
 
-                    is_ss = _read_hits(tcm, "hit", "psd/is_single_site")
+                    is_ss = _read_hits(tcm, "hit", "psd/single_temp/is_single_site")
                     out_table.add_field(
                         "geds/psd/single_temp/is_single_site",
                         VectorOfVectors(is_ss[hitsel]),
@@ -477,13 +479,13 @@ def main() -> None:
                         "geds/psd/pulse_lib", Table(size=len(unified_tcm))
                     )
 
-                    aoe_corr = _read_hits(tcm, "hit", "psd_psl/aoe_corr")
+                    aoe_corr = _read_hits(tcm, "hit", "psd/pulse_lib/aoe_corr")
                     out_table.add_field(
                         "geds/psd/pulse_lib/aoe_corr",
                         VectorOfVectors(ak.values_astype(aoe_corr[hitsel], np.float32)),
                     )
 
-                    aoe = _read_hits(tcm, "hit", "psd_psl/aoe")
+                    aoe = _read_hits(tcm, "hit", "psd/pulse_lib/aoe")
 
                     out_table.add_field(
                         "geds/psd/pulse_lib/aoe",
@@ -493,24 +495,24 @@ def main() -> None:
                         "geds/psd/pulse_lib/has_aoe",
                         VectorOfVectors(~np.isnan(aoe[hitsel])),
                     )
-                    drift_time = _read_hits(tcm, "hit", "psd_psl/drift_time_amax")
+                    drift_time = _read_hits(tcm, "hit", "psd/pulse_lib/drift_time_amax")
                     out_table.add_field(
                         "geds/psd/pulse_lib/drift_time_amax",
                         VectorOfVectors(
                             ak.values_astype(drift_time[hitsel], np.float32)
                         ),
                     )
-                    is_ss = _read_hits(tcm, "hit", "psd_psl/is_single_site")
+                    is_ss = _read_hits(tcm, "hit", "psd/pulse_lib/is_single_site")
                     out_table.add_field(
                         "geds/psd/pulse_lib/is_single_site",
                         VectorOfVectors(is_ss[hitsel]),
                     )
-                    is_bb_like = _read_hits(tcm, "hit", "psd_psl/is_bb_like")
+                    is_bb_like = _read_hits(tcm, "hit", "psd/pulse_lib/is_bb_like")
                     out_table.add_field(
                         "geds/psd/pulse_lib/is_bb_like",
                         VectorOfVectors(is_bb_like[hitsel]),
                     )
-                    is_high_aoe = _read_hits(tcm, "hit", "psd_psl/is_high_aoe")
+                    is_high_aoe = _read_hits(tcm, "hit", "psd/pulse_lib/is_high_aoe")
                     out_table.add_field(
                         "geds/psd/pulse_lib/is_high_aoe",
                         VectorOfVectors(is_high_aoe[hitsel]),

--- a/workflow/src/legendsimflow/scripts/tier/hit.py
+++ b/workflow/src/legendsimflow/scripts/tier/hit.py
@@ -549,7 +549,12 @@ def main() -> None:
                         np.asarray(energy, dtype=np.float32), attrs={"units": "keV"}
                     ),
                 )
-                # save psd fields
+                # save psd fields: method-specific fields go into dedicated
+                # subtables under a common psd parent, one per simulation method
+                if simulate_psd or simulate_psd_with_psl:
+                    psd_table = Table(size=len(out_table))
+
+                # single-template A/E
                 if simulate_psd:
                     psd_sub_table = Table(size=len(out_table))
                     psd_sub_table.add_field(
@@ -576,9 +581,9 @@ def main() -> None:
                         "is_single_site", lgdo.Array(psd_fields.is_single_site)
                     )
 
-                    out_table.add_field("psd", psd_sub_table)
+                    psd_table.add_field("single_temp", psd_sub_table)
 
-                # detailed psd fields
+                # pulse-shape-library (PSL) based
                 if simulate_psd_with_psl:
                     psd_sub_table_psl = Table(size=len(out_table))
 
@@ -619,7 +624,10 @@ def main() -> None:
                         "is_single_site",
                         lgdo.Array(psd_fields_detailed.is_single_site),
                     )
-                    out_table.add_field("psd_psl", psd_sub_table_psl)
+                    psd_table.add_field("pulse_lib", psd_sub_table_psl)
+
+                if simulate_psd or simulate_psd_with_psl:
+                    out_table.add_field("psd", psd_table)
 
                 _, period, run, _ = mutils.parse_runid(runid)
                 field_vals = [period, run, mutils.encode_usability(usability)]

--- a/workflow/src/legendsimflow/scripts/tier/pdf.py
+++ b/workflow/src/legendsimflow/scripts/tier/pdf.py
@@ -151,7 +151,9 @@ def main() -> None:
     # events without a valid or simulated A/E are classified as background (cut).
     def _psd_mask(d: ak.Array) -> ak.Array:
         return ak.all(
-            d.geds.psd.is_good & d.geds.psd.has_aoe & d.geds.psd.is_single_site,
+            d.geds.psd.is_good
+            & d.geds.psd.single_temp.has_aoe
+            & d.geds.psd.single_temp.is_single_site,
             axis=-1,
         )
 
@@ -213,7 +215,10 @@ def main() -> None:
                 )
 
             psd_fail_mask = (
-                ak.all(data_m1.geds.psd.is_good & data_m1.geds.psd.has_aoe, axis=-1)
+                ak.all(
+                    data_m1.geds.psd.is_good & data_m1.geds.psd.single_temp.has_aoe,
+                    axis=-1,
+                )
                 & ~psd_pass_m1
             )
             data_m1_psd_fail = data_m1[psd_fail_mask]


### PR DESCRIPTION
Closes #293.

Restructures the `evt`-tier `geds/psd` subtable so that method-specific fields are grouped into dedicated per-method subtables, while flags common to every PSD method stay directly below `psd`:

- `geds/psd/single_temp` — single-template A/E fields (`aoe`, `aoe_corr`, `drift_time_amax`, `has_aoe`, `is_single_site`), previously written directly under `geds/psd`.
- `geds/psd/pulse_lib` — pulse-shape-library (PSL) fields (the same A/E fields plus `is_bb_like`, `is_high_aoe`), previously the separate `geds/psd_psl` subtable.
- `is_good` and `is_valid_sim` remain directly under `geds/psd`. They are now written whenever at least one PSD method is enabled (before, they were tied to `simulate_psd`).

### Scope

- `evt` tier (`scripts/tier/evt.py`): the actual restructure.
- `pdf` tier (`scripts/tier/pdf.py`): PSD cut masks now read `psd.single_temp.has_aoe` / `psd.single_temp.is_single_site` (`psd.is_good` unchanged).
- `cvt` observables plot (`scripts/plots/tier_cvt_observables.py`): updated to the new paths.
- The `hit` tier applies the same grouping so its layout matches the `evt` tier: the former top-level `psd` and `psd_psl` subtables become `psd/single_temp` and `psd/pulse_lib` under a common `psd` parent. The `evt` tier reads the fields back from the new nested paths, and the hit observables plot is updated to match.
- The `cvt` tier merges tables generically and needs no change; the nested structure passes through transparently.
- Tests (`test_tier_evt.py`, `test_tier_pdf.py`) and `docs/source/manual/output.md` updated to the new layout.

### Testing

- `pytest tests/scripts/test_tier_pdf.py` and the remage-gated `test_tier_hit.py` / `test_tier_evt.py` pass with the new structure.
- The full `test_l1000_workflow` integration test (vtx→pdf, both PSD methods enabled) passes, exercising the `psd/pulse_lib` hit→evt path end-to-end.
- `pre-commit run --all-files` passes.
- `cd docs && make` builds without warnings.

### New `evt`-tier layout

`lh5ls` of the `evt` table (both PSD methods enabled), with the restructured `geds/psd` subtable:

```
evt
├── coincident
│   ├── geds
│   └── spms
├── geds
│   ├── energy
│   ├── energy_sum
│   ├── hit_idx
│   ├── is_good_channel
│   ├── multiplicity
│   ├── psd
│   │   ├── is_good
│   │   ├── is_valid_sim
│   │   ├── single_temp
│   │   │   ├── aoe
│   │   │   ├── aoe_corr
│   │   │   ├── drift_time_amax
│   │   │   ├── has_aoe
│   │   │   └── is_single_site
│   │   └── pulse_lib
│   │       ├── aoe
│   │       ├── aoe_corr
│   │       ├── drift_time_amax
│   │       ├── has_aoe
│   │       ├── is_bb_like
│   │       ├── is_high_aoe
│   │       └── is_single_site
│   └── rawid
├── spms
│   ├── energy
│   ├── energy_sum
│   ├── hit_idx
│   ├── is_saturated
│   ├── multiplicity
│   ├── rawid
│   └── time
└── trigger
    ├── evtid
    ├── period
    ├── run
    └── timestamp
```


### New `hit`-tier layout

`lh5ls` of a per-detector `psd` subtable in the `hit` tier (both PSD methods enabled):

```
hit/<detector>/psd
├── single_temp
│   ├── aoe
│   ├── aoe_corr
│   ├── aoe_raw
│   ├── drift_time_amax
│   └── is_single_site
└── pulse_lib
    ├── aoe
    ├── aoe_corr
    ├── aoe_raw
    ├── drift_time_amax
    ├── is_bb_like
    ├── is_high_aoe
    └── is_single_site
```

