### PR TITLE
fix: guard cvt-observables plot against skip_opt/skip_hit

### DIFF
--- a/tests/scripts/test_plot_cvt_observables.py
+++ b/tests/scripts/test_plot_cvt_observables.py
@@ -1,0 +1,218 @@
+# Copyright (C) 2026 Luigi Pertoldi <gipert@pm.me>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+
+import lh5
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from dbetto import AttrsDict
+from lgdo import Array, Scalar, Struct, Table, VectorOfVectors
+from snakemake.iocontainers import InputFiles
+
+import legendsimflow
+
+# the cvt-observables plot is a pure Snakemake script (no CLI ``main()``); it is
+# driven here via ``runpy`` with a mock ``snakemake`` global, mirroring how
+# Snakemake injects it at run time.
+_PLOT_SCRIPT = (
+    Path(legendsimflow.__file__).parent
+    / "scripts"
+    / "plots"
+    / "tier_cvt_observables.py"
+)
+
+
+def _write_cvt_root(path: Path, names: list[str], uids: list[int]) -> None:
+    """Write the cvt root metadata (detector_uids, number_of_simulated_events)."""
+    detector_uids = Struct(
+        {name: Scalar(int(uid)) for name, uid in zip(names, uids, strict=True)}
+    )
+    lh5.write(detector_uids, "detector_uids", str(path), wo_mode="append")
+    lh5.write(Scalar(1000), "number_of_simulated_events", str(path), wo_mode="append")
+
+
+def _trigger_table() -> Table:
+    return Table(col_dict={"timestamp": Array(np.zeros(4, dtype=np.float32))})
+
+
+def _geds_table() -> Table:
+    """A geds sub-table with the single-template PSD fields the plot reads."""
+    single_temp = Table(
+        col_dict={
+            "has_aoe": VectorOfVectors(data=[[True], [True], [True, True], [True]]),
+            "is_single_site": VectorOfVectors(
+                data=[[True], [False], [True, True], [True]]
+            ),
+        }
+    )
+    psd = Table(
+        col_dict={
+            "is_good": VectorOfVectors(data=[[True], [True], [True, True], [True]]),
+            "single_temp": single_temp,
+        }
+    )
+    return Table(
+        col_dict={
+            "energy": VectorOfVectors(
+                data=[[500.0], [1000.0], [200.0, 300.0], [2000.0]]
+            ),
+            "is_good_channel": VectorOfVectors(
+                data=[[True], [True], [True, True], [True]]
+            ),
+            "multiplicity": Array(np.array([1, 1, 2, 1], dtype=np.int32)),
+            "psd": psd,
+        }
+    )
+
+
+def _spms_table() -> Table:
+    """An spms sub-table; ``time`` is doubly-jagged (per channel, per pe)."""
+    return Table(
+        col_dict={
+            "multiplicity": Array(np.array([0, 2, 5, 1], dtype=np.int32)),
+            "energy_sum": Array(np.array([0.0, 10.0, 30.0, 3.0], dtype=np.float32)),
+            "time": VectorOfVectors(
+                data=[[[]], [[100.0, 200.0], [150.0]], [[50.0]], [[300.0]]]
+            ),
+        }
+    )
+
+
+def _make_cvt_full(path: Path) -> None:
+    """Full cvt file: both geds and spms tables, with coincident.spms."""
+    coincident = Table(
+        col_dict={
+            "geds": Array(np.array([True, True, False, True])),
+            "spms": Array(np.array([False, True, False, False])),
+        }
+    )
+    evt = Table(
+        col_dict={
+            "trigger": _trigger_table(),
+            "geds": _geds_table(),
+            "spms": _spms_table(),
+            "coincident": coincident,
+        }
+    )
+    lh5.write(evt, "evt", str(path), wo_mode="write_safe")
+    _write_cvt_root(path, ["V01", "B02"], [1, 2])
+
+
+def _make_cvt_skip_opt(path: Path) -> None:
+    """Skip-opt cvt file: no spms table, no coincident.spms."""
+    coincident = Table(col_dict={"geds": Array(np.array([True, True, False, True]))})
+    evt = Table(
+        col_dict={
+            "trigger": _trigger_table(),
+            "geds": _geds_table(),
+            "coincident": coincident,
+        }
+    )
+    lh5.write(evt, "evt", str(path), wo_mode="write_safe")
+    _write_cvt_root(path, ["V01", "B02"], [1, 2])
+
+
+def _make_cvt_skip_hit(path: Path) -> None:
+    """Skip-hit cvt file: no geds table, no coincident.geds."""
+    coincident = Table(col_dict={"spms": Array(np.array([False, True, False, False]))})
+    evt = Table(
+        col_dict={
+            "trigger": _trigger_table(),
+            "spms": _spms_table(),
+            "coincident": coincident,
+        }
+    )
+    lh5.write(evt, "evt", str(path), wo_mode="write_safe")
+    # skip_hit produces an empty detector_uids mapping at the evt tier
+    _write_cvt_root(path, [], [])
+
+
+def _run_plot(cvt_file: Path, out_pdf: Path, simid: str = "test_simid") -> None:
+    """Execute the plot script with a mock ``snakemake`` global."""
+    snakemake = SimpleNamespace(
+        input=InputFiles(toclone=[str(cvt_file)]),
+        output=[str(out_pdf)],
+        wildcards=SimpleNamespace(simid=simid),
+        config=AttrsDict({"nersc": {"dvs_ro": False}}),
+    )
+    try:
+        runpy.run_path(
+            str(_PLOT_SCRIPT),
+            init_globals={"snakemake": snakemake},
+            run_name="__main__",
+        )
+    finally:
+        plt.close("all")
+
+
+def test_plot_cvt_observables_full(tmp_path):
+    """Both geds and spms present: the script builds all panels."""
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_full(cvt_file)
+    out_pdf = tmp_path / "out.pdf"
+
+    _run_plot(cvt_file, out_pdf)
+
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0
+
+
+def test_plot_cvt_observables_skip_opt(tmp_path):
+    """No spms table (skip_opt): the script must skip the LAr/spms panels.
+
+    Regression test: the plot used to access ``evt.coincident.spms`` and the
+    ``spms`` sub-tables unconditionally, crashing with ``AttributeError`` when
+    the evt tier was built with ``skip_opt``.
+    """
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_skip_opt(cvt_file)
+    out_pdf = tmp_path / "out.pdf"
+
+    _run_plot(cvt_file, out_pdf)
+
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0
+
+
+def test_plot_cvt_observables_skip_hit(tmp_path):
+    """No geds table (skip_hit): the script must skip the HPGe/energy panels."""
+    cvt_file = tmp_path / "cvt.lh5"
+    _make_cvt_skip_hit(cvt_file)
+    out_pdf = tmp_path / "out.pdf"
+
+    _run_plot(cvt_file, out_pdf)
+
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0
+
+
+@pytest.mark.needs_remage
+def test_plot_cvt_observables_with_real_cvt(tmp_path, legend_cvt_path):
+    """Run the plot on a real cvt file produced by the full test pipeline."""
+    out_pdf = tmp_path / "out.pdf"
+
+    _run_plot(legend_cvt_path, out_pdf, simid="birds_nest_K40")
+
+    assert out_pdf.exists()
+    assert out_pdf.stat().st_size > 0

