### PR TITLE
fix: tolerate missing HPGe flags when caching detector usabilities

### DIFF
--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -427,3 +427,39 @@ def test_skip_list_all_hpges_reflects_exclusion(config):
         "l200-p02-r007-phy",
     ):
         assert hpges[runid]["V99000A"]["is_modelable"] is False
+
+
+def test_pivot_detinfo_omits_flags_no_detector_carries():
+    """Flags absent from every entry must not appear in the pivoted mapping.
+
+    ``psd_usability`` and ``crystal_metadata_usability`` are only set for HPGe
+    detectors, so an experiment without any (a LAr-only configuration) produces
+    a mapping holding ``usability`` alone.  ``cache_detector_usabilities`` must
+    therefore not index those keys unconditionally.
+    """
+    spms_only = {
+        "l200-p13-r003-aph": {
+            "S002": {"usability": "on"},
+            "S003": {"usability": "off"},
+        }
+    }
+
+    out = agg.pivot_detinfo(spms_only)
+
+    assert set(out) == {"usability"}
+    assert out["usability"]["l200-p13-r003-aph"] == {"S002": "on", "S003": "off"}
+
+
+def test_pivot_detinfo_keeps_flags_carried_by_some_detectors():
+    """A flag set by only part of the detectors still pivots for those."""
+    mixed = {
+        "l200-p03-r000-phy": {
+            "S002": {"usability": "on"},
+            "V02160A": {"usability": "on", "psd_usability": "valid"},
+        }
+    }
+
+    out = agg.pivot_detinfo(mixed)
+
+    assert set(out) == {"usability", "psd_usability"}
+    assert out["psd_usability"]["l200-p03-r000-phy"] == {"V02160A": "valid"}

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -205,10 +205,14 @@ rule cache_detector_usabilities:
         detinfo = aggregate.pivot_detinfo(
             aggregate.gen_list_of_all_usabilities(config).to_dict()
         )
-        dbetto.utils.write_dict(detinfo["usability"], output.usability)
-        dbetto.utils.write_dict(detinfo["psd_usability"], output.psd_usability)
+        # `pivot_detinfo` only creates a key for a flag that at least one
+        # detector carries, and psd/crystal usability are set for HPGes only.
+        # An experiment without HPGe detectors therefore yields neither, so
+        # index defensively and write those files empty instead of raising.
+        dbetto.utils.write_dict(detinfo.get("usability", {}), output.usability)
+        dbetto.utils.write_dict(detinfo.get("psd_usability", {}), output.psd_usability)
         dbetto.utils.write_dict(
-            detinfo["crystal_metadata_usability"],
+            detinfo.get("crystal_metadata_usability", {}),
             output.crystal_metadata_usability,
         )
 

--- a/workflow/rules/aux.smk
+++ b/workflow/rules/aux.smk
@@ -205,10 +205,6 @@ rule cache_detector_usabilities:
         detinfo = aggregate.pivot_detinfo(
             aggregate.gen_list_of_all_usabilities(config).to_dict()
         )
-        # `pivot_detinfo` only creates a key for a flag that at least one
-        # detector carries, and psd/crystal usability are set for HPGes only.
-        # An experiment without HPGe detectors therefore yields neither, so
-        # index defensively and write those files empty instead of raising.
         dbetto.utils.write_dict(detinfo.get("usability", {}), output.usability)
         dbetto.utils.write_dict(detinfo.get("psd_usability", {}), output.psd_usability)
         dbetto.utils.write_dict(


### PR DESCRIPTION
**Issue:**
`cache_detector_usabilities` fails with `KeyError: 'psd_usability'` for any experiment without HPGe detectors.

`aggregate.pivot_detinfo()` pivots `{runid: {det: {flag: value}}}` into `{flag: {runid: {det: value}}}`, and — as its own docstring states — a flag absent from every entry simply does not appear in the result.
`gen_list_of_all_usabilities()` sets `psd_usability` and `crystal_metadata_usability` only for detectors with `system == "geds"`, so a LAr-only configuration produces a mapping containing `usability` alone. The rule then indexes all three keys unconditionally and raises.

I hit this issue while setting up a LAr-only production (p13, no germanium detectors installed), where it blocks the `opt` and `evt` tiers since both depend on the cached usabilities.

**Fix:**
Index the pivoted mapping with `.get(flag, {})` and write the HPGe-specific files empty when no detector carries those flags. Experiments with HPGe detectors are unaffected: the keys exist, so `.get()` returns exactly what the subscript returned before.

Note: To truly test this, we'd need some dummy data without Ge detectors.