### PR TITLE
Feat: implement logic for the maurina gamma cascades

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -155,6 +155,10 @@ Supported fields per `simid`:
   for this `simid`. This configuration block is injected unmodified to the
   geometry tooling (currently
   [legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io)).
+- `maurina_gamma_cascades`: Optional boolean (default `false`). If `true`,
+  register the tabulated MAURINA gamma cascades with _remage_. Every isotope
+  directory in the cascade data repository is registered, see
+  {ref}`gamma-cascade-data`.
 
 Example:
 
@@ -236,6 +240,11 @@ variable placeholders that the workflow substitutes:
 
 - `$GENERATOR`: Replaced with the generator block content.
 - `$CONFINEMENT`: Replaced with the confinement block content.
+- `$MAURINA_GAMMA_CASCADES`: Replaced with the commands registering the MAURINA
+  gamma cascades, requested via the {ref}`simconfig.yaml`
+  `maurina_gamma_cascades` field, or with nothing if it is not set. **Must be
+  placed before `/run/initialize`**: the settings are read when _remage_ builds
+  the high-precision hadronic models, which happens at initialization.
 - `{SEED}`: A 32-bit random integer generated per job.
 - `{N_EVENTS}`: The number of events to simulate for the job, taken from
   `primaries_per_job`.
