### PR TITLE
feat: allow per-SiPM optical map scaling factors

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -385,6 +385,10 @@ buffer_len: "10*MB"
     S003: 0.461
   ```
 
+  Channels absent from the mapping fall back to `default`; if neither the
+  channel nor `default` is present, processing fails with a `KeyError` naming
+  the missing channel.
+
   Per-channel values are equivalent to the `sipm_efficiencies` option of
   [legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io), which only
   takes effect while photons are tracked and so cannot be used with a pre-built

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -371,9 +371,25 @@ buffer_len: "10*MB"
 - `optmap_per_sipm` (bool) — when `true`, photoelectrons are sampled per SiPM
   channel using the per-SiPM optical map; when `false`, the combined map across
   all SiPMs is used.
-- `optmap_scaling_factor` (float) — factor multiplied to every map value,
-  globally scaling the photoelectron detection probability. Maps produced with
-  SiPM PDE set to 1 should use a value equal to the true SiPM PDE.
+- `optmap_scaling_factor` (float or dict) — factor multiplied to every map
+  value, scaling the photoelectron detection probability. Maps produced with
+  SiPM PDE set to 1 should use a value equal to the true SiPM PDE. A scalar is
+  applied to every channel. A mapping `<sipm name> -> <factor>` applies a
+  per-channel efficiency instead, with a reserved `default` key used for
+  channels absent from it:
+
+  ```{code-block} yaml
+  optmap_scaling_factor:
+    default: 0.3
+    S002: 0.384
+    S003: 0.461
+  ```
+
+  Per-channel values are equivalent to the `sipm_efficiencies` option of
+  [legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io), which only
+  takes effect while photons are tracked and so cannot be used with a pre-built
+  optical map.
+
 - `photoelectron_resolution_sigma` (float) — single-photoelectron amplitude
   resolution (σ, relative). Applied as Gaussian smearing to each detected
   photoelectron.

--- a/tests/scripts/test_tier_opt.py
+++ b/tests/scripts/test_tier_opt.py
@@ -7,6 +7,7 @@ import lh5
 import numpy as np
 import pytest
 import yaml
+from dbetto import AttrsDict
 
 from legendsimflow.scripts.tier import opt
 
@@ -111,3 +112,27 @@ def test_opt_script_cli(
     assert np.all(_field(_SIPM_OFF, "usability", opt_per_sipm) == 2), (
         f"{_SIPM_OFF} usability should be 2 (off)"
     )
+
+
+def test_resolve_map_scaling_scalar():
+    """A scalar setting applies to every channel, as before."""
+    assert opt.resolve_map_scaling(0.3, _SIPM_ON) == pytest.approx(0.3)
+    assert opt.resolve_map_scaling(0.3, "all") == pytest.approx(0.3)
+    assert opt.resolve_map_scaling(1, _SIPM_ON) == pytest.approx(1.0)
+
+
+def test_resolve_map_scaling_per_channel():
+    """A mapping applies each channel's value, falling back to ``default``.
+
+    Uses AttrsDict, which is what settings read from YAML actually are.
+    """
+    setting = AttrsDict({"default": 0.3, _SIPM_ON: 0.42})
+
+    assert opt.resolve_map_scaling(setting, _SIPM_ON) == pytest.approx(0.42)
+    assert opt.resolve_map_scaling(setting, _SIPM_OFF) == pytest.approx(0.3)
+
+
+def test_resolve_map_scaling_without_default_raises():
+    """A missing channel is an error rather than a silent guess."""
+    with pytest.raises(KeyError, match="no optmap_scaling_factor entry"):
+        opt.resolve_map_scaling({_SIPM_ON: 0.42}, _SIPM_OFF)

--- a/workflow/src/legendsimflow/scripts/tier/opt.py
+++ b/workflow/src/legendsimflow/scripts/tier/opt.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
+from collections.abc import Mapping
 from pathlib import Path
 
 import awkward as ak
@@ -44,6 +45,42 @@ from legendsimflow.metadata import get_tier_settings
 from legendsimflow.profile import make_profiler
 from legendsimflow.scripts import log_script_invocation
 from legendsimflow.tcm import build_tcm
+
+
+def resolve_map_scaling(setting: float | Mapping[str, float], sipm: str) -> float:
+    """Return the optical-map scaling factor to apply to one SiPM.
+
+    ``optmap_scaling_factor`` is either a scalar applied to every channel, or a
+    mapping ``<sipm name> -> <scaling factor>`` for per-channel photon detection
+    efficiencies. In the latter case channels missing from the mapping fall back
+    to the reserved ``default`` key; without it, a missing channel is an error
+    rather than a silent guess.
+
+    Parameters
+    ----------
+    setting
+        The ``optmap_scaling_factor`` value from the ``opt`` tier settings.
+    sipm
+        Name of the SiPM being processed, or ``"all"`` for the combined map.
+
+    Returns
+    -------
+    float
+    """
+    if not isinstance(setting, Mapping):
+        return float(setting)
+
+    if sipm in setting:
+        return float(setting[sipm])
+
+    if "default" in setting:
+        return float(setting["default"])
+
+    msg = (
+        f"no optmap_scaling_factor entry for {sipm} and no 'default' key in the "
+        "opt tier settings"
+    )
+    raise KeyError(msg)
 
 
 @snakemake_compatible(
@@ -164,7 +201,7 @@ def main() -> None:
                     scint_ph,
                     optmap_lar,
                     sipm,
-                    map_scaling=optmap_scaling_factor,
+                    map_scaling=resolve_map_scaling(optmap_scaling_factor, sipm),
                     max_pes_per_hit=max_pes_per_hit,
                 )
             if max_pes_per_hit > 0:

--- a/workflow/src/legendsimflow/scripts/tier/opt.py
+++ b/workflow/src/legendsimflow/scripts/tier/opt.py
@@ -185,6 +185,11 @@ def main() -> None:
             if not isinstance(optmap_lar, OptmapForConvolve):
                 optmap_lar = reboost.spms.pe.load_optmap(optmap_lar, sipm)
 
+        # constant for this SiPM, so resolve it once instead of per chunk
+        map_scaling = resolve_map_scaling(optmap_scaling_factor, sipm)
+        msg = f"using optical map scaling factor {map_scaling} for {sipm}"
+        log.debug(msg)
+
         for lgdo_chunk in iterator:
             chunk = lgdo_chunk.view_as("ak")
 
@@ -201,7 +206,7 @@ def main() -> None:
                     scint_ph,
                     optmap_lar,
                     sipm,
-                    map_scaling=resolve_map_scaling(optmap_scaling_factor, sipm),
+                    map_scaling=map_scaling,
                     max_pes_per_hit=max_pes_per_hit,
                 )
             if max_pes_per_hit > 0:


### PR DESCRIPTION
**Issue (see https://github.com/legend-exp/legend-simflow/issues/320):** 
`optmap_scaling_factor` can only be a single number applied to every SiPM. `legend-pygeom-l200` has a
`sipm_efficiencies` option, but it scales the Geant4 `EFFICIENCY` vector on the SiPM optical surface, so it only takes effect while photons are tracked, i.e. during optical map generation. It does nothing when a pre-built map is convolved in the `opt` tier.

**Change:** 
`optmap_scaling_factor` may now be either a scalar, as before, or a mapping
`<sipm name> -> <factor>`:

```yaml
optmap_scaling_factor:
  default: 0.3
  S002: 0.384
  S003: 0.461
```

Channels absent from the mapping fall back to the reserved `default` key. If a channel is missing and no `default` is given, a `KeyError` naming the channel is raised rather than silently guessing a value.

This is only useful together with `optmap_per_sipm: true`, where `opt.py` already loads the map and calls reboost once per channel; the scaling was simply read once outside that loop.