--- a/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
+++ b/workflow/src/legendsimflow/scripts/plots/tier_cvt_observables.py
@@ -27,16 +27,28 @@ args = nersc.dvs_ro_snakemake(snakemake)  # noqa: F821
 
 BUFFER_LEN = "100*MB"
 
-
-def _gimme_ehist():
-    return hist.new.Reg(500, 0, 5000, name="energy (keV)").Double()
-
-
 cvt_file = args.input
 output_pdf = args.output[0]
 simid = args.wildcards.simid
 
-has_rc = "evt/spms/rc_energy" in lh5.ls(str(cvt_file), "evt/spms/")
+# detect what data is available in the cvt file. skip_opt/skip_hit at the evt
+# tier omit the spms/geds tables (and the coincident.spms flag), so probe the
+# groups before plotting and build only the applicable panels.
+_cvt_file_str = str(cvt_file)
+_evt_groups = {k.removeprefix("evt/") for k in lh5.ls(_cvt_file_str, "evt/")}
+has_geds = "geds" in _evt_groups
+has_spms = "spms" in _evt_groups
+has_psd = has_geds and "single_temp" in {
+    k.removeprefix("evt/geds/psd/") for k in lh5.ls(_cvt_file_str, "evt/geds/psd/")
+}
+has_spms_coinc = has_spms and "spms" in {
+    k.removeprefix("evt/coincident/") for k in lh5.ls(_cvt_file_str, "evt/coincident/")
+}
+has_rc = has_spms and "evt/spms/rc_energy" in lh5.ls(_cvt_file_str, "evt/spms/")
+
+
+def _gimme_ehist():
+    return hist.new.Reg(500, 0, 5000, name="energy (keV)").Double()
 
 
 def _fill_ehist(h, evt_chunk, mask):