@@ -246,6 +255,10 @@ Example template snippets:
 
 ```
 /RMG/Manager/Randomization/Seed {SEED}
+...
+$MAURINA_GAMMA_CASCADES
+
+/run/initialize
 ...
 $GENERATOR
 $CONFINEMENT

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -155,10 +155,10 @@ Supported fields per `simid`:
   for this `simid`. This configuration block is injected unmodified to the
   geometry tooling (currently
   [legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io)).
-- `maurina_gamma_cascades`: Optional boolean (default `false`). If `true`,
-  register the tabulated MAURINA gamma cascades with _remage_. Every isotope
-  directory in the cascade data repository is registered, see
-  {ref}`gamma-cascade-data`.
+- `maurina_gamma_cascades`: Optional boolean (default `false`) or list of tuples
+  `(Z, A)` of isotopes. If boolean and `true`, register all tabulated MAURINA
+  gamma cascades with _remage_. If a list of tuples is provided, only the
+  specified isotopes are registered.
 
 Example:
 

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -80,9 +80,9 @@ Here's a basic description of its fields:
   - `dtmaps` (optional output): generated HPGe drift-time maps. Defaults to
     `{paths.pars}/hpge/dtmaps` if not set.
   - `maurina_gamma_cascades` (optional, writable): per-production checkout of
-    the MAURINA gamma cascade data, see {ref}`gamma-cascade-data`. Only needed
-    by simulations enabling the `maurina_gamma_cascades` field in
-    {ref}`simconfig.yaml`. The data lives in the currently legend-exp private
+    the MAURINA gamma cascade data. Only needed by simulations enabling the
+    `maurina_gamma_cascades` field in {ref}`simconfig.yaml`. The data lives in
+    the currently legend-exp private
     [generated-maurina-output](https://github.com/legend-exp/generated-maurina-output)
     repository, organized as `<Z>/<A>/`, with one `*_ncapture_filelist.txt` per
     isotope mapping neutron kinetic-energy ranges to cascade files.

--- a/docs/source/manual/setup.md
+++ b/docs/source/manual/setup.md
@@ -79,6 +79,13 @@ Here's a basic description of its fields:
     `{paths.pars}/geom` if not set.
   - `dtmaps` (optional output): generated HPGe drift-time maps. Defaults to
     `{paths.pars}/hpge/dtmaps` if not set.
+  - `maurina_gamma_cascades` (optional, writable): per-production checkout of
+    the MAURINA gamma cascade data, see {ref}`gamma-cascade-data`. Only needed
+    by simulations enabling the `maurina_gamma_cascades` field in
+    {ref}`simconfig.yaml`. The data lives in the currently legend-exp private
+    [generated-maurina-output](https://github.com/legend-exp/generated-maurina-output)
+    repository, organized as `<Z>/<A>/`, with one `*_ncapture_filelist.txt` per
+    isotope mapping neutron kinetic-energy ranges to cascade files.
   - `tier` (dict, output): generated outputs for each tier, keyed by tier name
     (e.g. `tier.stp`, `tier.hit`, ...). Validation plots for each tier are
     stored in a `plots/` subdirectory (e.g. `tier.stp/plots/`).

--- a/templates/default.yaml
+++ b/templates/default.yaml
@@ -26,6 +26,7 @@ make_steps:
   - pdf
 
 # legend_metadata_version: main
+# maurina_output_version: main
 
 benchmark:
   enabled: false
@@ -42,6 +43,7 @@ paths:
   config: $_/inputs/simprod/config
   optical_maps:
     lar: $_/inputs/simprod/l200a-optical-map-lar.lh5
+  maurina_gamma_cascades: $_/inputs/generated-maurina-output
 
   pars: $_/generated/pars
   macros: $_/generated/macros

--- a/tests/test_gamma_cascades.py
+++ b/tests/test_gamma_cascades.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from legendsimflow import gamma_cascades
+
+
+@pytest.fixture
+def cascade_repo(tmp_path):
+    """A minimal MAURINA-like repository with two isotopes."""
+    for z, a, name in ((32, 76, "ge76"), (64, 155, "gd155")):
+        d = tmp_path / str(z) / str(a)
+        d.mkdir(parents=True)
+        (d / f"{name}_ncapture_filelist.txt").write_text(
+            f"cas{a}{name[:2]}_00100_a.txt 0 100000\n"
+        )
+    return tmp_path
+
+
+@pytest.fixture
+def cascade_config(fresh_config, cascade_repo):
+    fresh_config.paths["maurina_gamma_cascades"] = str(cascade_repo)
+    return fresh_config
+
+
+def test_maurina_macro_commands(cascade_config, cascade_repo):
+    lines = gamma_cascades.maurina_macro_commands(cascade_config)
+
+    assert lines[0] == "/RMG/Processes/UseGrabmayrsGammaCascades true"
+    assert lines[-1] == (
+        "/RMG/GrabmayrGammaCascades/SetGammaCascadeRandomStartLocation 1"
+    )
+
+    # Z and A are taken from the two directory levels, sorted for determinism
+    assert lines[1:-1] == [
+        "/RMG/GrabmayrGammaCascades/SetGammaCascadeFilelist 32 76 "
+        f"{cascade_repo / '32' / '76' / 'ge76_ncapture_filelist.txt'}",
+        "/RMG/GrabmayrGammaCascades/SetGammaCascadeFilelist 64 155 "
+        f"{cascade_repo / '64' / '155' / 'gd155_ncapture_filelist.txt'}",
+    ]
+
+
+def test_macro_block_empty_when_unconfigured(cascade_config):
+    assert gamma_cascades.maurina_macro_block(cascade_config, {}) == ""
+    assert (
+        gamma_cascades.maurina_macro_block(
+            cascade_config, {"maurina_gamma_cascades": False}
+        )
+        == ""
+    )
+
+
+def test_macro_block_registers_cascades(cascade_config):
+    block = gamma_cascades.maurina_macro_block(
+        cascade_config, {"maurina_gamma_cascades": True}
+    )
+
+    assert block.split("\n")[0] == "/RMG/Processes/UseGrabmayrsGammaCascades true"

--- a/tests/test_gamma_cascades.py
+++ b/tests/test_gamma_cascades.py
@@ -39,6 +39,18 @@ def test_maurina_macro_commands(cascade_config, cascade_repo):
         f"{cascade_repo / '64' / '155' / 'gd155_ncapture_filelist.txt'}",
     ]
 
+    lines = gamma_cascades.maurina_macro_commands(cascade_config, subset={(32, 76)})
+
+    assert lines[0] == "/RMG/Processes/UseGrabmayrsGammaCascades true"
+    assert lines[-1] == (
+        "/RMG/GrabmayrGammaCascades/SetGammaCascadeRandomStartLocation 1"
+    )
+
+    assert lines[1:-1] == [
+        "/RMG/GrabmayrGammaCascades/SetGammaCascadeFilelist 32 76 "
+        f"{cascade_repo / '32' / '76' / 'ge76_ncapture_filelist.txt'}",
+    ]
+
 
 def test_macro_block_empty_when_unconfigured(cascade_config):
     assert gamma_cascades.maurina_macro_block(cascade_config, {}) == ""

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -96,8 +96,9 @@ rule _init_julia_env:
         "> {log} 2>&1 && touch {output}"
 
 
-# the MAURINA gamma cascade data lives in a separate (currently private, ~1 GB) repository,
-# Only simulations that opt in via the`maurina_gamma_cascades` simconfig field depend on this rule.
+# The MAURINA gamma cascade data lives in a separate (currently private, ~1 GB)
+# repository. Only simulations that opt in via the `maurina_gamma_cascades`
+# simconfig field depend on this rule.
 rule fetch_maurina_gamma_cascades:
     """Make the MAURINA gamma cascade data available on disk.
 

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -96,6 +96,43 @@ rule _init_julia_env:
         "> {log} 2>&1 && touch {output}"
 
 
+# the MAURINA gamma cascade data lives in a separate (currently private, ~1 GB) repository,
+# Only simulations that opt in via the`maurina_gamma_cascades` simconfig field depend on this rule.
+rule fetch_maurina_gamma_cascades:
+    """Make the MAURINA gamma cascade data available on disk.
+
+    Clones the `legend-exp/generated-maurina-output` repository into
+    the writable, per-production ``paths.maurina_gamma_cascades`` directory. If the
+    directory is already a git checkout, that revision is fetched and checked
+    out.
+    """
+    localrule: True
+    message:
+        "Fetching MAURINA gamma cascade data"
+    params:
+        dest=config.paths.get("maurina_gamma_cascades", ""),
+        rev=config.get("maurina_output_version", "main"),
+        url="https://github.com/legend-exp/generated-maurina-output",
+    output:
+        touch(config.paths.generated / ".maurina-gamma-cascades-fetched"),
+    log:
+        patterns.log_dirname(config) / "fetch-maurina-gamma-cascades.log",
+    shell:
+        "{{ "
+        "if [ -z '{params.dest}' ]; then "
+        "  echo 'paths.maurina_gamma_cascades is not set in the Simflow config'; "
+        "  exit 1; "
+        "fi; "
+        "if [ -d '{params.dest}/.git' ]; then "
+        "  git -C '{params.dest}' fetch --depth 1 origin '{params.rev}' && "
+        "  git -C '{params.dest}' checkout --detach FETCH_HEAD; "
+        "else "
+        "  git clone --depth 1 --single-branch --branch '{params.rev}' "
+        "    '{params.url}' '{params.dest}'; "
+        "fi; "
+        "}} > {log} 2>&1"
+
+
 # Memoize the on-demand fallback result to avoid re-running the expensive
 # gen_list_of_all_hpges_valid_for_modeling() more than once per Snakemake
 # invocation (touch executor / no YAML on disk).

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -86,6 +86,14 @@ rule build_geom_gdml:
         "legend-pygeom-l200 --verbose --config {input} -- {output} &> {log}"
 
 
+def smk_maurina_gamma_cascades(wildcards):
+    """Depend on the MAURINA cascade data only for `simid`s that opted in."""
+    sim_cfg = mutils.get_simconfig(config, "stp", simid=wildcards.simid)
+    if not sim_cfg.get("maurina_gamma_cascades", False):
+        return []
+    return rules.fetch_maurina_gamma_cascades.output
+
+
 rule gen_remage_macro:
     """Write the remage macro file for a `stp` tier simulation to disk.
 
@@ -99,6 +107,8 @@ rule gen_remage_macro:
         "Generating remage macro for stp.{wildcards.simid}"
     input:
         geom=patterns.geom_gdml_filename(config, tier="stp"),
+        # only simulations that opted in need the cascade data on disk
+        cascades=smk_maurina_gamma_cascades,
     params:
         # make this rule dependent on the actual simconfig block it is very
         # important here to ignore the simconfig fields that, if updated,

--- a/workflow/src/legendsimflow/commands.py
+++ b/workflow/src/legendsimflow/commands.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import legenddataflowscripts as lds
 import pyg4ometry
 
-from . import SimflowConfig, nersc, patterns, utils
+from . import SimflowConfig, gamma_cascades, nersc, patterns, utils
 from .exceptions import SimflowConfigError
 from .metadata import get_simconfig
 
@@ -324,8 +324,8 @@ def make_remage_macro(
     Notes
     -----
     - The macro template path is taken from the simconfig `template` field.
-    - Supported substitutions currently include: ``GENERATOR`` and
-      ``CONFINEMENT``.
+    - Supported substitutions currently include: ``GENERATOR``, ``CONFINEMENT``
+      and ``MAURINA_GAMMA_CASCADES`` (see :mod:`legendsimflow.gamma_cascades`).
     - The user can provide arbitrary macro substitutions with the
       optional `macro_substitutions` field.
     - The macro is written to the canonical path returned by
@@ -453,6 +453,10 @@ def make_remage_macro(
             confinement = "\n".join(confinement)
 
         mac_subs["CONFINEMENT"] = confinement
+
+    # register the MAURINA gamma cascades, if requested
+    macro_block = gamma_cascades.maurina_macro_block(config, sim_cfg, block)
+    mac_subs[gamma_cascades.MACRO_VARIABLE] = macro_block
 
     # the user might want to substitute some other variables
     mac_subs |= sim_cfg.get("macro_substitutions", {})

--- a/workflow/src/legendsimflow/gamma_cascades.py
+++ b/workflow/src/legendsimflow/gamma_cascades.py
@@ -14,10 +14,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Build the _remage_ macro block registering the MAURINA gamma cascades.
 
-The ``maurina_gamma_cascades`` boolean of the `stp` tier simconfig enables the
+The ``maurina_gamma_cascades`` field of the `stp` tier simconfig enables the
 tabulated MAURINA gamma cascades: they change how the compound nucleus
-de-excites after a neutron capture. Every isotope directory in the cascade data
-repository is registered with _remage_.
+de-excites after a neutron capture. It can be either ``true`` (register all
+isotopes) or a list of ``(Z, A)`` pairs selecting a subset.
 
 The commands must be issued **before** ``/run/initialize``, since they are read
 when ``RMGPhysics::ConstructProcess()`` builds the high-precision hadronic
@@ -42,7 +42,9 @@ MACRO_VARIABLE = "MAURINA_GAMMA_CASCADES"
 
 
 def maurina_macro_commands(
-    config: SimflowConfig, block: str | None = None
+    config: SimflowConfig,
+    block: str | None = None,
+    subset: set[tuple[int, int]] | None = None,
 ) -> list[str]:
     """Return the commands registering all MAURINA gamma cascades.
 
@@ -91,6 +93,10 @@ def maurina_macro_commands(
             )
             raise SimflowConfigError(msg, block) from e
 
+        # ignore isotopes when a subset is defined and the isotope is not contained in it
+        if subset is not None and isotope not in subset:
+            continue
+
         # remage resets previously registered cascades for an isotope, so a
         # second filelist would silently shadow the first
         if isotope in seen:
@@ -119,7 +125,39 @@ def maurina_macro_block(
     Renders :func:`maurina_macro_commands` if the optional
     ``maurina_gamma_cascades`` field of `sim_cfg` is set.
     """
-    if not sim_cfg.get("maurina_gamma_cascades", False):
+    if "maurina_gamma_cascades" not in sim_cfg:
         return ""
 
-    return "\n".join(maurina_macro_commands(config, block))
+    if isinstance(  # test for bool
+        sim_cfg["maurina_gamma_cascades"], bool
+    ):
+        if not sim_cfg.get("maurina_gamma_cascades", False):
+            return ""
+        return "\n".join(maurina_macro_commands(config, block))
+
+    if isinstance(  # test for list
+        sim_cfg["maurina_gamma_cascades"], list
+    ):
+        subset = set()
+        for pair in sim_cfg["maurina_gamma_cascades"]:
+            if (
+                not isinstance(pair, (list, tuple))
+                or len(pair) != 2
+                or not all(isinstance(x, int) for x in pair)
+            ):
+                msg = (
+                    "the 'maurina_gamma_cascades' list must contain pairs of integers (Z, A), "
+                    f"got {pair!r}"
+                )
+                raise SimflowConfigError(msg, block)
+
+            z, a = pair
+            subset.add((z, a))
+        return "\n".join(maurina_macro_commands(config, block, subset=subset))
+
+    # neither bool nor list
+    msg = (
+        "the 'maurina_gamma_cascades' field must be either a boolean or a "
+        f"list of (Z, A) pairs, got {sim_cfg['maurina_gamma_cascades']}"
+    )
+    raise SimflowConfigError(msg, block)

--- a/workflow/src/legendsimflow/gamma_cascades.py
+++ b/workflow/src/legendsimflow/gamma_cascades.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2025 Luigi Pertoldi <gipert@pm.me>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Build the _remage_ macro block registering the MAURINA gamma cascades.
+
+The ``maurina_gamma_cascades`` boolean of the `stp` tier simconfig enables the
+tabulated MAURINA gamma cascades: they change how the compound nucleus
+de-excites after a neutron capture. Every isotope directory in the cascade data
+repository is registered with _remage_.
+
+The commands must be issued **before** ``/run/initialize``, since they are read
+when ``RMGPhysics::ConstructProcess()`` builds the high-precision hadronic
+models, which Geant4 does at initialization time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from . import SimflowConfig, nersc
+from .exceptions import SimflowConfigError
+
+#: Glob matching the per-isotope filelists in the cascade data repository. The
+#: basenames are not uniform across isotopes (``ge76_``, ``gd155_``, ``cr53_``,
+#: ...), so they cannot be constructed from `Z` and `A`.
+FILELIST_GLOB = "*/*/*_ncapture_filelist.txt"
+
+#: Name of the macro template variable holding the rendered block.
+MACRO_VARIABLE = "MAURINA_GAMMA_CASCADES"
+
+
+def maurina_macro_commands(
+    config: SimflowConfig, block: str | None = None
+) -> list[str]:
+    """Return the commands registering all MAURINA gamma cascades.
+
+    Walks the ``<Z>/<A>/`` directory structure of the cascade data repository at
+    ``config.paths.maurina_gamma_cascades`` and registers the filelist found in
+    each.
+
+    Note
+    ----
+    The filelists are referenced at their location in the repository, because
+    _remage_ resolves the cascade file names they contain relative to the
+    directory holding the filelist.
+    """
+    if "maurina_gamma_cascades" not in config.paths:
+        msg = (
+            "MAURINA gamma cascades are enabled but "
+            "'paths.maurina_gamma_cascades' is not configured: it must point to "
+            "a checkout of the legend-exp/generated-maurina-output repository"
+        )
+        raise SimflowConfigError(msg, block)
+
+    root = Path(nersc.dvs_ro(config, config.paths.maurina_gamma_cascades))
+    if not root.is_dir():
+        msg = f"MAURINA gamma cascade data directory '{root}' does not exist"
+        raise SimflowConfigError(msg, block)
+
+    filelists = sorted(root.glob(FILELIST_GLOB))
+    if not filelists:
+        msg = (
+            f"no '{FILELIST_GLOB}' found below MAURINA gamma cascade directory '{root}'"
+        )
+        raise SimflowConfigError(msg, block)
+
+    commands = ["/RMG/Processes/UseGrabmayrsGammaCascades true"]
+    seen: dict[tuple[int, int], Path] = {}
+
+    for filelist in filelists:
+        z_dir, a_dir = filelist.parent.parent.name, filelist.parent.name
+        try:
+            isotope = (int(z_dir), int(a_dir))
+        except ValueError as e:
+            msg = (
+                f"cannot parse Z/A from MAURINA gamma cascade path '{filelist}': "
+                f"the two directory levels below '{root}' must be integers, got "
+                f"'{z_dir}/{a_dir}'"
+            )
+            raise SimflowConfigError(msg, block) from e
+
+        # remage resets previously registered cascades for an isotope, so a
+        # second filelist would silently shadow the first
+        if isotope in seen:
+            msg = (
+                f"multiple MAURINA gamma cascade filelists for isotope "
+                f"Z={isotope[0]} "
+                f"A={isotope[1]}: '{seen[isotope]}' and '{filelist}'"
+            )
+            raise SimflowConfigError(msg, block)
+        seen[isotope] = filelist
+
+        commands.append(
+            "/RMG/GrabmayrGammaCascades/SetGammaCascadeFilelist "
+            f"{isotope[0]} {isotope[1]} {filelist}"
+        )
+
+    commands.append("/RMG/GrabmayrGammaCascades/SetGammaCascadeRandomStartLocation 1")
+    return commands
+
+
+def maurina_macro_block(
+    config: SimflowConfig, sim_cfg: Mapping, block: str | None = None
+) -> str:
+    """Return the full macro block for a simulation, or ``""`` if unconfigured.
+
+    Renders :func:`maurina_macro_commands` if the optional
+    ``maurina_gamma_cascades`` field of `sim_cfg` is set.
+    """
+    if not sim_cfg.get("maurina_gamma_cascades", False):
+        return ""
+
+    return "\n".join(maurina_macro_commands(config, block))


### PR DESCRIPTION
Add logic to automatically pull the [[generated-maurina-output](https://github.com/legend-exp/generated-maurina-output/tree/main)] repository and generate the macro commands to link into the remage simulation. Adds a rule that runs a `git clone` command with `--depth 1` since the repository is ~1Gb. This requires a new entry in `config.paths` to specify where the repository should be cloned (opinions?). Users can choose to run the simulation with the generated cascades by specifying `maurina_gamma_cascade` in the stp simconfig.yaml for the specific simid. This can be either a boolean indicating whether all or none (default) are registered, or a list of tuples specifying which isotopes should be registered.