### PR TITLE
feat: store HPGe SSD-modeling provenance as detinfo metadata

### DIFF
--- a/docs/source/manual/output.md
+++ b/docs/source/manual/output.md
@@ -71,6 +71,27 @@ modeling flags for **every deployed germanium** detector:
 | `is_modelable.yaml`             | `true` / `false` | Whether the detector is suitable for drift-time-map and current-pulse modeling. See {ref}`hpge-modeling-criteria` for the eligibility criteria. |
 | `operational_voltage_in_V.yaml` | integer / `null` | Operational bias voltage read from the parameters database. `null` for detectors with no bias (e.g. off detectors).                             |
 
+Unlike the flags above (queried from `legend-metadata`), the
+[`aggregate_hpge_ssd_modeling_info`](../api/snakemake_rules.md) rule writes a
+single file whose values are **outputs of the SSD simulation** run for each
+drift-time map. Its `runid -> detector` leaves are a nested mapping rather than
+a scalar:
+
+| File                     | Applies to | Description                                                                         |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------------- |
+| `hpge_ssd_modeling.yaml` | geds       | SSD-modeling provenance for each modelable detector: the four scalars listed below. |
+
+| Key                                    | Type           | Units | Description                                                                                                                             |
+| -------------------------------------- | -------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `impurity_scaling_factor`              | float / `null` | —     | Dimensionless factor applied to the crystal impurities to match the measured depletion voltage. `null` when no rescaling was performed. |
+| `measured_depletion_voltage_in_V`      | float / `null` | V     | Measured depletion voltage from `legend-metadata` (`characterization.l200_site.depletion_voltage_in_V`). `null` when absent.            |
+| `simulated_depletion_voltage_raw_in_V` | float          | V     | Depletion voltage estimated from the simulation before the impurity rescaling.                                                          |
+| `simulated_depletion_voltage_in_V`     | float          | V     | Depletion voltage estimated from the simulation after the impurity rescaling and bias adjustment.                                       |
+
+This file is produced together with the drift-time maps, so it is written only
+when the `hit` tier is built with PSD enabled (`simulate_psd`, see
+{ref}`hit-tier-settings`).
+
 ## `hit` tier — HPGe detector post-processing
 
 The `hit` tier applies detector response models (energy resolution, pulse-shape

--- a/docs/source/manual/pipeline.md
+++ b/docs/source/manual/pipeline.md
@@ -180,6 +180,16 @@ file is created.
 The `SolidStateDetectors.jl` (SSD) simulation parameters (grid size, refinement
 thresholds, padding) are controlled by {ref}`ssd-settings-meta`.
 
+Both this simulation and the ideal pulse-shape library tune the crystal impurity
+profile so that the _simulated_ depletion voltage reproduces the _measured_ one
+(`characterization.l200_site.depletion_voltage_in_V` in the diode metadata): any
+impurity-curve corrections stored in the metadata are reset, the impurity
+density is rescaled to match the measurement, and the job aborts if the two
+depletion voltages still disagree by more than a fixed threshold (200 V). The
+resulting impurity scaling factor and the raw and corrected depletion voltages
+are recorded as provenance in `pars/detinfo/hpge_ssd_modeling.yaml` (see
+{ref}`par-detinfo`).
+
 (hpge-ideal-psl-extraction)=
 
 ### Ideal HPGe pulse-shape library

--- a/tests/scripts/test_make_hpge_drift_time_maps.py
+++ b/tests/scripts/test_make_hpge_drift_time_maps.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import dbetto
 import lh5
 import pytest
 
@@ -16,6 +17,7 @@ repo_root = Path(__file__).parent.parent.parent
 def test_make_hpge_drift_time_maps_l1000(tmp_path):
     """Run the Julia drift time map script and verify the output LH5 structure."""
     dtmap_file = tmp_path / "V05261B-4200V-hpge-drift-time-map.lh5"
+    info_file = tmp_path / "V05261B-4200V-hpge-ssd-modeling.yaml"
 
     subprocess.run(
         [
@@ -40,6 +42,8 @@ def test_make_hpge_drift_time_maps_l1000(tmp_path):
             ),
             "--output-file",
             str(dtmap_file),
+            "--info-file",
+            str(info_file),
         ],
         check=True,
         cwd=repo_root,
@@ -55,3 +59,23 @@ def test_make_hpge_drift_time_maps_l1000(tmp_path):
         assert f"V05261B/{expected}" in inner_keys, (
             f"Expected dataset 'V05261B/{expected}' in LH5, found: {inner_keys}"
         )
+
+    # the SSD-modeling provenance scalars are stored in the sidecar, not the LH5
+    for scalar in (
+        "impurity_scaling_factor",
+        "measured_depletion_voltage_in_V",
+        "simulated_depletion_voltage_raw_in_V",
+        "simulated_depletion_voltage_in_V",
+    ):
+        assert f"V05261B/{scalar}" not in inner_keys, (
+            f"Scalar '{scalar}' should not be stored in the LH5 map"
+        )
+
+    assert info_file.exists(), "SSD-modeling info sidecar was not created"
+    info = dbetto.utils.load_dict(info_file)
+    assert set(info) == {
+        "impurity_scaling_factor",
+        "measured_depletion_voltage_in_V",
+        "simulated_depletion_voltage_raw_in_V",
+        "simulated_depletion_voltage_in_V",
+    }

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import dbetto
 import pytest
 from dbetto import AttrsDict
 
@@ -206,6 +207,41 @@ def test_dtmap_stuff(config):
     for p in agg.gen_list_of_dtmap_plots_outputs(config, simid):
         assert p in par_plots
     assert len(agg.gen_list_of_all_plots_outputs(config, "par")) >= 1
+
+
+def test_hpge_ssd_modeling_info_aggregation(fresh_config, tmp_path):
+    config = fresh_config
+    # keep the fake sidecars out of the shared dummyprod output tree
+    config.paths["dtmaps"] = tmp_path
+
+    # the modeling cache the Snakemake rule would pass in: runid -> det -> {opv}.
+    # two runids share the same (detector, voltage), so the sidecar is shared
+    cache = {
+        "l200-p02-r000-phy": {"V02160A": {"operational_voltage_in_V": 4200}},
+        "l200-p02-r001-phy": {"V02160A": {"operational_voltage_in_V": 4200}},
+    }
+
+    # one sidecar per (detector, voltage), deduplicated across runids
+    info_files = agg.gen_list_of_dtmap_info_files(config, cache)
+    assert len(info_files) == 1
+    assert "4200V" in str(info_files[0])
+    assert info_files[0].suffix == ".yaml"
+
+    # write a fake sidecar and check the pivot into runid -> det -> {scalars}
+    sidecar = {
+        "impurity_scaling_factor": 0.97,
+        "measured_depletion_voltage_in_V": 3600,
+        "simulated_depletion_voltage_raw_in_V": 3810,
+        "simulated_depletion_voltage_in_V": 3650,
+    }
+    info_files[0].parent.mkdir(parents=True, exist_ok=True)
+    dbetto.utils.write_dict(sidecar, info_files[0])
+
+    collected = agg.collect_hpge_ssd_modeling_info(config, cache)
+    assert collected == {
+        "l200-p02-r000-phy": {"V02160A": sidecar},
+        "l200-p02-r001-phy": {"V02160A": sidecar},
+    }
 
 
 def test_par_plots_psd_gate(fresh_config):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -61,6 +61,7 @@ STD_PSD_RULES = {
     "build_hpge_drift_time_map",
     "merge_hpge_drift_time_maps",
     "plot_hpge_drift_time_maps",
+    "aggregate_hpge_ssd_modeling_info",
     "extract_current_pulse_model",
     "merge_current_pulse_model_pars",
 }

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -189,6 +189,15 @@ def test_dtmap_filenames(config):
     assert result.suffix == ".lh5"
     assert "singles" in str(result)
 
+    result = p.output_dtmap_info_filename(
+        config, hpge_detector=DET, hpge_voltage=VOLTAGE
+    )
+    assert isinstance(result, Path)
+    assert DET in str(result)
+    assert f"{VOLTAGE}V" in str(result)
+    assert result.suffix == ".yaml"
+    assert "singles" in str(result)
+
     result = p.output_dtmap_merged_filename(config, runid=RUNID)
     assert isinstance(result, Path)
     assert RUNID in str(result)

--- a/workflow/rules/hit.smk
+++ b/workflow/rules/hit.smk
@@ -16,6 +16,13 @@ rule gen_all_tier_hit:
     input:
         aggregate.gen_list_of_all_simid_outputs(config, tier="hit"),
         lambda wc: aggregate.gen_list_of_all_plots_outputs(config, tier="hit"),
+        # SSD-modeling provenance detinfo, aggregated from the drift-time-map
+        # sidecars; gated by the same `simulate_psd` setting that builds them
+        lambda wc: (
+            [patterns.detinfo_filename(config, "hpge_ssd_modeling")]
+            if get_tier_settings(config, "hit").get("simulate_psd", True)
+            else []
+        ),
 
 
 # NOTE: we don't rely on rules from other tiers here (e.g.

--- a/workflow/rules/par.smk
+++ b/workflow/rules/par.smk
@@ -127,7 +127,8 @@ rule build_hpge_drift_time_map:
     params:
         metadata_path=config.paths.metadata,
     output:
-        patterns.output_dtmap_filename(config),
+        dtmap_file=patterns.output_dtmap_filename(config),
+        info_file=patterns.output_dtmap_info_filename(config),
     log:
         patterns.log_dtmap_filename(config),
     benchmark:
@@ -141,7 +142,8 @@ rule build_hpge_drift_time_map:
         f"   --metadata {config.paths.metadata}"
         "    --ssd-settings {input.ssd_settings}"
         "    --opv {wildcards.hpge_voltage}"
-        "    --output-file {output} &> {log}"
+        "    --output-file {output.dtmap_file}"
+        "    --info-file {output.info_file} &> {log}"
 
 
 rule merge_hpge_drift_time_maps:
@@ -187,6 +189,36 @@ rule merge_hpge_drift_time_maps:
         """
 
 
+rule aggregate_hpge_ssd_modeling_info:
+    """Aggregate the HPGe SSD-modeling provenance into a `detinfo` file.
+
+    Each `build_hpge_drift_time_map` job writes, next to its LH5 map, a small
+    YAML sidecar holding the SSD simulation provenance scalars for that
+    `(detector, voltage)` pair (impurity scaling factor, measured and simulated
+    depletion voltages). This rule collects those sidecars and pivots them into
+    a single `pars/detinfo/hpge_ssd_modeling.yaml` mapping `runid -> detector ->
+    {impurity_scaling_factor, measured_depletion_voltage_in_V,
+    simulated_depletion_voltage_raw_in_V, simulated_depletion_voltage_in_V}`,
+    following the `detinfo` convention (see {ref}`par-detinfo`).
+
+    No wildcards are used.
+    """
+    localrule: True
+    message:
+        "Aggregating HPGe SSD-modeling provenance into a detinfo file"
+    input:
+        lambda wc: aggregate.gen_list_of_dtmap_info_files(
+            config, cache=smk_load_hpge_cache()
+        ),
+    output:
+        patterns.detinfo_filename(config, "hpge_ssd_modeling"),
+    run:
+        import dbetto
+
+        info = aggregate.collect_hpge_ssd_modeling_info(config, smk_load_hpge_cache())
+        dbetto.utils.write_dict(info, output[0])
+
+
 rule plot_hpge_drift_time_maps:
     """Produce a validation plot of an HPGe drift-time map.
 
@@ -198,7 +230,7 @@ rule plot_hpge_drift_time_maps:
     message:
         "Plotting drift-time map for HPGe {wildcards.hpge_detector} at {wildcards.hpge_voltage}V"
     input:
-        rules.build_hpge_drift_time_map.output,
+        rules.build_hpge_drift_time_map.output.dtmap_file,
     output:
         patterns.plot_dtmap_filename(config),
     script:

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -480,11 +480,18 @@ checks depletion voltage, and calculates weighting potential.
 - `recompute_corrections`: flag to recompute impurity corrections to match depletion.
 # Returns
 - `sim`: Fully configured SolidStateDetectors Simulation object
-- `info`: dictionary of information on the SSD simulation, contains:
-    - `:impurity_scale`:scaling factor for impurities to match measured depletion voltage
-    - `:vdep_raw`: unscaled depletion voltage
-    - `:vdep_corr`: scaled depletion voltage
-    - `:vdep_meas`: measured depletion voltage
+- `info`: dictionary of provenance on the SSD simulation, serialization-ready
+  (Unitful quantities stripped to plain numbers, missing values normalized to
+  `nothing`), with explicit keys:
+    - `:impurity_scaling_factor`: dimensionless scaling factor applied to the
+      impurities to match the measured depletion voltage (`nothing` when no
+      rescaling was performed)
+    - `:measured_depletion_voltage_in_V`: measured depletion voltage from
+      `legend-metadata` (`nothing` when absent)
+    - `:simulated_depletion_voltage_raw_in_V`: simulated depletion voltage
+      before the impurity rescaling
+    - `:simulated_depletion_voltage_in_V`: simulated depletion voltage after
+      the impurity rescaling and bias adjustment
 
 """
 function setup_hpge_simulation(meta_path::String,
@@ -568,7 +575,18 @@ function setup_hpge_simulation(meta_path::String,
         verbose = false
     )
 
-    return sim, Dict(:impurity_scale=>scale, :vdep_meas=>vdep, :vdep_raw=>dep_raw, :vdep_corr=>dep)
+    # normalize into a serialization-ready provenance dict with explicit names:
+    # strip Unitful voltages to plain numbers (in V) and map missing measured
+    # depletion voltage to `nothing`
+    vdep_meas = (vdep isa PropDicts.MissingProperty || vdep === nothing) ? nothing : Float64(vdep)
+
+    return sim,
+    Dict(
+        :impurity_scaling_factor => scale,
+        :measured_depletion_voltage_in_V => vdep_meas,
+        :simulated_depletion_voltage_raw_in_V => ustrip(u"V", dep_raw),
+        :simulated_depletion_voltage_in_V => ustrip(u"V", dep)
+    )
 end
 
 

--- a/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
+++ b/workflow/src/LegendSimflow.jl/src/pulse_shape_sim_helpers.jl
@@ -467,6 +467,16 @@ Set up and run the full SSD simulation for an HPGe detector: builds the simulati
 applies the ADL charge drift model, calculates electric potential, electric field,
 checks depletion voltage, and calculates weighting potential.
 
+When a measured depletion voltage is available in the metadata
+(`characterization.l200_site.depletion_voltage_in_V`) and `recompute_corrections`
+is set, the crystal impurity profile is tuned so the *simulated* depletion
+voltage reproduces the *measured* one: any pre-existing impurity-curve
+corrections (`impurity_curve.corrections.scale`/`offset`) are reset to identity,
+the raw (uncorrected) depletion voltage is estimated, and the impurity density is
+then rescaled to match the measurement. The run aborts if the simulated and
+measured depletion voltages still differ by more than `threshold`. The resulting
+scaling factor and the raw/corrected depletion voltages are returned in `info`.
+
 # Arguments
 - `meta_path`: Path to legend-metadata
 - `meta`: Detector metadata (PropDict)
@@ -477,7 +487,9 @@ checks depletion voltage, and calculates weighting potential.
 -  `threshold`: Maximum allowed difference between simulated and measured depletion voltage (default: 200 V)
 - `medium`: Detector environment medium (default: "LAr")
 - `temperature`: Detector environment temperature in K (default: 87 K)
-- `recompute_corrections`: flag to recompute impurity corrections to match depletion.
+- `recompute_corrections`: when `true` (default), rescale the crystal impurity
+  profile so the simulated depletion voltage matches the measured one (see
+  above); when `false`, keep the impurity corrections as stored in the metadata.
 # Returns
 - `sim`: Fully configured SolidStateDetectors Simulation object
 - `info`: dictionary of provenance on the SSD simulation, serialization-ready

--- a/workflow/src/LegendSimflow.jl/test/test_lib.jl
+++ b/workflow/src/LegendSimflow.jl/test/test_lib.jl
@@ -79,10 +79,13 @@ end
     @test sim.detector.semiconductor.charge_drift_model.temperaturemodel.reference_temperature == T(87)
 
     @test info isa Dict
-    @test haskey(info, :impurity_scale)
-    @test haskey(info, :vdep_raw)
-    @test haskey(info, :vdep_corr)
-    @test haskey(info, :vdep_meas)
+    @test haskey(info, :impurity_scaling_factor)
+    @test haskey(info, :simulated_depletion_voltage_raw_in_V)
+    @test haskey(info, :simulated_depletion_voltage_in_V)
+    @test haskey(info, :measured_depletion_voltage_in_V)
+    # depletion voltages are serialization-ready plain numbers (Unitful stripped)
+    @test info[:simulated_depletion_voltage_in_V] isa Real
+    @test info[:simulated_depletion_voltage_raw_in_V] isa Real
 
     # test valid spawn pos
     # Candidate positions include one valid and one invalid

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -518,12 +518,7 @@ def gen_list_of_dtmap_info_files(
     config: SimflowConfig,
     cache: Mapping[str, Mapping[str, Mapping[str, int]]],
 ) -> list[Path]:
-    """Deduplicated list of HPGe SSD-modeling info sidecars for the modeling `cache`.
-
-    One sidecar exists per ``(detector, voltage)`` pair, so the same file is
-    shared across every runid operating a detector at the same voltage; the
-    returned list is deduplicated.
-    """
+    """Deduplicated list of HPGe SSD-modeling info sidecars for the modeling `cache`."""
     seen: dict[str, Path] = {}
     for dets in cache.values():
         for hpge, entry in dets.items():
@@ -540,13 +535,10 @@ def collect_hpge_ssd_modeling_info(
     config: SimflowConfig,
     cache: Mapping[str, Mapping[str, Mapping[str, int]]],
 ) -> dict[str, dict[str, dict[str, object]]]:
-    """Aggregate the HPGe SSD-modeling sidecars into a ``runid -> detector`` mapping.
-
-    Reads the per-``(detector, voltage)`` YAML sidecars written next to the
-    drift-time maps (see :func:`legendsimflow.patterns.output_dtmap_info_filename`)
-    and lays them out as ``runid -> detector -> {scalars}`` following the
-    ``detinfo`` convention. Expects every referenced sidecar to exist on disk.
-    """
+    """Aggregate the HPGe SSD-modeling sidecars into a ``runid -> detector -> {scalars}`` mapping."""
+    # a single sidecar is shared by every runid operating a detector at the same
+    # voltage, so cache each file's contents to read it from disk only once
+    loaded: dict[str, dict[str, object]] = {}
     out: dict[str, dict[str, dict[str, object]]] = {}
     for runid, dets in cache.items():
         for hpge, entry in dets.items():
@@ -555,7 +547,10 @@ def collect_hpge_ssd_modeling_info(
                 hpge_detector=hpge,
                 hpge_voltage=entry["operational_voltage_in_V"],
             )
-            out.setdefault(runid, {})[hpge] = dict(dbetto.utils.load_dict(path))
+            key = str(path)
+            if key not in loaded:
+                loaded[key] = dict(dbetto.utils.load_dict(path))
+            out.setdefault(runid, {})[hpge] = dict(loaded[key])
     return out
 
 

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -19,6 +19,7 @@ import logging
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 
+import dbetto
 from dbetto import AttrsDict
 from legendmeta.police import validate_dict_schema
 
@@ -511,6 +512,51 @@ def gen_list_of_dtmaps(
         )
         for hpge, entry in hpge_voltages.items()
     ]
+
+
+def gen_list_of_dtmap_info_files(
+    config: SimflowConfig,
+    cache: Mapping[str, Mapping[str, Mapping[str, int]]],
+) -> list[Path]:
+    """Deduplicated list of HPGe SSD-modeling info sidecars for the modeling `cache`.
+
+    One sidecar exists per ``(detector, voltage)`` pair, so the same file is
+    shared across every runid operating a detector at the same voltage; the
+    returned list is deduplicated.
+    """
+    seen: dict[str, Path] = {}
+    for dets in cache.values():
+        for hpge, entry in dets.items():
+            path = patterns.output_dtmap_info_filename(
+                config,
+                hpge_detector=hpge,
+                hpge_voltage=entry["operational_voltage_in_V"],
+            )
+            seen[str(path)] = path
+    return list(seen.values())
+
+
+def collect_hpge_ssd_modeling_info(
+    config: SimflowConfig,
+    cache: Mapping[str, Mapping[str, Mapping[str, int]]],
+) -> dict[str, dict[str, dict[str, object]]]:
+    """Aggregate the HPGe SSD-modeling sidecars into a ``runid -> detector`` mapping.
+
+    Reads the per-``(detector, voltage)`` YAML sidecars written next to the
+    drift-time maps (see :func:`legendsimflow.patterns.output_dtmap_info_filename`)
+    and lays them out as ``runid -> detector -> {scalars}`` following the
+    ``detinfo`` convention. Expects every referenced sidecar to exist on disk.
+    """
+    out: dict[str, dict[str, dict[str, object]]] = {}
+    for runid, dets in cache.items():
+        for hpge, entry in dets.items():
+            path = patterns.output_dtmap_info_filename(
+                config,
+                hpge_detector=hpge,
+                hpge_voltage=entry["operational_voltage_in_V"],
+            )
+            out.setdefault(runid, {})[hpge] = dict(dbetto.utils.load_dict(path))
+    return out
 
 
 def gen_list_of_merged_dtmaps(

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -286,6 +286,21 @@ def output_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
     )
 
 
+def output_dtmap_info_filename(config: SimflowConfig, **kwargs) -> Path:
+    """The path to the HPGe SSD-modeling info sidecar for a detector and voltage.
+
+    A small YAML file written next to each drift-time map holding the SSD
+    simulation provenance scalars (impurity scaling, measured and simulated
+    depletion voltages), aggregated downstream into the ``hpge_ssd_modeling``
+    :func:`detinfo_filename`.
+    """
+    return _expand(
+        config.paths.dtmaps
+        / "singles/{hpge_detector}-{hpge_voltage}V-hpge-ssd-modeling.yaml",
+        **kwargs,
+    )
+
+
 def output_dtmap_merged_filename(config: SimflowConfig, **kwargs) -> Path:
     """The path to the merged HPGe drift-time map file for a `runid`."""
     return _expand(config.paths.dtmaps / "{runid}-hpge-drift-time-maps.lh5", **kwargs)

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -287,13 +287,7 @@ def output_dtmap_filename(config: SimflowConfig, **kwargs) -> Path:
 
 
 def output_dtmap_info_filename(config: SimflowConfig, **kwargs) -> Path:
-    """The path to the HPGe SSD-modeling info sidecar for a detector and voltage.
-
-    A small YAML file written next to each drift-time map holding the SSD
-    simulation provenance scalars (impurity scaling, measured and simulated
-    depletion voltages), aggregated downstream into the ``hpge_ssd_modeling``
-    :func:`detinfo_filename`.
-    """
+    """The path to the HPGe SSD-modeling info sidecar for a detector and voltage."""
     return _expand(
         config.paths.dtmaps
         / "singles/{hpge_detector}-{hpge_voltage}V-hpge-ssd-modeling.yaml",

--- a/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl
+++ b/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl
@@ -88,6 +88,7 @@ function main()
     info_file = parsed_args["info-file"]
 
     isfile(output_file) && error("Output file already exists")
+    !isnothing(info_file) && isfile(info_file) && error("Info file already exists")
 
     raw_opv = parsed_args["opv"]
     opv_val = isnothing(raw_opv) ? nothing : parse(Float32, raw_opv)

--- a/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl
+++ b/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl
@@ -65,6 +65,11 @@ function main()
         required = true
     end
     @add_arg_table s begin
+        "--info-file"
+        help = "Path to output YAML file with the SSD-modeling provenance scalars (optional)"
+        default = nothing
+    end
+    @add_arg_table s begin
         "--opv"
         help = "detector operational voltage in V (defaults to metadata value)"
     end
@@ -80,6 +85,7 @@ function main()
     meta_path = parsed_args["metadata"]
     opv = parsed_args["opv"]
     output_file = parsed_args["output-file"]
+    info_file = parsed_args["info-file"]
 
     isfile(output_file) && error("Output file already exists")
 
@@ -108,10 +114,6 @@ function main()
         key = Symbol("drift_time_$(lpad(string(angle), 3, '0'))_deg")
         if output === nothing
             output = Dict{Symbol,Any}(pairs(result))
-
-            for (name, value) in info
-                output[name] = value
-            end
         else
             output[key] = result[key]
         end
@@ -120,6 +122,14 @@ function main()
     @info "Saving to disk..."
     lh5open(output_file, "cw") do f
         return f[det] = (; output...)
+    end
+
+    # the SSD-modeling provenance scalars (impurity scaling, measured and
+    # simulated depletion voltages) are stored separately as metadata, not as
+    # LH5 scalars; they are aggregated into a `detinfo` file downstream
+    if !isnothing(info_file)
+        @info "Saving SSD-modeling info to $info_file..."
+        writeprops(info_file, PropDict(info))
     end
 end
 

--- a/workflow/src/legendsimflow/scripts/make_hpge_ideal_pulse_shape_lib.jl
+++ b/workflow/src/legendsimflow/scripts/make_hpge_ideal_pulse_shape_lib.jl
@@ -92,7 +92,9 @@ function main()
     padding = get(sim_cfg, :padding, DEFAULT_PADDING)
 
     @info "using ref limits $ref_limits"
-    sim, info = setup_hpge_simulation(meta_path, meta, xtal, opv_val, T, ref_limits)
+    # the SSD-modeling provenance scalars are stored as metadata by the
+    # drift-time-map job, so the returned `info` is intentionally discarded here
+    sim, _ = setup_hpge_simulation(meta_path, meta, xtal, opv_val, T, ref_limits)
     output = nothing
     for a in CRYSTAL_AXIS_ANGLES
         result = compute_ideal_pulse_shape_lib(sim, meta, T, a, false, grid_size, padding)
@@ -100,11 +102,6 @@ function main()
         key = Symbol("waveform_$(lpad(string(a), 3, '0'))_deg")
         if output === nothing
             output = Dict{Symbol,Any}(pairs(result))
-
-            # also save the info
-            for (name, value) in info
-                output[name] = value
-            end
         else
             output[key] = result[key]
         end


### PR DESCRIPTION
The HPGe drift-time-map and pulse-shape-library Julia scripts embedded four SSD-simulation provenance scalars (`impurity_scale`, `vdep_meas`, `vdep_raw`, `vdep_corr`) as LH5 scalar fields inside the map/library files. Nothing downstream ever read them back (confirmed by grepping the Python package, the Snakemake rules, and reboost), so they were effectively orphan diagnostic fields living in binary outputs.

This PR moves them out of the LH5 and into a dedicated `par`-tier detinfo metadata file with explicit names.

## What changes

The drift-time-map job now writes a small YAML sidecar per `(detector, voltage)` next to its LH5 map, and a new `aggregate_hpge_ssd_modeling_info` rule pivots all sidecars into a single `pars/detinfo/hpge_ssd_modeling.yaml`, keyed `runid -> detector` following the existing detinfo convention:

```yaml
l200-p03-r000-phy:
  V00048A:
    impurity_scaling_factor: 0.97
    measured_depletion_voltage_in_V: 3600
    simulated_depletion_voltage_raw_in_V: 3810
    simulated_depletion_voltage_in_V: 3650
```

Field renames (LH5 scalar -> metadata field):

| old | new |
| --- | --- |
| `impurity_scale` | `impurity_scaling_factor` |
| `vdep_meas` | `measured_depletion_voltage_in_V` |
| `vdep_raw` | `simulated_depletion_voltage_raw_in_V` |
| `vdep_corr` | `simulated_depletion_voltage_in_V` |

Details:

- `setup_hpge_simulation` returns a serialization-ready dict: Unitful voltages stripped to plain numbers (in V), missing measured depletion voltage normalized to `null`.
- The drift-time-map script is the single producer (it is the baseline HPGe-modeling output; the ideal PSL is only built on the realistic-PSD path). Both Julia scripts stop embedding the scalars in their LH5 outputs.
- The aggregate rule is gated by the `simulate_psd` hit-tier setting and wired into `gen_all_tier_hit`, so `snakemake par` does not newly trigger SSD runs; the file is produced together with the drift-time maps.
- `measured_depletion_voltage_in_V` is kept (as a copy of `characterization.l200_site.depletion_voltage_in_V`) so the file is a self-contained "did the simulation match the measurement?" diagnostic.

## Tests / docs

- New coverage: `patterns.output_dtmap_info_filename`, `aggregate.gen_list_of_dtmap_info_files` / `collect_hpge_ssd_modeling_info`, the new rule added to `STD_PSD_RULES` in `test_dag`, and the Julia script test now asserts the sidecar is written and the scalars are absent from the LH5. `test_lib.jl` updated for the renamed keys.
- `docs/source/manual/output.md` documents the new detinfo file and its fields.

## Verification notes

- `pre-commit run --all-files` passes; Python test suite passes (my changes green).
- Two things could not be exercised in my local environment, both pre-existing and unrelated to this change: the `needs_julia` script test / `test_lib.jl` `map_generation` fail because the locally installed SolidStateDetectors lacks `adjust_impurity_and_electric_potential_to_match_depletion!` (fails before this code path), and the docs build needs `sphinx-apidoc` which is not installed locally. Both should run in CI.

## Note for reviewers

The YAML sidecar write relies on the `YAML` package being loaded transitively (via `LegendDataManagement` / `LegendHDF5IO`), the same mechanism the existing `readprops` calls already depend on. Happy to add `YAML` as a direct `LegendSimflow.jl` dependency if you would prefer it explicit.