@@ -71,158 +83,204 @@ def _plot_ehist(ax, mask, **kwargs):
     plot.plot_hist(h, ax=ax, **kwargs)
 
 
-fig = plt.figure(figsize=(14, 16))
+def _panel_energy_basic(ax):
+    _plot_ehist(
+        ax,
+        lambda evt: evt.coincident.geds,
+        color="black",
+        fill=False,
+        linewidth=1,
+        label="evt.coincident.geds",
+    )
+    base_mask = lambda evt: evt.coincident.geds & evt.geds.is_good_channel  # noqa: E731
+    _plot_ehist(
+        ax,
+        base_mask,
+        color="tab:gray",
+        fill=False,
+        label="geds.is_good_channel",
+    )
+    _plot_ehist(
+        ax,
+        lambda evt: base_mask(evt) & (evt.geds.multiplicity == 1),
+        color="silver",
+        label="... geds.multiplicity == 1",
+    )
+    # the ~coincident.spms cut is only available when the spms tier was built
+    if has_spms_coinc:
+        _plot_ehist(
+            ax,
+            lambda evt: (
+                base_mask(evt) & (evt.geds.multiplicity == 1) & ~evt.coincident.spms
+            ),
+            color="tab:blue",
+            label="... ~coincident.spms",
+        )
 
-outer = fig.add_gridspec(nrows=4, ncols=1, height_ratios=[1, 1, 1, 1])
-gs_top = outer[0].subgridspec(1, 1)
-gs_mid = outer[1].subgridspec(1, 1)
-gs_bot = outer[2].subgridspec(1, 2, width_ratios=[1, 1])
-gs_pe = outer[3].subgridspec(1, 2, width_ratios=[1, 1])
-
-ax = fig.add_subplot(gs_top[0, 0])
-
-_plot_ehist(
-    ax,
-    lambda evt: evt.coincident.geds,
-    color="black",
-    fill=False,
-    linewidth=1,
-    label="evt.coincident.geds",
-)
-base_mask = lambda evt: evt.coincident.geds & evt.geds.is_good_channel  # noqa: E731
-_plot_ehist(
-    ax,
-    base_mask,
-    color="tab:gray",
-    fill=False,
-    label="geds.is_good_channel",
-)
-_plot_ehist(
-    ax,
-    lambda evt: base_mask(evt) & (evt.geds.multiplicity == 1),
-    color="silver",
-    label="... geds.multiplicity == 1",
-)
-_plot_ehist(
-    ax,
-    lambda evt: base_mask(evt) & (evt.geds.multiplicity == 1) & ~evt.coincident.spms,
-    color="tab:blue",
-    label="... ~coincident.spms",
-)
-
-ax.set_yscale("log")
-ax.legend()
-
-ax = fig.add_subplot(gs_mid[0, 0])
-
-base_mask = (  # noqa: E731
-    lambda evt: evt.coincident.geds
-    & (evt.geds.multiplicity == 1)
-    & evt.geds.is_good_channel
-    & evt.geds.psd.single_temp.has_aoe
-    & evt.geds.psd.is_good
-)
-_plot_ehist(
-    ax,
-    base_mask,
-    color="silver",
-    label="geds.is_good_channel & geds.psd.single_temp.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
-)
-_plot_ehist(
-    ax,
-    lambda evt: base_mask(evt) & evt.geds.psd.single_temp.is_single_site,
-    color="tab:green",
-    label="... geds.psd.single_temp.is_single_site",
-)
-_plot_ehist(
-    ax,
-    lambda evt: base_mask(evt)
-    & evt.geds.psd.single_temp.is_single_site
-    & ~evt.coincident.spms,
-    color="tab:red",
-    label="... ~coincident.spms",
-)
-
-ax.set_yscale("log")
-ax.legend()
-
-ax = fig.add_subplot(gs_bot[0, 0])
-h = hist.new.IntCategory(range(10), name="geds multiplicity").Double()
-it = LH5Iterator(
-    cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=["geds/multiplicity"]
-)
-for evt_chunk in it:
-    h.fill(evt_chunk.view_as("ak").geds.multiplicity)
-plot.plot_hist(h, ax)
-
-ax = fig.add_subplot(gs_bot[0, 1])
-h_spms_mult_sim = hist.new.IntCategory(range(60), name="spms multiplicity").Double()
-if has_rc:
-    h_spms_mult_rc = hist.new.IntCategory(range(60), name="spms multiplicity").Double()
-field_mask = ["spms/multiplicity"]
-if has_rc:
-    field_mask.append("spms/rc_energy")
-it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
-for evt_chunk in it:
-    spms = evt_chunk.view_as("ak").spms
-    h_spms_mult_sim.fill(spms.multiplicity)
-    if has_rc:
-        h_spms_mult_rc.fill(ak.sum(ak.any(spms.rc_energy > 0, axis=-1), axis=-1))
-plot.plot_hist(h_spms_mult_sim, ax, label="simulated")
-if has_rc:
-    plot.plot_hist(h_spms_mult_rc, ax, label="random coincidences")
-ax.set_yscale("log")
-if has_rc:
+    ax.set_yscale("log")
     ax.legend()
 
