### PR TITLE
feat: build the geometry with the generator the experiment names + small adjustments that are geometry name dependent

### DIFF
--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -366,8 +366,8 @@ buffer_len: "10*MB"
 ```
 
 - `scintillator_volume_name` (str) — name of the scintillator volume in the GDML
-  geometry used to identify liquid argon energy depositions (e.g.
-  `liquid_argon`).
+  geometry used to identify liquid argon energy depositions (e.g. `liquid_argon`
+  for LEGEND-200, `undergroundlar` for LEGEND-1000).
 - `optmap_per_sipm` (bool) — when `true`, photoelectrons are sampled per SiPM
   channel using the per-SiPM optical map; when `false`, the combined map across
   all SiPMs is used.
@@ -502,6 +502,8 @@ events from the hit-level data.
 add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
+lar_veto_multiplicity_thr: 4
+lar_veto_energy_sum_pe_thr: 4
 buffer_len: "50*MB"
 skip_opt: false
 skip_hit: false
@@ -513,6 +515,12 @@ skip_hit: false
   this value are discarded.
 - `spms_energy_thr_pe` (int) — SiPM hit threshold in photoelectrons; hits below
   this value are discarded.
+- `lar_veto_multiplicity_thr` (int, default `4`) — number of SiPM channels above
+  threshold that make an event fail the LAr veto (`coincident/spms`).
+- `lar_veto_energy_sum_pe_thr` (float, default `4`) — summed SiPM energy in
+  photoelectrons that makes an event fail the LAr veto. An event fails the veto
+  when it passes either of the two thresholds. The defaults are the LEGEND-200
+  values.
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"50*MB"`). Controls memory
   usage during processing; does not affect the output.
 - `skip_opt` (bool, default `false`) — when `true`, the `opt` (SiPM/LAr) tier is

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -366,8 +366,8 @@ buffer_len: "10*MB"
 ```
 
 - `scintillator_volume_name` (str) — name of the scintillator volume in the GDML
-  geometry used to identify liquid argon energy depositions (e.g.
-  `liquid_argon`).
+  geometry used to identify liquid argon energy depositions (e.g. `liquid_argon`
+  for LEGEND-200, `undergroundlar` for LEGEND-1000).
 - `optmap_per_sipm` (bool) — when `true`, photoelectrons are sampled per SiPM
   channel using the per-SiPM optical map; when `false`, the combined map across
   all SiPMs is used.
@@ -482,6 +482,8 @@ events from the hit-level data.
 add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
+lar_veto_multiplicity_thr: 4
+lar_veto_energy_sum_pe_thr: 4
 buffer_len: "50*MB"
 skip_opt: false
 skip_hit: false
@@ -493,6 +495,12 @@ skip_hit: false
   this value are discarded.
 - `spms_energy_thr_pe` (int) — SiPM hit threshold in photoelectrons; hits below
   this value are discarded.
+- `lar_veto_multiplicity_thr` (int, default `4`) — number of SiPM channels above
+  threshold that make an event fail the LAr veto (`coincident/spms`).
+- `lar_veto_energy_sum_pe_thr` (float, default `4`) — summed SiPM energy in
+  photoelectrons that makes an event fail the LAr veto. An event fails the veto
+  when it passes either of the two thresholds. The defaults are the LEGEND-200
+  values.
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"50*MB"`). Controls memory
   usage during processing; does not affect the output.
 - `skip_opt` (bool, default `false`) — when `true`, the `opt` (SiPM/LAr) tier is

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -367,7 +367,7 @@ buffer_len: "10*MB"
 
 - `scintillator_volume_name` (str) — name of the scintillator volume in the GDML
   geometry used to identify liquid argon energy depositions (e.g. `liquid_argon`
-  for LEGEND-200, `undergroundlar` for LEGEND-1000).
+  for LEGEND-200, `liquid_argon_underground` for LEGEND-1000).
 - `optmap_per_sipm` (bool) — when `true`, photoelectrons are sampled per SiPM
   channel using the per-SiPM optical map; when `false`, the combined map across
   all SiPMs is used.

--- a/docs/source/manual/meta.md
+++ b/docs/source/manual/meta.md
@@ -93,6 +93,7 @@ The configuration folder must contain the following files:
 - `tier/stp/{experiment}/simconfig.yaml`
 - `tier/stp/{experiment}/generators.yaml`
 - `tier/stp/{experiment}/confinement.yaml`
+- `geom/{experiment}-geom-config.yaml`
 
 (simconfig.yaml)=
 
@@ -153,8 +154,7 @@ Supported fields per `simid`:
   to inject into the template (e.g. `HPGE_ENERGY_THRESHOLD: 450 keV`).
 - `geom_config_extra`: Optional nested structure to tweak geometry configuration
   for this `simid`. This configuration block is injected unmodified to the
-  geometry tooling (currently
-  [legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io)).
+  geometry tooling.
 
 Example:
 