-ax = fig.add_subplot(gs_pe[0, 0])
-h_npe_sim = hist.new.Reg(200, 0, 150, name="light per event (photoelectrons)").Double()
-if has_rc:
-    h_npe_rc = hist.new.Reg(
+
+def _panel_energy_psd(ax):
+    base_mask = (  # noqa: E731
+        lambda evt: (
+            evt.coincident.geds
+            & (evt.geds.multiplicity == 1)
+            & evt.geds.is_good_channel
+            & evt.geds.psd.single_temp.has_aoe
+            & evt.geds.psd.is_good
+        )
+    )
+    _plot_ehist(
+        ax,
+        base_mask,
+        color="silver",
+        label="geds.is_good_channel & geds.psd.single_temp.has_aoe & geds.psd.is_good & geds.multiplicity == 1",
+    )
+    _plot_ehist(
+        ax,
+        lambda evt: base_mask(evt) & evt.geds.psd.single_temp.is_single_site,
+        color="tab:green",
+        label="... geds.psd.single_temp.is_single_site",
+    )
+    # the ~coincident.spms cut is only available when the spms tier was built
+    if has_spms_coinc:
+        _plot_ehist(
+            ax,
+            lambda evt: (
+                base_mask(evt)
+                & evt.geds.psd.single_temp.is_single_site
+                & ~evt.coincident.spms
+            ),
+            color="tab:red",
+            label="... ~coincident.spms",
+        )
+
+    ax.set_yscale("log")
+    ax.legend()
+
+
+def _panel_geds_multiplicity(ax):
+    h = hist.new.IntCategory(range(10), name="geds multiplicity").Double()
+    it = LH5Iterator(
+        cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=["geds/multiplicity"]
+    )
+    for evt_chunk in it:
+        h.fill(evt_chunk.view_as("ak").geds.multiplicity)
+    plot.plot_hist(h, ax)
+
+
+def _panel_spms_multiplicity(ax):
+    h_spms_mult_sim = hist.new.IntCategory(range(60), name="spms multiplicity").Double()
+    if has_rc:
+        h_spms_mult_rc = hist.new.IntCategory(
+            range(60), name="spms multiplicity"
+        ).Double()
+    field_mask = ["spms/multiplicity"]
+    if has_rc:
+        field_mask.append("spms/rc_energy")
+    it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
+    for evt_chunk in it:
+        spms = evt_chunk.view_as("ak").spms
+        h_spms_mult_sim.fill(spms.multiplicity)
+        if has_rc:
+            h_spms_mult_rc.fill(ak.sum(ak.any(spms.rc_energy > 0, axis=-1), axis=-1))
+    plot.plot_hist(h_spms_mult_sim, ax, label="simulated")
+    if has_rc:
+        plot.plot_hist(h_spms_mult_rc, ax, label="random coincidences")
+    ax.set_yscale("log")
+    if has_rc:
+        ax.legend()
+
+
+def _panel_light_per_event(ax):
+    h_npe_sim = hist.new.Reg(
         200, 0, 150, name="light per event (photoelectrons)"
     ).Double()
-field_mask = ["spms/energy_sum"]
-if has_rc:
-    field_mask.append("spms/rc_energy")
-it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
-for evt_chunk in it:
-    spms = evt_chunk.view_as("ak").spms
-    h_npe_sim.fill(spms.energy_sum)
     if has_rc:
-        h_npe_rc.fill(ak.sum(ak.sum(spms.rc_energy, axis=-1), axis=-1))
-plot.plot_hist(h_npe_sim, ax, flow="hint", label="simulated")
-if has_rc:
-    plot.plot_hist(h_npe_rc, ax, flow="hint", label="random coincidences")
-ax.set_ylabel("counts")
-ax.set_yscale("log")
-ax.legend()
+        h_npe_rc = hist.new.Reg(
+            200, 0, 150, name="light per event (photoelectrons)"
+        ).Double()
+    field_mask = ["spms/energy_sum"]
+    if has_rc:
+        field_mask.append("spms/rc_energy")
+    it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
+    for evt_chunk in it:
+        spms = evt_chunk.view_as("ak").spms
+        h_npe_sim.fill(spms.energy_sum)
+        if has_rc:
+            h_npe_rc.fill(ak.sum(ak.sum(spms.rc_energy, axis=-1), axis=-1))
+    plot.plot_hist(h_npe_sim, ax, flow="hint", label="simulated")
+    if has_rc:
+        plot.plot_hist(h_npe_rc, ax, flow="hint", label="random coincidences")
+    ax.set_ylabel("counts")
+    ax.set_yscale("log")
+    ax.legend()
 
-ax = fig.add_subplot(gs_pe[0, 1])
-h_time_sim = hist.new.Reg(
-    375, -1000, 5000, name="photoelectron $t - t_0$ (ns)"
-).Double()
-if has_rc:
-    h_time_rc = hist.new.Reg(
+
+def _panel_pe_time(ax):
+    h_time_sim = hist.new.Reg(
         375, -1000, 5000, name="photoelectron $t - t_0$ (ns)"
     ).Double()
-field_mask = ["spms/time", "trigger/timestamp"]
-if has_rc:
-    field_mask.append("spms/rc_time")
-it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
-for evt_chunk in it:
-    evt = evt_chunk.view_as("ak")
-    t0, spms_time = ak.broadcast_arrays(evt.trigger.timestamp, evt.spms.time)
-    dt = spms_time - t0
-    h_time_sim.fill(ak.flatten(dt, axis=None))
     if has_rc:
-        t0_rc, rc_time = ak.broadcast_arrays(evt.trigger.timestamp, evt.spms.rc_time)
-        h_time_rc.fill(ak.flatten(rc_time - t0_rc, axis=None))
-plot.plot_hist(h_time_sim, ax, flow="none", label="simulated")
-if has_rc:
-    plot.plot_hist(h_time_rc, ax, flow="none", label="random coincidences")
-ax.set_ylabel("counts / 16 ns")
-ax.set_yscale("log")
-ax.legend()
+        h_time_rc = hist.new.Reg(
+            375, -1000, 5000, name="photoelectron $t - t_0$ (ns)"
+        ).Double()
+    field_mask = ["spms/time", "trigger/timestamp"]
+    if has_rc:
+        field_mask.append("spms/rc_time")
+    it = LH5Iterator(cvt_file, "evt", buffer_len=BUFFER_LEN, field_mask=field_mask)
+    for evt_chunk in it:
+        evt = evt_chunk.view_as("ak")
+        t0, spms_time = ak.broadcast_arrays(evt.trigger.timestamp, evt.spms.time)
+        dt = spms_time - t0
+        h_time_sim.fill(ak.flatten(dt, axis=None))
+        if has_rc:
+            t0_rc, rc_time = ak.broadcast_arrays(
+                evt.trigger.timestamp, evt.spms.rc_time
+            )
+            h_time_rc.fill(ak.flatten(rc_time - t0_rc, axis=None))
+    plot.plot_hist(h_time_sim, ax, flow="none", label="simulated")
+    if has_rc:
+        plot.plot_hist(h_time_rc, ax, flow="none", label="random coincidences")
+    ax.set_ylabel("counts / 16 ns")
+    ax.set_yscale("log")
+    ax.legend()
+
+
+# assemble the figure from the panels available for this cvt file. wide (energy)
+# panels get a full-width row each; small panels are laid out two per row. with
+# both geds and spms present this reproduces the original 4-row layout.
+wide_panels = []
+small_panels = []
+if has_geds:
+    wide_panels.append(_panel_energy_basic)
+if has_psd:
+    wide_panels.append(_panel_energy_psd)
+if has_geds:
+    small_panels.append(_panel_geds_multiplicity)
+if has_spms:
+    small_panels.extend(
+        [_panel_spms_multiplicity, _panel_light_per_event, _panel_pe_time]
+    )
+
+n_small_rows = (len(small_panels) + 1) // 2
+n_rows = len(wide_panels) + n_small_rows
+
+fig = plt.figure(figsize=(14, 4 * n_rows))
+outer = fig.add_gridspec(nrows=n_rows, ncols=1)
+
+row = 0
+for panel in wide_panels:
+    panel(fig.add_subplot(outer[row]))
+    row += 1
+
+for i in range(0, len(small_panels), 2):
+    chunk = small_panels[i : i + 2]
+    gs = outer[row].subgridspec(1, len(chunk))
+    for j, panel in enumerate(chunk):
+        panel(fig.add_subplot(gs[0, j]))
+    row += 1
 
 fig.suptitle(f"{simid}: evt tier")
 


### PR DESCRIPTION
The `tier_cvt_observables` validation plot accessed the `spms` sub-tables and the `coincident.spms` flag unconditionally. When the evt tier is built with `skip_opt` those groups are never written (see `scripts/tier/evt.py`, guarded by `if not skip_opt:`), so the plot crashed with `AttributeError: no field named 'spms'`. The symmetric `skip_hit` case would fail the same way on the `geds` groups.

## Fix

Probe the available `evt` groups up front (`has_geds`, `has_spms`, `has_spms_coinc`, `has_rc`, `has_psd`), mirroring what the tier-pdf script already does, and assemble the figure from only the panels whose inputs are present. Each panel is now a small function; energy panels get a full-width row and the rest are laid out two-per-row. With both `geds` and `spms` present the layout is unchanged from before. The `has_psd` probe additionally removes a latent crash that would occur when `simulate_psd` is disabled (the mid PSD panel reads `geds/psd/single_temp`, which is only written when `simulate_psd: true`).

The `has_rc` probe is now guarded by `has_spms`; previously it relied on `lh5.ls` returning an empty list for the missing `evt/spms/` group.

## Tests

New `tests/scripts/test_plot_cvt_observables.py` drives the plot script the way Snakemake does (via `runpy` with a mock `snakemake` global), building synthetic cvt files as in `test_tier_pdf.py`:

- `test_plot_cvt_observables_full` — geds + spms present
- `test_plot_cvt_observables_skip_opt` — no spms (the regression case)
- `test_plot_cvt_observables_skip_hit` — no geds
- `test_plot_cvt_observables_with_real_cvt` (`needs_remage`) — runs on the real cvt from the pipeline fixture, mirroring the pdf test

Verified the pre-fix script raises `AttributeError: no field named 'spms'` on the skip_opt case and the fixed script produces the PDF. `pre-commit run --all-files` and the plot + pdf-script test suites pass.