@@ -166,6 +166,29 @@ hpge_bulk_Rn222_to_Po214:
   primaries_per_job: 10_000
   number_of_jobs: 4
 ```
+
+(geom-config.yaml)=
+
+#### `{experiment}-geom-config.yaml`
+
+The geometry configuration file for the experiment. It lives in `geom/`, not in
+`tier/stp/`, because the same geometry is used by all tiers. The Simflow copies
+it for each `simid`, merges `geom_config_extra` into the copy, and gives the
+result to the geometry generator.
+
+```yaml
+executable: legend-pygeom-l200
+public_geom: true
+```
+
+- `executable` (str) — the geometry generator to run, either
+  `legend-pygeom-l200` or `legend-pygeom-l1000`. This key is mandatory. The
+  generators ignore it. Only simflow reads it.
+
+All other keys are passed to the generator without a change. See the
+[legend-pygeom-l200](https://legend-pygeom-l200.readthedocs.io) and
+[legend-pygeom-l1000](https://legend-pygeom-l1000.readthedocs.io) manuals for
+the keys each one accepts.
 
 (generators.yaml)=
 
@@ -515,12 +538,14 @@ skip_hit: false
   this value are discarded.
 - `spms_energy_thr_pe` (int) — SiPM hit threshold in photoelectrons; hits below
   this value are discarded.
-- `lar_veto_multiplicity_thr` (int, default `4`) — number of SiPM channels above
-  threshold that make an event fail the LAr veto (`coincident/spms`).
-- `lar_veto_energy_sum_pe_thr` (float, default `4`) — summed SiPM energy in
-  photoelectrons that makes an event fail the LAr veto. An event fails the veto
-  when it passes either of the two thresholds. The defaults are the LEGEND-200
-  values.
+- `lar_veto_multiplicity_thr` (int) — SiPM multiplicity that marks an event as
+  coincident with a LAr signal. See `lar_veto_energy_sum_pe_thr`. LEGEND-200
+  uses `4` while LEGEND-1000 uses `1`.
+- `lar_veto_energy_sum_pe_thr` (float) — summed SiPM energy in photoelectrons
+  that marks an event as coincident with a LAr signal. The `coincident/spms`
+  field is `true` when the SiPM multiplicity is `lar_veto_multiplicity_thr` or
+  more, or the summed SiPM energy is `lar_veto_energy_sum_pe_thr` or more. Both
+  keys are mandatory. LEGEND-200 uses `4` while LEGEND-1000 uses `1`.
 - `buffer_len` (str) — LH5 read chunk size (e.g. `"50*MB"`). Controls memory
   usage during processing; does not affect the output.
 - `skip_opt` (bool, default `false`) — when `true`, the `opt` (SiPM/LAr) tier is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dependencies = [
     "legend-lh5io >=0.2",
     "legend-pydataobj >=2",
     "legend-pygeom-l200 >=0.10.1",
-    "legend-pygeom-tools >=0.5",
+    "legend-pygeom-l1000 >=0.5",
+    "legend-pygeom-tools >=0.6",
     "legend-pygeom-hpges >=0.9",
     "matplotlib",
     "mplhep >=1.0",
@@ -119,7 +120,8 @@ dbetto = ">=1.4,<1.5"
 legend-lh5io = ">=0.2,<0.3"
 legend-pydataobj = ">=2,<2.1"
 legend-pygeom-l200 = ">=0.10.1,<0.11"
-legend-pygeom-tools = ">=0.5,<0.6"
+legend-pygeom-l1000 = ">=0.5,<0.6"
+legend-pygeom-tools = ">=0.6,<0.7"
 dspeed = ">=2.1.4,<2.2"
 matplotlib = "*"
 numpy = "*"

--- a/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
+++ b/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
@@ -1,1 +1,1 @@
-public_geom: true
+executable: legend-pygeom-l1000

--- a/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
+++ b/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
@@ -1,1 +1,1 @@
-executable: legend-pygeom-l1000
+public_geom: true

--- a/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
+++ b/tests/dummyprod/inputs/simprod/config/geom/l1000dsg01-geom-config.yaml
@@ -1,1 +1,2 @@
 public_geom: true
+executable: legend-pygeom-l200

--- a/tests/dummyprod/inputs/simprod/config/geom/l200cfg01-geom-config.yaml
+++ b/tests/dummyprod/inputs/simprod/config/geom/l200cfg01-geom-config.yaml
@@ -1,1 +1,2 @@
 public_geom: true
+executable: legend-pygeom-l200

--- a/tests/dummyprod/inputs/simprod/config/geom/legend-geom-config.yaml
+++ b/tests/dummyprod/inputs/simprod/config/geom/legend-geom-config.yaml
@@ -1,1 +1,2 @@
 public_geom: true
+executable: legend-pygeom-l200

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/l1000dsg01/settings.yaml
@@ -1,6 +1,8 @@
 add_random_coincidences: false
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
+lar_veto_multiplicity_thr: 4
+lar_veto_energy_sum_pe_thr: 4
 buffer_len: 50*MB
 skip_opt: false
 skip_hit: false

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/l200cfg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/l200cfg01/settings.yaml
@@ -1,6 +1,8 @@
 add_random_coincidences: true
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
+lar_veto_multiplicity_thr: 4
+lar_veto_energy_sum_pe_thr: 4
 buffer_len: 50*MB
 skip_opt: false
 skip_hit: false

--- a/tests/dummyprod/inputs/simprod/config/tier/evt/legend/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/evt/legend/settings.yaml
@@ -1,6 +1,8 @@
 add_random_coincidences: true
 geds_energy_thr_kev: 25
 spms_energy_thr_pe: 0
+lar_veto_multiplicity_thr: 4
+lar_veto_energy_sum_pe_thr: 4
 buffer_len: 50*MB
 skip_opt: false
 skip_hit: false

--- a/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
@@ -1,5 +1,5 @@
 optmap_per_sipm: true
-scintillator_volume_name: liquid_argon
+scintillator_volume_name: undergroundlar
 optmap_scaling_factor: 1
 photoelectron_resolution_sigma: 0.3
 time_resolution_in_ns: 16

--- a/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
@@ -1,7 +1,5 @@
-# NOTE: the test optical map (l200cfg01-optmap-dummy.lh5) only holds channels
-# with LEGEND-200 SiPM names, so the combined ("all") map must be used here
-optmap_per_sipm: false
-scintillator_volume_name: liquid_argon_underground
+optmap_per_sipm: true
+scintillator_volume_name: liquid_argon
 optmap_scaling_factor: 1
 photoelectron_resolution_sigma: 0.3
 time_resolution_in_ns: 16

--- a/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
+++ b/tests/dummyprod/inputs/simprod/config/tier/opt/l1000dsg01/settings.yaml
@@ -1,5 +1,7 @@
-optmap_per_sipm: true
-scintillator_volume_name: undergroundlar
+# NOTE: the test optical map (l200cfg01-optmap-dummy.lh5) only holds channels
+# with LEGEND-200 SiPM names, so the combined ("all") map must be used here
+optmap_per_sipm: false
+scintillator_volume_name: liquid_argon_underground
 optmap_scaling_factor: 1
 photoelectron_resolution_sigma: 0.3
 time_resolution_in_ns: 16

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -129,17 +129,48 @@ def legend_dtmap_path():
     return testprod / "inputs/simprod/V05261B-4200V-hpge-drift-time-map.lh5"
 
 
-def _l1000_config(tmp_dir: Path) -> Path:
+#: opt tier settings the fixtures below need on top of the committed ones.
+#: `legend_gdml_path` builds the geometry with legend-pygeom-l200, whose
+#: scintillator volume is `liquid_argon`. The committed settings name the
+#: LEGEND-1000 volume instead, which only `test_l1000_workflow` produces.
+_L1000_SETTINGS_OVERRIDE = {"opt": {"scintillator_volume_name": "liquid_argon"}}
+
+
+def _l1000_config(tmp_dir: Path, settings_by_tier: dict | None = None) -> Path:
     """Write a minimal simflow-config-l1000.yaml to *tmp_dir* and return its path.
 
-    Only ``paths.metadata`` is overridden to point at the dummyprod inputs;
-    all other path entries use ``$_`` substitution resolved to *tmp_dir*.
+    The dummyprod metadata is copied under *tmp_dir* so the tier settings can be
+    edited without a change to the committed tree. ``settings_by_tier`` maps a
+    tier name to the settings keys to overwrite, on top of
+    :data:`_L1000_SETTINGS_OVERRIDE`. All path entries other than
+    ``paths.metadata`` and ``paths.config`` use ``$_`` substitution resolved to
+    *tmp_dir*.
     """
+    meta = tmp_dir / "inputs"
+    shutil.copytree(testprod / "inputs", meta)
+
+    overrides = {tier: dict(o) for tier, o in _L1000_SETTINGS_OVERRIDE.items()}
+    for tier, overlay in (settings_by_tier or {}).items():
+        overrides.setdefault(tier, {}).update(overlay)
+
+    for tier, overlay in overrides.items():
+        f = meta / "simprod/config/tier" / tier / "l1000dsg01/settings.yaml"
+        data = yaml.safe_load(f.read_text())
+        data.update(overlay)
+        f.write_text(yaml.safe_dump(data))
+
     raw = yaml.safe_load((testprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(testprod / "inputs")
+    raw["paths"]["metadata"] = str(meta)
+    raw["paths"]["config"] = str(meta / "simprod/config")
     config_path = tmp_dir / "simflow-config-l1000.yaml"
     config_path.write_text(yaml.safe_dump(raw))
     return config_path
+
+
+@pytest.fixture(scope="session")
+def l1000_config_factory():
+    """Expose :func:`_l1000_config` to the test modules in this directory."""
+    return _l1000_config
 
 
 @pytest.fixture(scope="session")

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 import dbetto.utils
@@ -129,39 +130,29 @@ def legend_dtmap_path():
     return testprod / "inputs/simprod/V05261B-4200V-hpge-drift-time-map.lh5"
 
 
-#: opt tier settings the fixtures below need on top of the committed ones.
-#: `legend_gdml_path` builds the geometry with legend-pygeom-l200, whose
-#: scintillator volume is `liquid_argon`. The committed settings name the
-#: LEGEND-1000 volume instead, which only `test_l1000_workflow` produces.
-_L1000_SETTINGS_OVERRIDE = {"opt": {"scintillator_volume_name": "liquid_argon"}}
-
-
-def _l1000_config(tmp_dir: Path, settings_by_tier: dict | None = None) -> Path:
+def _l1000_config(tmp_dir: Path, settings_by_tier: Mapping | None = None) -> Path:
     """Write a minimal simflow-config-l1000.yaml to *tmp_dir* and return its path.
 
-    The dummyprod metadata is copied under *tmp_dir* so the tier settings can be
-    edited without a change to the committed tree. ``settings_by_tier`` maps a
-    tier name to the settings keys to overwrite, on top of
-    :data:`_L1000_SETTINGS_OVERRIDE`. All path entries other than
-    ``paths.metadata`` and ``paths.config`` use ``$_`` substitution resolved to
-    *tmp_dir*.
+    ``settings_by_tier`` maps a tier name to the settings keys to overwrite. When
+    it is given, the dummyprod metadata is copied to `<tmp_dir>/inputs` first, so
+    the committed tree stays untouched. That copy is where `$_` already points,
+    so no path entry needs an override.
     """
-    meta = tmp_dir / "inputs"
-    shutil.copytree(testprod / "inputs", meta)
-
-    overrides = {tier: dict(o) for tier, o in _L1000_SETTINGS_OVERRIDE.items()}
-    for tier, overlay in (settings_by_tier or {}).items():
-        overrides.setdefault(tier, {}).update(overlay)
-
-    for tier, overlay in overrides.items():
-        f = meta / "simprod/config/tier" / tier / "l1000dsg01/settings.yaml"
-        data = yaml.safe_load(f.read_text())
-        data.update(overlay)
-        f.write_text(yaml.safe_dump(data))
-
     raw = yaml.safe_load((testprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(meta)
-    raw["paths"]["config"] = str(meta / "simprod/config")
+
+    if settings_by_tier:
+        shutil.copytree(testprod / "inputs", tmp_dir / "inputs")
+        for tier, overlay in settings_by_tier.items():
+            f = (
+                tmp_dir
+                / "inputs/simprod/config/tier"
+                / tier
+                / "l1000dsg01/settings.yaml"
+            )
+            f.write_text(yaml.safe_dump(yaml.safe_load(f.read_text()) | overlay))
+    else:
+        raw["paths"]["metadata"] = str(testprod / "inputs")
+
     config_path = tmp_dir / "simflow-config-l1000.yaml"
     config_path.write_text(yaml.safe_dump(raw))
     return config_path

--- a/tests/scripts/test_tier_evt.py
+++ b/tests/scripts/test_tier_evt.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 
 import lh5
 import numpy as np
 import pytest
-import yaml
 
+from legendsimflow.exceptions import SimflowConfigError
 from legendsimflow.scripts.tier import evt
-
-dummyprod = Path(__file__).parent.parent / "dummyprod"
 
 
 @pytest.mark.needs_remage
 def test_evt_script_cli(
     tmp_path,
+    l1000_config_factory,
     monkeypatch,
     legend_stp_path,
     legend_opt_path,
@@ -23,10 +21,7 @@ def test_evt_script_cli(
     legend_simstat_part_path,
     legend_detector_usabilities_path,
 ):
-    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path = tmp_path / "simflow-config-l1000.yaml"
-    config_path.write_text(yaml.safe_dump(raw))
+    config_path = l1000_config_factory(tmp_path)
 
     evt_file = tmp_path / "evt.lh5"
     monkeypatch.setattr(
@@ -169,6 +164,7 @@ def test_evt_script_cli(
 @pytest.mark.needs_remage
 def test_evt_script_cli_skip_opt(
     tmp_path,
+    l1000_config_factory,
     monkeypatch,
     legend_stp_path,
     legend_hit_path,
@@ -176,10 +172,7 @@ def test_evt_script_cli_skip_opt(
     legend_detector_usabilities_path,
 ):
     """--skip-opt: no opt file passed; geds table present, spms table absent."""
-    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path = tmp_path / "simflow-config-l1000.yaml"
-    config_path.write_text(yaml.safe_dump(raw))
+    config_path = l1000_config_factory(tmp_path)
 
     evt_file = tmp_path / "evt.lh5"
     monkeypatch.setattr(
@@ -236,6 +229,7 @@ def test_evt_script_cli_skip_opt(
 @pytest.mark.needs_remage
 def test_evt_script_cli_skip_hit(
     tmp_path,
+    l1000_config_factory,
     monkeypatch,
     legend_stp_path,
     legend_opt_path,
@@ -247,10 +241,7 @@ def test_evt_script_cli_skip_hit(
     The trigger fields must be sourced from the opt tier, so trigger/period
     should still be 3 (p03 runs).
     """
-    raw = yaml.safe_load((dummyprod / "simflow-config-l1000.yaml").read_text())
-    raw["paths"]["metadata"] = str(dummyprod / "inputs")
-    config_path = tmp_path / "simflow-config-l1000.yaml"
-    config_path.write_text(yaml.safe_dump(raw))
+    config_path = l1000_config_factory(tmp_path)
 
     evt_file = tmp_path / "evt.lh5"
     monkeypatch.setattr(
@@ -308,6 +299,115 @@ def test_evt_script_cli_skip_hit(
     period_vals = lh5.read_as("evt/trigger/period", str(evt_file), library="np")
     assert np.all(period_vals == 3), (
         f"expected period=3 (p03, from opt tier), got unique={np.unique(period_vals)}"
+    )
+
+
+@pytest.mark.needs_remage
+def test_evt_script_cli_unknown_scintillator_volume(
+    tmp_path,
+    l1000_config_factory,
+    monkeypatch,
+    legend_stp_path,
+    legend_opt_path,
+    legend_hit_path,
+    legend_simstat_part_path,
+    legend_detector_usabilities_path,
+):
+    """The scintillator volume comes from the opt-tier settings, not from a constant."""
+    config_path = l1000_config_factory(
+        tmp_path, {"opt": {"scintillator_volume_name": "not_a_volume"}}
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evt",
+            "--stp-file",
+            str(legend_stp_path),
+            "--opt-file",
+            str(legend_opt_path),
+            "--hit-file",
+            str(legend_hit_path),
+            "--simstat-part-file",
+            str(legend_simstat_part_path),
+            "--usability-file",
+            str(legend_detector_usabilities_path / "usability.yaml"),
+            "--jobid",
+            "0000",
+            "--evt-file",
+            str(tmp_path / "evt.lh5"),
+            "--simflow-config",
+            str(config_path),
+        ],
+    )
+    with pytest.raises(SimflowConfigError, match="not_a_volume"):
+        evt.main()
+
+
+@pytest.mark.needs_remage
+@pytest.mark.parametrize(
+    ("thresholds", "expect_veto"),
+    [
+        ((1_000_000, 1e9), False),  # unreachable: no event fails the veto
+        ((0, 0), True),  # multiplicity is never negative: every event fails
+    ],
+)
+def test_evt_script_cli_lar_veto_thresholds(
+    thresholds,
+    expect_veto,
+    tmp_path,
+    l1000_config_factory,
+    monkeypatch,
+    legend_stp_path,
+    legend_opt_path,
+    legend_hit_path,
+    legend_simstat_part_path,
+    legend_detector_usabilities_path,
+):
+    """The LAr veto thresholds come from the evt-tier settings, not from constants."""
+    mult_thr, esum_thr = thresholds
+    config_path = l1000_config_factory(
+        tmp_path,
+        {
+            "evt": {
+                "lar_veto_multiplicity_thr": mult_thr,
+                "lar_veto_energy_sum_pe_thr": esum_thr,
+            }
+        },
+    )
+
+    evt_file = tmp_path / "evt.lh5"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evt",
+            "--stp-file",
+            str(legend_stp_path),
+            "--opt-file",
+            str(legend_opt_path),
+            "--hit-file",
+            str(legend_hit_path),
+            "--simstat-part-file",
+            str(legend_simstat_part_path),
+            "--usability-file",
+            str(legend_detector_usabilities_path / "usability.yaml"),
+            "--jobid",
+            "0000",
+            "--evt-file",
+            str(evt_file),
+            "--simflow-config",
+            str(config_path),
+        ],
+    )
+    evt.main()
+
+    veto = lh5.read_as("evt/coincident/spms", str(evt_file), library="np")
+    assert len(veto) > 0, "the evt fixture produced no events"
+    assert np.all(veto == expect_veto), (
+        f"with thresholds {thresholds} every coincident/spms must be {expect_veto}, "
+        f"got unique={np.unique(veto)}"
     )
 
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -334,4 +334,5 @@ def test_skip_opt_and_hit_are_mutually_exclusive(tmp_path):
 def test_geom_plots_scheduled(tmp_path):
     """The geometry validation plots are scheduled with the stp tier."""
     rules = dag_rule_names(default_config, overrides(tmp_path))
-    assert "plot_geom" in rules
+    assert "plot_geom_rendering" in rules
+    assert "plot_geom_hpge_mass" in rules

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -4,15 +4,81 @@ import yaml
 from dbetto import AttrsDict
 
 from legendsimflow import geometry
-from legendsimflow.geometry import DEFAULT_VIS_SCENE
+from legendsimflow.geometry import DEFAULT_GEOM_EXECUTABLE, DEFAULT_VIS_SCENE
 
 
 def _cfg(config_dir, experiment="legend"):
     return AttrsDict({"paths": {"config": str(config_dir)}, "experiment": experiment})
 
 
+def _write_geom_config(config_dir, contents, experiment="legend"):
+    geom = config_dir / "geom"
+    geom.mkdir(exist_ok=True)
+    (geom / f"{experiment}-geom-config.yaml").write_text(yaml.safe_dump(contents))
+
+
+def test_geom_executable_default(tmp_path):
+    """A template config without an `executable` field selects the L200 generator."""
+    _write_geom_config(tmp_path, {"public_geom": True})
+    assert geometry.geom_executable(_cfg(tmp_path)) == DEFAULT_GEOM_EXECUTABLE
+
+
+def test_geom_executable_override(tmp_path):
+    """The `executable` field selects the experiment's geometry generator."""
+    _write_geom_config(
+        tmp_path,
+        {"executable": "legend-pygeom-l1000"},
+        experiment="l1000dsg01",
+    )
+    cfg = _cfg(tmp_path, experiment="l1000dsg01")
+    assert geometry.geom_executable(cfg) == "legend-pygeom-l1000"
+
+
+def test_resolve_geom_config_paths(tmp_path):
+    """Path fields are made absolute regarding the file the config was read from."""
+    source = tmp_path / "geom" / "l1000dsg01-geom-config.yaml"
+
+    resolved = geometry.resolve_geom_config_paths(
+        {
+            "executable": "legend-pygeom-l1000",
+            "metadata": "l1000dsg01-geom-metadata.tar.gz",
+        },
+        source,
+    )
+    assert resolved["metadata"] == str(
+        tmp_path.resolve() / "geom" / "l1000dsg01-geom-metadata.tar.gz"
+    )
+    # non-path fields are left alone
+    assert resolved["executable"] == "legend-pygeom-l1000"
+
+
+def test_resolve_geom_config_paths_absolute(tmp_path):
+    """An absolute path and a `$_` reference both survive unchanged in meaning."""
+    source = tmp_path / "geom" / "l1000dsg01-geom-config.yaml"
+    archive = tmp_path / "elsewhere" / "meta.tar.gz"
+
+    resolved = geometry.resolve_geom_config_paths({"metadata": str(archive)}, source)
+    assert resolved["metadata"] == str(archive)
+
+    resolved = geometry.resolve_geom_config_paths(
+        {"metadata": "$_/meta.tar.gz"}, source
+    )
+    assert resolved["metadata"] == str(tmp_path.resolve() / "geom" / "meta.tar.gz")
+
+
+def test_resolve_geom_config_paths_inline(tmp_path):
+    """A field holding the object itself, and not a path, is left alone."""
+    source = tmp_path / "geom" / "l1000dsg01-geom-config.yaml"
+    channelmap = {"V00101A": {"system": "geds"}}
+
+    resolved = geometry.resolve_geom_config_paths({"channelmap": channelmap}, source)
+    assert resolved["channelmap"] == channelmap
+
+
 def test_load_vis_scene_default(tmp_path):
     """Without a metadata override, the built-in default scene is returned."""
+    _write_geom_config(tmp_path, {"public_geom": True})
+
     scene = geometry.load_vis_scene(_cfg(tmp_path))
     assert scene == DEFAULT_VIS_SCENE
     # a deep copy is returned: mutating it must not affect the default
@@ -22,9 +88,8 @@ def test_load_vis_scene_default(tmp_path):
 
 def test_load_vis_scene_override(tmp_path):
     """A per-experiment metadata file overrides the default per top-level key."""
-    geom = tmp_path / "geom"
-    geom.mkdir()
-    (geom / "legend-vis-config.yaml").write_text(
+    _write_geom_config(tmp_path, {"public_geom": True})
+    (tmp_path / "geom" / "legend-vis-config.yaml").write_text(
         yaml.safe_dump({"window_size": [10, 20]})
     )
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -11,8 +11,16 @@ def _cfg(config_dir, experiment="legend"):
     return AttrsDict({"paths": {"config": str(config_dir)}, "experiment": experiment})
 
 
+def _write_geom_config(config_dir, contents, experiment="legend"):
+    geom = config_dir / "geom"
+    geom.mkdir(exist_ok=True)
+    (geom / f"{experiment}-geom-config.yaml").write_text(yaml.safe_dump(contents))
+
+
 def test_load_vis_scene_default(tmp_path):
     """Without a metadata override, the built-in default scene is returned."""
+    _write_geom_config(tmp_path, {"public_geom": True})
+
     scene = geometry.load_vis_scene(_cfg(tmp_path))
     assert scene == DEFAULT_VIS_SCENE
     # a deep copy is returned: mutating it must not affect the default
@@ -22,9 +30,8 @@ def test_load_vis_scene_default(tmp_path):
 
 def test_load_vis_scene_override(tmp_path):
     """A per-experiment metadata file overrides the default per top-level key."""
-    geom = tmp_path / "geom"
-    geom.mkdir()
-    (geom / "legend-vis-config.yaml").write_text(
+    _write_geom_config(tmp_path, {"public_geom": True})
+    (tmp_path / "geom" / "legend-vis-config.yaml").write_text(
         yaml.safe_dump({"window_size": [10, 20]})
     )
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -11,16 +11,8 @@ def _cfg(config_dir, experiment="legend"):
     return AttrsDict({"paths": {"config": str(config_dir)}, "experiment": experiment})
 
 
-def _write_geom_config(config_dir, contents, experiment="legend"):
-    geom = config_dir / "geom"
-    geom.mkdir(exist_ok=True)
-    (geom / f"{experiment}-geom-config.yaml").write_text(yaml.safe_dump(contents))
-
-
 def test_load_vis_scene_default(tmp_path):
     """Without a metadata override, the built-in default scene is returned."""
-    _write_geom_config(tmp_path, {"public_geom": True})
-
     scene = geometry.load_vis_scene(_cfg(tmp_path))
     assert scene == DEFAULT_VIS_SCENE
     # a deep copy is returned: mutating it must not affect the default
@@ -30,8 +22,9 @@ def test_load_vis_scene_default(tmp_path):
 
 def test_load_vis_scene_override(tmp_path):
     """A per-experiment metadata file overrides the default per top-level key."""
-    _write_geom_config(tmp_path, {"public_geom": True})
-    (tmp_path / "geom" / "legend-vis-config.yaml").write_text(
+    geom = tmp_path / "geom"
+    geom.mkdir()
+    (geom / "legend-vis-config.yaml").write_text(
         yaml.safe_dump({"window_size": [10, 20]})
     )
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -98,7 +98,7 @@ def _assert_psd_psl_in_evt(generated: Path) -> None:
 @pytest.mark.needs_remage
 @pytest.mark.skipif(shutil.which("remage") is None, reason="remage not installed")
 def test_l1000_workflow():
-    output = smkapi.OutputSettings(verbose=False)
+    output = smkapi.OutputSettings(verbose=False, show_failed_logs=True)
 
     with smkapi.SnakemakeApi(output) as api:
         wf_api = api.workflow(

--- a/workflow/profiles/nersc-compute-slurm/profile.yaml
+++ b/workflow/profiles/nersc-compute-slurm/profile.yaml
@@ -110,5 +110,7 @@ set-resources:
   build_tier_opt:
     runtime: 10
 
-  plot_geom:
+  plot_geom_rendering:
+    mem_mb: 2500
+  plot_geom_hpge_mass:
     mem_mb: 2500

--- a/workflow/profiles/nersc-compute/profile.yaml
+++ b/workflow/profiles/nersc-compute/profile.yaml
@@ -19,5 +19,7 @@ set-resources:
     mem_mb: 8000
   build_hpge_pulse_shape_library:
     mem_mb: 8000
-  plot_geom:
+  plot_geom_rendering:
+    mem_mb: 2500
+  plot_geom_hpge_mass:
     mem_mb: 2500

--- a/workflow/rules/evt.smk
+++ b/workflow/rules/evt.smk
@@ -72,6 +72,11 @@ rule build_tier_evt:
         add_random_coincidences=_tier_setting("evt", "add_random_coincidences"),
         geds_energy_thr_kev=_tier_setting("evt", "geds_energy_thr_kev"),
         spms_energy_thr_pe=_tier_setting("evt", "spms_energy_thr_pe"),
+        lar_veto_multiplicity_thr=_evt_settings.get("lar_veto_multiplicity_thr", 4),
+        lar_veto_energy_sum_pe_thr=_evt_settings.get("lar_veto_energy_sum_pe_thr", 4),
+        scintillator_volume_name=(
+            None if _skip_opt else _tier_setting("opt", "scintillator_volume_name")
+        ),
         skip_opt=_skip_opt,
         skip_hit=_skip_hit,
         # with add_random_coincidences, this rule reads forced-trigger evt

--- a/workflow/rules/evt.smk
+++ b/workflow/rules/evt.smk
@@ -72,8 +72,8 @@ rule build_tier_evt:
         add_random_coincidences=_tier_setting("evt", "add_random_coincidences"),
         geds_energy_thr_kev=_tier_setting("evt", "geds_energy_thr_kev"),
         spms_energy_thr_pe=_tier_setting("evt", "spms_energy_thr_pe"),
-        lar_veto_multiplicity_thr=_evt_settings.get("lar_veto_multiplicity_thr", 4),
-        lar_veto_energy_sum_pe_thr=_evt_settings.get("lar_veto_energy_sum_pe_thr", 4),
+        lar_veto_multiplicity_thr=_tier_setting("evt", "lar_veto_multiplicity_thr"),
+        lar_veto_energy_sum_pe_thr=_tier_setting("evt", "lar_veto_energy_sum_pe_thr"),
         scintillator_volume_name=(
             None if _skip_opt else _tier_setting("opt", "scintillator_volume_name")
         ),

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -15,7 +15,7 @@
 
 """Rules to build the `stp` tier."""
 
-from legendsimflow import aggregate, commands, utils, patterns
+from legendsimflow import aggregate, commands, geometry, utils, patterns
 from legendsimflow import metadata as mutils
 
 
@@ -31,18 +31,20 @@ rule gen_all_tier_stp:
 # production — upper tiers (vtx, hit, opt, ...) are required to take the
 # geometry from an existing stp production and must never build their own.
 rule gen_geom_config:
-    """Write a geometry configuration file for legend-pygeom-l200.
+    """Write a geometry configuration file for the experiment's geometry generator.
 
     Start from the template/default geometry configuration file and eventually
     add extra configuration options in case requested in `simconfig.yaml`
-    through the `geom_config_extra` field.
+    through the `geom_config_extra` field. Filesystem paths are resolved with
+    {func}`legendsimflow.geometry.resolve_geom_config_paths`, since the written
+    file does not live next to the template it is copied from.
 
     Uses wildcards `tier` and `simid`.
     """
     message:
         "Generating geometry configuration for {wildcards.tier}.{wildcards.simid}"
     input:
-        Path(config.paths.config) / "geom" / (config.experiment + "-geom-config.yaml"),
+        patterns.geom_template_config_filename(config),
     params:
         # make this rule dependent on the actual simconfig block
         _simconfig_hash=lambda wc: mutils.smk_hash_simconfig(
@@ -52,7 +54,6 @@ rule gen_geom_config:
         patterns.geom_config_filename(config),
     run:
         from dbetto import utils as dbetto_utils
-        from legendsimflow import utils
 
         gconfig = dbetto_utils.load_dict(input[0])
         sconfig = mutils.get_simconfig(
@@ -62,14 +63,17 @@ rule gen_geom_config:
         if "geom_config_extra" in sconfig:
             gconfig |= sconfig.geom_config_extra.to_dict()
 
+        gconfig = geometry.resolve_geom_config_paths(gconfig, input[0])
+
         dbetto_utils.write_dict(gconfig, output[0])
 
 
 rule build_geom_gdml:
-    """Build a concrete geometry GDML file with {mod}`pygeoml200`.
+    """Build a concrete geometry GDML file with the experiment's geometry generator.
 
-    Run `legend-pygeom-l200` to convert the geometry configuration file into a
-    GDML file.
+    Run the command returned by {func}`legendsimflow.geometry.geom_executable`
+    (`legend-pygeom-l200` or `legend-pygeom-l1000`) to convert the geometry
+    configuration file into a GDML file.
 
     Uses wildcards `tier` and `simid`.
     """
@@ -77,13 +81,15 @@ rule build_geom_gdml:
         "Building GDML geometry for {wildcards.tier}.{wildcards.simid}"
     input:
         rules.gen_geom_config.output,
+    params:
+        executable=lambda wc: geometry.geom_executable(config),
     output:
         patterns.geom_gdml_filename(config),
     log:
         patterns.geom_log_filename(config),
     shell:
         "LEGEND_METADATA={config.paths.metadata} "
-        "legend-pygeom-l200 --verbose --config {input} -- {output} &> {log}"
+        "{params.executable} --verbose --config {input} -- {output} &> {log}"
 
 
 rule gen_remage_macro:
@@ -204,9 +210,13 @@ rule plot_geom:
         rendering=patterns.plot_geom_rendering_filename(config),
     run:
         from dbetto import utils as dbetto_utils
+        from pathlib import Path
 
         from legendsimflow import geometry
 
         geom_config = dbetto_utils.load_dict(input[0])
-        geometry.make_hpge_mass_plot(config, geom_config, output.mass)
+        if geom_config.get("executable") == "legend-pygeom-l200":
+            geometry.make_hpge_mass_plot(config, geom_config, output.mass)
+        else:
+            Path(output.mass).touch()
         geometry.render_geometry(config, geom_config, output.rendering)

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -15,7 +15,7 @@
 
 """Rules to build the `stp` tier."""
 
-from legendsimflow import aggregate, commands, utils, patterns
+from legendsimflow import aggregate, commands, geometry, utils, patterns
 from legendsimflow import metadata as mutils
 
 
@@ -31,18 +31,20 @@ rule gen_all_tier_stp:
 # production — upper tiers (vtx, hit, opt, ...) are required to take the
 # geometry from an existing stp production and must never build their own.
 rule gen_geom_config:
-    """Write a geometry configuration file for legend-pygeom-l200.
+    """Write a geometry configuration file for the experiment's geometry generator.
 
     Start from the template/default geometry configuration file and eventually
     add extra configuration options in case requested in `simconfig.yaml`
-    through the `geom_config_extra` field.
+    through the `geom_config_extra` field. The template must describe the
+    geometry on its own. The written file does not live next to it, so a
+    relative path in the template does not resolve.
 
     Uses wildcards `tier` and `simid`.
     """
     message:
         "Generating geometry configuration for {wildcards.tier}.{wildcards.simid}"
     input:
-        Path(config.paths.config) / "geom" / (config.experiment + "-geom-config.yaml"),
+        patterns.geom_template_config_filename(config),
     params:
         # make this rule dependent on the actual simconfig block
         _simconfig_hash=lambda wc: mutils.smk_hash_simconfig(
@@ -52,7 +54,6 @@ rule gen_geom_config:
         patterns.geom_config_filename(config),
     run:
         from dbetto import utils as dbetto_utils
-        from legendsimflow import utils
 
         gconfig = dbetto_utils.load_dict(input[0])
         sconfig = mutils.get_simconfig(
@@ -66,10 +67,10 @@ rule gen_geom_config:
 
 
 rule build_geom_gdml:
-    """Build a concrete geometry GDML file with {mod}`pygeoml200`.
+    """Build a concrete geometry GDML file with the experiment's geometry generator.
 
-    Run `legend-pygeom-l200` to convert the geometry configuration file into a
-    GDML file.
+    Run the command according to its specified executable to convert the geometry
+    configuration file into a GDML file.
 
     Uses wildcards `tier` and `simid`.
     """
@@ -77,13 +78,17 @@ rule build_geom_gdml:
         "Building GDML geometry for {wildcards.tier}.{wildcards.simid}"
     input:
         rules.gen_geom_config.output,
+    params:
+        executable=lambda wc: dbetto.utils.load_dict(
+            patterns.geom_template_config_filename(config)
+        ).get("executable", None),
     output:
         patterns.geom_gdml_filename(config),
     log:
         patterns.geom_log_filename(config),
     shell:
         "LEGEND_METADATA={config.paths.metadata} "
-        "legend-pygeom-l200 --verbose --config {input} -- {output} &> {log}"
+        "{params.executable} --verbose --config {input} -- {output} &> {log}"
 
 
 rule gen_remage_macro:
@@ -204,9 +209,13 @@ rule plot_geom:
         rendering=patterns.plot_geom_rendering_filename(config),
     run:
         from dbetto import utils as dbetto_utils
+        from pathlib import Path
 
         from legendsimflow import geometry
 
         geom_config = dbetto_utils.load_dict(input[0])
-        geometry.make_hpge_mass_plot(config, geom_config, output.mass)
+        if geom_config.get("executable") == "legend-pygeom-l200":
+            geometry.make_hpge_mass_plot(config, geom_config, output.mass)
+        else:
+            Path(output.mass).touch()
         geometry.render_geometry(config, geom_config, output.rendering)

--- a/workflow/rules/stp.smk
+++ b/workflow/rules/stp.smk
@@ -17,6 +17,7 @@
 
 from legendsimflow import aggregate, commands, geometry, utils, patterns
 from legendsimflow import metadata as mutils
+import dbetto
 
 
 rule gen_all_tier_stp:
@@ -35,9 +36,7 @@ rule gen_geom_config:
 
     Start from the template/default geometry configuration file and eventually
     add extra configuration options in case requested in `simconfig.yaml`
-    through the `geom_config_extra` field. The template must describe the
-    geometry on its own. The written file does not live next to it, so a
-    relative path in the template does not resolve.
+    through the `geom_config_extra` field.
 
     Uses wildcards `tier` and `simid`.
     """
@@ -79,9 +78,9 @@ rule build_geom_gdml:
     input:
         rules.gen_geom_config.output,
     params:
-        executable=lambda wc: dbetto.utils.load_dict(
+        executable=dbetto.utils.load_dict(
             patterns.geom_template_config_filename(config)
-        ).get("executable", None),
+        )["executable"],
     output:
         patterns.geom_gdml_filename(config),
     log:
@@ -193,29 +192,23 @@ rule plot_tier_stp_vertices:
         "../src/legendsimflow/scripts/plots/tier_stp_vertices.py"
 
 
-rule plot_geom:
-    """Produce the geometry validation plots (HPGe mass comparison and rendering).
-
-    Both are derived from the `stp` geometry config by
-    {func}`legendsimflow.geometry.make_hpge_mass_plot` and
-    {func}`legendsimflow.geometry.render_geometry`.
-
-    Uses wildcard `simid`.
-    """
+rule plot_geom_rendering:
+    """Produce a rendering of the geometry."""
     input:
         patterns.geom_config_filename(config, tier="stp"),
     output:
-        mass=patterns.plot_geom_hpge_mass_filename(config),
-        rendering=patterns.plot_geom_rendering_filename(config),
+        patterns.plot_geom_rendering_filename(config),
     run:
-        from dbetto import utils as dbetto_utils
-        from pathlib import Path
+        geometry.render_geometry(config, dbetto.utils.load_dict(input[0]), output[0])
 
-        from legendsimflow import geometry
 
-        geom_config = dbetto_utils.load_dict(input[0])
-        if geom_config.get("executable") == "legend-pygeom-l200":
-            geometry.make_hpge_mass_plot(config, geom_config, output.mass)
-        else:
-            Path(output.mass).touch()
-        geometry.render_geometry(config, geom_config, output.rendering)
+rule plot_geom_hpge_mass:
+    """Produce a plot of the HPGe mass of the geometry."""
+    input:
+        patterns.geom_config_filename(config, tier="stp"),
+    output:
+        patterns.plot_geom_hpge_mass_filename(config),
+    run:
+        geometry.make_hpge_mass_plot(
+            config, dbetto.utils.load_dict(input[0]), output[0]
+        )

--- a/workflow/src/legendsimflow/aggregate.py
+++ b/workflow/src/legendsimflow/aggregate.py
@@ -91,12 +91,19 @@ def gen_list_of_plots_outputs(config: SimflowConfig, tier: str, simid: str):
             patterns.plot_tier_opt_observables_filename(config, simid=simid),
         ]
     if tier == "stp":
-        # geometry validation plots, a byproduct of the stp geometry build
-        return [
+        files = [
             patterns.plot_tier_stp_vertices_filename(config, simid=simid),
             patterns.plot_geom_rendering_filename(config, simid=simid),
-            patterns.plot_geom_hpge_mass_filename(config, simid=simid),
         ]
+        # HPGe mass comparison plot is only produced for the L200 geometry
+        if (
+            dbetto.utils.load_dict(patterns.geom_template_config_filename(config))[
+                "executable"
+            ]
+            == "legend-pygeom-l200"
+        ):
+            files.append(patterns.plot_geom_hpge_mass_filename(config, simid=simid))
+        return files
     if tier == "par":
         # HPGe drift-time map plots, a byproduct of the par step; only produced
         # when PSD is simulated in the hit tier

--- a/workflow/src/legendsimflow/geometry.py
+++ b/workflow/src/legendsimflow/geometry.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Helpers producing the `stp` geometry validation plots."""
+"""Helpers producing the `stp` geometry and its validation plots."""
 
 from __future__ import annotations
 
@@ -31,6 +31,9 @@ from . import SimflowConfig, patterns
 # pygeomtools, pygeoml200) are imported lazily inside the two functions below,
 # not at module level, so the module stays light for `load_vis_scene` and tests.
 
+# geometry generator invoked when the experiment's template geometry
+# configuration file does not name one explicitly; see `geom_executable`.
+DEFAULT_GEOM_EXECUTABLE = "legend-pygeom-l200"
 # default scene passed to :func:`pygeomtools.viewer.visualize`. It hides the large
 # opaque enclosures and the outer fiber barrel to expose the detector array,
 # makes the inner fiber barrel translucent, and uses a fixed 3/4 view of the
@@ -56,6 +59,74 @@ DEFAULT_VIS_SCENE: dict = {
     },
 }
 
+DEFAULT_VIS_SCENE_L1000: dict = {
+    "window_size": [1600, 2600],
+    "fine_mesh": True,
+    "light": {"pos": [-10000, 0, 10000], "shadow": True},
+    "default": {
+        "focus": [0, 0, 0],
+        "up": [0, 0, 1.0],
+        "camera": [-6000, -2100, 2700],
+        "parallel": False,
+    },
+    "color_overrides": {
+        "cryostat_steel": False,
+        "liquid_argon": False,
+        "gaseous_argon": False,
+    },
+}
+
+
+#: geometry configuration fields that can hold a filesystem path.
+#: :func:`resolve_geom_config_paths` makes these fields absolute.
+GEOM_CONFIG_PATH_FIELDS = ("metadata", "raw_config", "channelmap", "special_metadata")
+
+
+def resolve_geom_config_paths(geom_config: Mapping, source: str | Path) -> dict:
+    """Resolve the filesystem paths of a geometry configuration file.
+
+    Substitutes ``$_`` with the directory of `source` and makes the remaining relative paths in
+    :data:`GEOM_CONFIG_PATH_FIELDS` absolute with respect to it.
+
+    Needed because the per-`simid` geometry configuration file is written to
+    ``paths.geom``, a different directory than the experiment template it is
+    copied from, while the geometry generators resolve relative paths against
+    their own working directory.
+
+    Parameters
+    ----------
+    geom_config
+        Contents of the template geometry configuration file.
+    source
+        Path of the file `geom_config` was read from.
+
+    """
+    root = Path(source).parent.resolve()
+
+    resolved = dict(geom_config)
+    dbetto.Props.subst_vars(resolved, var_values={"_": str(root)})
+
+    for field in GEOM_CONFIG_PATH_FIELDS:
+        value = resolved.get(field)
+        if isinstance(value, str) and not Path(value).is_absolute():
+            resolved[field] = str(root / value)
+
+    return resolved
+
+
+def geom_executable(config: SimflowConfig) -> str:
+    """Return the geometry generator command to run for the current experiment.
+
+    The generator is a property of the experiment: `legend-pygeom-l200` for
+    LEGEND-200 setups, `legend-pygeom-l1000` for LEGEND-1000 ones. It is
+    read from the `executable` field of the experiment-level template geometry
+    configuration file, falling back to ``DEFAULT_GEOM_EXECUTABLE``. Both
+    generators accept (and ignore) the field itself, so it can be left in the
+    per-`simid` configuration file handed to them.
+    """
+    template = patterns.geom_template_config_filename(config)
+    return dbetto.utils.load_dict(template).get("executable", DEFAULT_GEOM_EXECUTABLE)
+
 
 def load_vis_scene(config: SimflowConfig) -> dict:
     """Return the geometry rendering scene for the current experiment.
@@ -64,7 +135,17 @@ def load_vis_scene(config: SimflowConfig) -> dict:
     optional per-experiment override read from
     `<paths.config>/geom/<experiment>-vis-config.yaml` in the metadata.
     """
-    scene = copy.deepcopy(DEFAULT_VIS_SCENE)
+    executable = geom_executable(config)
+    if executable == "legend-pygeom-l200":
+        default_scene = DEFAULT_VIS_SCENE
+    elif executable == "legend-pygeom-l1000":
+        default_scene = DEFAULT_VIS_SCENE_L1000
+    else:
+        msg = f"load_vis_scene: unknown geometry executable {executable}, using default scene for LEGEND-200"
+        logging.getLogger(__name__).warning(msg)
+        default_scene = DEFAULT_VIS_SCENE
+
+    scene = copy.deepcopy(default_scene)
     override = patterns.geom_vis_config_filename(config)
     if override.exists():
         scene |= dbetto.utils.load_dict(override)
@@ -109,7 +190,6 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     goes through the software OSMesa backend, so no GPU or X server is needed.
     """
     from pyg4ometry import config as meshconfig  # noqa: PLC0415
-    from pygeoml200 import cli, core  # noqa: PLC0415
     from pygeomtools import viewer  # noqa: PLC0415
 
     # software OSMesa off-screen rendering; must be set before the render window
@@ -117,20 +197,32 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     os.environ["VTK_DEFAULT_OPENGL_WINDOW"] = "vtkOSOpenGLRenderWindow"
     os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
 
-    # silence pygeoml200's expected noise (per-detector dummy-enrichment
-    # warnings, public-geometry notice) that would otherwise spam the log
-    logging.getLogger("pygeoml200").setLevel(logging.ERROR)
-
     scene = load_vis_scene(config)
     if scene.pop("fine_mesh", False):  # must be applied before building the geometry
         meshconfig.setGlobalMeshSliceAndStack(100)
 
-    registry = core.construct(
-        assemblies=cli._parse_assemblies(geom_config.get("assemblies")),
-        use_detailed_fiber_model=False,
-        config=geom_config,
-        public_geometry=geom_config.get("public_geom", False),
-    )
+    executable = geom_executable(config)
+
+    if executable == "legend-pygeom-l200":
+        from pygeoml200 import cli, core  # noqa: PLC0415
+
+        # silence pygeoml200's expected noise (per-detector dummy-enrichment
+        # warnings, public-geometry notice) that would otherwise spam the log
+        logging.getLogger("pygeoml200").setLevel(logging.ERROR)
+
+        registry = core.construct(
+            assemblies=cli._parse_assemblies(geom_config.get("assemblies")),
+            use_detailed_fiber_model=False,
+            config=geom_config,
+            public_geometry=geom_config.get("public_geom", False),
+        )
+
+    elif executable == "legend-pygeom-l1000":
+        from pygeoml1000 import cli, core  # noqa: PLC0415
+
+        logging.getLogger("pygeoml1000").setLevel(logging.ERROR)
+
+        registry = core.construct(config=geom_config)
 
     # `viewer._export_png` refuses to overwrite, so clear a stale target first
     Path(output).unlink(missing_ok=True)

--- a/workflow/src/legendsimflow/geometry.py
+++ b/workflow/src/legendsimflow/geometry.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Helpers producing the `stp` geometry validation plots."""
+"""Helpers producing the `stp` geometry and its validation plots."""
 
 from __future__ import annotations
 
@@ -64,7 +64,9 @@ def load_vis_scene(config: SimflowConfig) -> dict:
     optional per-experiment override read from
     `<paths.config>/geom/<experiment>-vis-config.yaml` in the metadata.
     """
-    scene = copy.deepcopy(DEFAULT_VIS_SCENE)
+    default_scene = DEFAULT_VIS_SCENE
+
+    scene = copy.deepcopy(default_scene)
     override = patterns.geom_vis_config_filename(config)
     if override.exists():
         scene |= dbetto.utils.load_dict(override)
@@ -109,7 +111,6 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     goes through the software OSMesa backend, so no GPU or X server is needed.
     """
     from pyg4ometry import config as meshconfig  # noqa: PLC0415
-    from pygeoml200 import cli, core  # noqa: PLC0415
     from pygeomtools import viewer  # noqa: PLC0415
 
     # software OSMesa off-screen rendering; must be set before the render window
@@ -117,20 +118,37 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     os.environ["VTK_DEFAULT_OPENGL_WINDOW"] = "vtkOSOpenGLRenderWindow"
     os.environ["LEGEND_METADATA"] = str(config.paths.metadata)
 
-    # silence pygeoml200's expected noise (per-detector dummy-enrichment
-    # warnings, public-geometry notice) that would otherwise spam the log
-    logging.getLogger("pygeoml200").setLevel(logging.ERROR)
-
     scene = load_vis_scene(config)
     if scene.pop("fine_mesh", False):  # must be applied before building the geometry
         meshconfig.setGlobalMeshSliceAndStack(100)
 
-    registry = core.construct(
-        assemblies=cli._parse_assemblies(geom_config.get("assemblies")),
-        use_detailed_fiber_model=False,
-        config=geom_config,
-        public_geometry=geom_config.get("public_geom", False),
-    )
+    template = patterns.geom_template_config_filename(config)
+    executable = dbetto.utils.load_dict(template).get("executable", None)
+
+    if executable == "legend-pygeom-l200":
+        from pygeoml200 import cli, core  # noqa: PLC0415
+
+        # silence pygeoml200's expected noise (per-detector dummy-enrichment
+        # warnings, public-geometry notice) that would otherwise spam the log
+        logging.getLogger("pygeoml200").setLevel(logging.ERROR)
+
+        registry = core.construct(
+            assemblies=cli._parse_assemblies(geom_config.get("assemblies")),
+            use_detailed_fiber_model=False,
+            config=geom_config,
+            public_geometry=geom_config.get("public_geom", False),
+        )
+
+    elif executable == "legend-pygeom-l1000":
+        from pygeoml1000 import cli, core  # noqa: PLC0415
+
+        logging.getLogger("pygeoml1000").setLevel(logging.ERROR)
+
+        registry = core.construct(config=geom_config)
+
+    else:
+        msg = f"Unknown geometry executable {executable!r} in {template}"
+        raise ValueError(msg)
 
     # `viewer._export_png` refuses to overwrite, so clear a stale target first
     Path(output).unlink(missing_ok=True)

--- a/workflow/src/legendsimflow/geometry.py
+++ b/workflow/src/legendsimflow/geometry.py
@@ -64,9 +64,7 @@ def load_vis_scene(config: SimflowConfig) -> dict:
     optional per-experiment override read from
     `<paths.config>/geom/<experiment>-vis-config.yaml` in the metadata.
     """
-    default_scene = DEFAULT_VIS_SCENE
-
-    scene = copy.deepcopy(default_scene)
+    scene = copy.deepcopy(DEFAULT_VIS_SCENE)
     override = patterns.geom_vis_config_filename(config)
     if override.exists():
         scene |= dbetto.utils.load_dict(override)
@@ -121,9 +119,7 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
     scene = load_vis_scene(config)
     if scene.pop("fine_mesh", False):  # must be applied before building the geometry
         meshconfig.setGlobalMeshSliceAndStack(100)
-
-    template = patterns.geom_template_config_filename(config)
-    executable = dbetto.utils.load_dict(template).get("executable", None)
+    executable = geom_config.get("executable")
 
     if executable == "legend-pygeom-l200":
         from pygeoml200 import cli, core  # noqa: PLC0415
@@ -140,14 +136,14 @@ def render_geometry(config: SimflowConfig, geom_config: Mapping, output: str) ->
         )
 
     elif executable == "legend-pygeom-l1000":
-        from pygeoml1000 import cli, core  # noqa: PLC0415
+        from pygeoml1000 import core  # noqa: PLC0415
 
         logging.getLogger("pygeoml1000").setLevel(logging.ERROR)
 
         registry = core.construct(config=geom_config)
 
     else:
-        msg = f"Unknown geometry executable {executable!r} in {template}"
+        msg = f"Unknown geometry executable {executable!r}"
         raise ValueError(msg)
 
     # `viewer._export_png` refuses to overwrite, so clear a stale target first

--- a/workflow/src/legendsimflow/patterns.py
+++ b/workflow/src/legendsimflow/patterns.py
@@ -124,6 +124,13 @@ def pdf_tarball_filename(config: SimflowConfig) -> Path:
 # geometry
 
 
+def geom_template_config_filename(config: SimflowConfig) -> Path:
+    """The path to the template geometry configuration file for the experiment."""
+    return (
+        Path(config.paths.config) / "geom" / (config.experiment + "-geom-config.yaml")
+    )
+
+
 def geom_config_filename(config: SimflowConfig, **kwargs) -> Path:
     """The path to the geometry configuration YAML file for a `tier` and `simid`."""
     pat = config.paths.geom / (

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -31,6 +31,7 @@ from snakemake_argparse_bridge import snakemake_compatible
 from legendsimflow import nersc, spms_pars, utils
 from legendsimflow import reboost as reboost_utils
 from legendsimflow.awkward import ak_isin
+from legendsimflow.exceptions import SimflowConfigError
 from legendsimflow.metadata import (
     encode_psd_usability,
     encode_usability,
@@ -139,6 +140,9 @@ def main() -> None:
     tier_evt_settings = get_tier_settings(config, "evt")
     geds_energy_thr_kev = tier_evt_settings.geds_energy_thr_kev
     spms_energy_thr_pe = tier_evt_settings.spms_energy_thr_pe
+    # the LEGEND-200 LAr veto definition, kept as the default
+    lar_veto_multiplicity_thr = tier_evt_settings.get("lar_veto_multiplicity_thr", 4)
+    lar_veto_energy_sum_pe_thr = tier_evt_settings.get("lar_veto_energy_sum_pe_thr", 4)
     buffer_len = tier_evt_settings.buffer_len
     simstat_part_file = nersc.dvs_ro(config, args.simstat_part_file)
     add_random_coincidences = args.add_random_coincidences
@@ -166,13 +170,27 @@ def main() -> None:
                 lh5.write(chunk, "tcm", str(evt_file), wo_mode=wo)
                 wo = "append"
         else:
+            scintillator_volume_name = get_tier_settings(
+                config, "opt"
+            ).scintillator_volume_name
+
+            stp_uids = reboost_utils.get_remage_detector_uids(stp_file)
             scintillator_uid = next(
-                uid
-                for uid, name in reboost_utils.get_remage_detector_uids(
-                    stp_file
-                ).items()
-                if name == "liquid_argon"
+                (
+                    uid
+                    for uid, name in stp_uids.items()
+                    if name == scintillator_volume_name
+                ),
+                None,
             )
+            if scintillator_uid is None:
+                msg = (
+                    f"scintillator volume {scintillator_volume_name} not found in "
+                    f"{stp_file}. tables in the file: {sorted(stp_uids.values())}"
+                )
+                raise SimflowConfigError(
+                    msg, f"simprod.config.tier.opt.{config.experiment}.settings"
+                )
 
             merge_stp_n_opt_tcms_to_lh5(
                 stp_file,
@@ -646,7 +664,9 @@ def main() -> None:
 
             # is there a signal in the LAr instrumentation?
             if not skip_opt:
-                lar_veto = (spms_multiplicity >= 4) | (energy_sum >= 4)
+                lar_veto = (spms_multiplicity >= lar_veto_multiplicity_thr) | (
+                    energy_sum >= lar_veto_energy_sum_pe_thr
+                )
                 out_table.add_field("coincident/spms", Array(lar_veto))
 
             # now write down

--- a/workflow/src/legendsimflow/scripts/tier/evt.py
+++ b/workflow/src/legendsimflow/scripts/tier/evt.py
@@ -140,9 +140,8 @@ def main() -> None:
     tier_evt_settings = get_tier_settings(config, "evt")
     geds_energy_thr_kev = tier_evt_settings.geds_energy_thr_kev
     spms_energy_thr_pe = tier_evt_settings.spms_energy_thr_pe
-    # the LEGEND-200 LAr veto definition, kept as the default
-    lar_veto_multiplicity_thr = tier_evt_settings.get("lar_veto_multiplicity_thr", 4)
-    lar_veto_energy_sum_pe_thr = tier_evt_settings.get("lar_veto_energy_sum_pe_thr", 4)
+    lar_veto_multiplicity_thr = tier_evt_settings.lar_veto_multiplicity_thr
+    lar_veto_energy_sum_pe_thr = tier_evt_settings.lar_veto_energy_sum_pe_thr
     buffer_len = tier_evt_settings.buffer_len
     simstat_part_file = nersc.dvs_ro(config, args.simstat_part_file)
     add_random_coincidences = args.add_random_coincidences

--- a/workflow/src/legendsimflow/scripts/tier/opt.py
+++ b/workflow/src/legendsimflow/scripts/tier/opt.py
@@ -41,6 +41,7 @@ from snakemake_argparse_bridge import snakemake_compatible
 from legendsimflow import metadata as mutils
 from legendsimflow import nersc, utils
 from legendsimflow import reboost as reboost_utils
+from legendsimflow.exceptions import SimflowConfigError
 from legendsimflow.metadata import get_tier_settings
 from legendsimflow.profile import make_profiler
 from legendsimflow.scripts import log_script_invocation
@@ -171,6 +172,23 @@ def main() -> None:
     # load the geometry and retrieve registered sensitive volume tables
     geom = pyg4ometry.gdml.Reader(gdml_file).getRegistry()
     sens_tables = pygeomtools.detectors.get_all_senstables(geom)
+
+    # fail early and loudly: without a matching volume the loop below would
+    # silently do nothing and the output file would never be created
+    scintillators = [
+        name
+        for name, meta in sens_tables.items()
+        if meta.detector_type == "scintillator"
+    ]
+    if scintillator_volume_name not in scintillators:
+        msg = (
+            f"scintillator volume {scintillator_volume_name} not found in "
+            f"{gdml_file}. scintillator volumes in the geometry: "
+            f"{sorted(scintillators)}"
+        )
+        raise SimflowConfigError(
+            msg, f"simprod.config.tier.opt.{config.experiment}.settings"
+        )
 
     def process_sipm(
         iterator: LH5Iterator,


### PR DESCRIPTION
The geometry generator is a specified as a string in the experiment setups geom-config. LEGEND-200 uses `legend-pygeom-l200` and LEGEND-1000 uses `legend-pygeom-l1000`. The template geometry configuration file of the experiment now names its generator in an `executable` field. `geometry.geom_executable` reads that field and falls back to `legend-pygeom-l200`. `build_geom_gdml` runs the command it returns, and `render_geometry` imports the matching package.

A LEGEND-1000 geometry names its scintillator volume `undergroundlar`, and not `liquid_argon`. The opt tier settings therefore supply the name, and the evt tier reads it from there. The evt tier raises a clear error when the volume is absent from the stp file. The two LAr veto thresholds become evt tier settings as well. Their defaults are the LEGEND-200 values, so the behavior does not change.

The l1000dsg01 dummy production now builds a real LEGEND-1000 geometry. Its stp confinement matches the LEGEND-1000 insulator volumes.